### PR TITLE
Fix correctness bugs, security issues, and perf problems from code review

### DIFF
--- a/k8s/statefulset.yaml
+++ b/k8s/statefulset.yaml
@@ -38,7 +38,7 @@ spec:
         - name: DUCKLAKE_DATA_PATH
           value: "s3://posthog-ducklake-prod-us/data"
         - name: DUCKLAKE_METADATA_URL
-          value: "jdbc:postgresql://rds-host/ducklake"
+          value: "postgresql://rds-host/ducklake"
         - name: FLUSH_SIZE
           value: "104857600"  # 100MB
         - name: FLUSH_INTERVAL_MS

--- a/k8s/statefulset.yaml
+++ b/k8s/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           periodSeconds: 30
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /readyz
             port: 8000
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/millpond/arrow_converter.py
+++ b/millpond/arrow_converter.py
@@ -6,12 +6,31 @@ import pyarrow as pa
 log = logging.getLogger(__name__)
 
 
-def _cast_numeric_to_double(table: pa.Table) -> pa.Table:
-    """Cast all integer and float columns to float64 to avoid type wobble across batches."""
+def _normalize_numeric_types(table: pa.Table) -> pa.Table:
+    """Normalize numeric columns: integers→int64, floats→float64.
+
+    Avoids type wobble across batches (e.g. int8 vs int64) while preserving
+    precision for large integers (values > 2^53 are not representable in float64).
+    """
+    new_columns = []
+    new_fields = []
+    changed = False
     for i, field in enumerate(table.schema):
-        if pa.types.is_integer(field.type) or pa.types.is_floating(field.type):
-            table = table.set_column(i, field.name, table.column(i).cast(pa.float64()))
-    return table
+        col = table.column(i)
+        if pa.types.is_integer(field.type) and field.type != pa.int64():
+            new_columns.append(col.cast(pa.int64()))
+            new_fields.append(pa.field(field.name, pa.int64(), nullable=field.nullable))
+            changed = True
+        elif pa.types.is_floating(field.type) and field.type != pa.float64():
+            new_columns.append(col.cast(pa.float64()))
+            new_fields.append(pa.field(field.name, pa.float64(), nullable=field.nullable))
+            changed = True
+        else:
+            new_columns.append(col)
+            new_fields.append(field)
+    if not changed:
+        return table
+    return pa.table(dict(zip([f.name for f in new_fields], new_columns)), schema=pa.schema(new_fields))
 
 
 def _build_schema(records: list[dict]) -> pa.Schema:
@@ -19,29 +38,27 @@ def _build_schema(records: list[dict]) -> pa.Schema:
 
     pa.Table.from_pylist() only uses the first record's keys to infer the schema,
     silently dropping fields that only appear in later records. This function
-    scans all records to build the complete key set, then lets PyArrow infer
-    types from a single-record table per field.
+    scans all records to build the complete key set and collects the first
+    non-null sample for each key in a single pass.
     """
+    # Single pass: collect all keys (ordered) and first non-null sample per key
+    first_non_null: dict[str, object] = {}
     all_keys: dict[str, None] = {}  # ordered set via dict
     for record in records:
-        for key in record:
-            if key not in all_keys:
-                all_keys[key] = None
+        for k, v in record.items():
+            if k not in all_keys:
+                all_keys[k] = None
+            if k not in first_non_null and v is not None:
+                first_non_null[k] = v
 
-    # Build schema by inferring type from first non-null value for each key
     fields = []
     for key in all_keys:
-        sample = None
-        for record in records:
-            if key in record and record[key] is not None:
-                sample = record[key]
-                break
+        sample = first_non_null.get(key)
         if sample is None:
             fields.append(pa.field(key, pa.string(), nullable=True))
         else:
-            # Let PyArrow infer the type from a single-element table
-            inferred = pa.Table.from_pylist([{key: sample}]).schema.field(key)
-            fields.append(pa.field(key, inferred.type, nullable=True))
+            inferred_type = pa.array([sample]).type
+            fields.append(pa.field(key, inferred_type, nullable=True))
 
     return pa.schema(fields)
 
@@ -72,5 +89,5 @@ def convert(messages: list[bytes]) -> pa.Table | None:
 
     schema = _build_schema(records)
     table = pa.Table.from_pylist(records, schema=schema)
-    table = _cast_numeric_to_double(table)
+    table = _normalize_numeric_types(table)
     return table

--- a/millpond/arrow_converter.py
+++ b/millpond/arrow_converter.py
@@ -41,15 +41,23 @@ def _build_schema(records: list[dict]) -> pa.Schema:
     scans all records to build the complete key set and collects the first
     non-null sample for each key in a single pass.
     """
-    # Single pass: collect all keys (ordered) and first non-null sample per key
+    # Single pass: collect all keys (ordered) and first non-null sample per key.
+    # For nested types (dicts), prefer a sample with no null inner values to
+    # avoid inferring 'null' type for struct fields.
     first_non_null: dict[str, object] = {}
     all_keys: dict[str, None] = {}  # ordered set via dict
     for record in records:
         for k, v in record.items():
             if k not in all_keys:
                 all_keys[k] = None
-            if k not in first_non_null and v is not None:
-                first_non_null[k] = v
+            if v is not None:
+                existing = first_non_null.get(k)
+                if existing is None:
+                    first_non_null[k] = v
+                elif isinstance(v, dict) and isinstance(existing, dict) and None in existing.values():
+                    # Replace a dict sample that has null inner values
+                    if None not in v.values():
+                        first_non_null[k] = v
 
     fields = []
     for key in all_keys:

--- a/millpond/config.py
+++ b/millpond/config.py
@@ -3,6 +3,8 @@ import os
 import re
 from dataclasses import dataclass
 
+_SAFE_TABLE_NAME = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
 log = logging.getLogger(__name__)
 
 
@@ -55,6 +57,10 @@ def _require(name: str) -> str:
 def load() -> Config:
     topic = _require("KAFKA_TOPIC")
     ducklake_table = _require("DUCKLAKE_TABLE")
+    if not _SAFE_TABLE_NAME.match(ducklake_table):
+        raise RuntimeError(
+            f"DUCKLAKE_TABLE {ducklake_table!r} contains unsafe characters (must match [a-zA-Z_][a-zA-Z0-9_]*)"
+        )
 
     pod_name = os.environ.get("POD_NAME") or os.environ.get("HOSTNAME", "millpond-0")
     ordinal = _parse_ordinal(pod_name)

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from urllib.parse import urlparse
 
 import duckdb
@@ -9,6 +10,15 @@ from millpond import schema
 from millpond.config import Config
 
 log = logging.getLogger(__name__)
+
+_SETTING_VALUE_RE = re.compile(r"^[a-zA-Z0-9_.:/\-@+=]+$")
+
+
+def _sanitize_setting_value(val: str) -> str:
+    """Validate a DuckDB SET value to prevent SQL injection."""
+    if not _SETTING_VALUE_RE.match(val):
+        raise ValueError(f"Illegal character in DuckDB setting value: {val!r}")
+    return val
 
 
 def connect(cfg: Config) -> duckdb.DuckDBPyConnection:
@@ -27,7 +37,7 @@ def connect(cfg: Config) -> duckdb.DuckDBPyConnection:
         val = os.environ.get(key)
         if val is not None:
             setting = key.lower().replace("duckdb_", "")
-            conn.execute(f"SET {setting} = '{val}'")
+            conn.execute(f"SET {setting} = '{_sanitize_setting_value(val)}'")
 
     conn.execute("LOAD httpfs")
     conn.execute("LOAD ducklake")

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -59,8 +59,13 @@ def connect(cfg: Config) -> duckdb.DuckDBPyConnection:
     return conn
 
 
+_tables_ensured: set[str] = set()
+
+
 def _ensure_table(conn: duckdb.DuckDBPyConnection, table_name: str, batch: pa.Table) -> None:
-    """Create the DuckLake table from Arrow schema if it doesn't exist."""
+    """Create the DuckLake table from Arrow schema if it doesn't exist. Cached after first call."""
+    if table_name in _tables_ensured:
+        return
     conn.register("_schema_batch", batch.slice(0, 0))  # empty batch, just schema
     try:
         conn.execute(
@@ -69,6 +74,7 @@ def _ensure_table(conn: duckdb.DuckDBPyConnection, table_name: str, batch: pa.Ta
         )
     finally:
         conn.unregister("_schema_batch")
+    _tables_ensured.add(table_name)
 
 
 def write(

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -43,14 +43,17 @@ def connect(cfg: Config) -> duckdb.DuckDBPyConnection:
     conn.execute("LOAD ducklake")
     conn.execute("LOAD postgres")
 
-    # Parse the PG URL into a libpq connection string for DuckLake
+    # Parse the PG URL into a libpq connection string for DuckLake.
+    # The 'postgres:' prefix tells DuckLake to use the Postgres extension
+    # for metadata storage rather than a local DuckDB file.
+    # See: https://ducklake.select/docs/stable/duckdb/usage/connecting
     parsed = urlparse(cfg.ducklake_metadata_url)
     pg_connstr = (
         f"host={parsed.hostname} port={parsed.port or 5432} "
         f"dbname={parsed.path.lstrip('/')} user={parsed.username} password={parsed.password}"
     )
     conn.execute(f"""
-        ATTACH 'ducklake:{pg_connstr}' AS lake (
+        ATTACH 'ducklake:postgres:{pg_connstr}' AS lake (
             DATA_PATH '{cfg.ducklake_data_path}'
         )
     """)

--- a/millpond/main.py
+++ b/millpond/main.py
@@ -10,11 +10,36 @@ from millpond import arrow_converter, config, consumer, ducklake, logging_config
 
 log = logging.getLogger(__name__)
 
+_LAG_SAMPLE_INTERVAL_S = 60.0  # how often to query watermark offsets for lag metrics
+_WRITE_MAX_RETRIES = 3
+_WRITE_BASE_DELAY_S = 1.0
+
+
+def _write_with_retry(db, table_name, consolidated, schema_mgr):
+    """Write to DuckLake with exponential backoff on transient failures."""
+    for attempt in range(_WRITE_MAX_RETRIES):
+        try:
+            ducklake.write(db, table_name, consolidated, schema_mgr)
+            return
+        except Exception:
+            if attempt == _WRITE_MAX_RETRIES - 1:
+                raise
+            delay = _WRITE_BASE_DELAY_S * (2**attempt)
+            log.warning(
+                "Write failed (attempt %d/%d), retrying in %.1fs",
+                attempt + 1,
+                _WRITE_MAX_RETRIES,
+                delay,
+                exc_info=True,
+            )
+            metrics.errors_total.labels(type="write_retry").inc()
+            time.sleep(delay)
+
 
 def _flush(db, cfg, kafka, consolidated, pending_bytes, pending_records, offsets, elapsed, schema_mgr):
     """Write to DuckLake, commit offsets, update metrics."""
     t0 = time.monotonic()
-    ducklake.write(db, cfg.ducklake_table, consolidated, schema_mgr)
+    _write_with_retry(db, cfg.ducklake_table, consolidated, schema_mgr)
     write_duration = time.monotonic() - t0
 
     # Commit offsets synchronously — at-least-once requires knowing commit succeeded
@@ -40,11 +65,16 @@ def _flush(db, cfg, kafka, consolidated, pending_bytes, pending_records, offsets
     metrics.batches_flushed_total.inc()
     server.health.record_flush()
 
-    # Update per-partition offset and lag metrics
+    # Always update committed offset metrics (cheap, local)
     for tp in tp_offsets:
         metrics.last_committed_offset.labels(partition=str(tp.partition)).set(tp.offset)
+
+
+def _update_lag_metrics(kafka, tp_offsets):
+    """Sample watermark offsets for lag metrics. Called periodically, not on every flush."""
+    for tp in tp_offsets:
         try:
-            lo, hi = kafka.get_watermark_offsets(tp, timeout=5)
+            _lo, hi = kafka.get_watermark_offsets(tp, timeout=5)
             metrics.consumer_lag.labels(partition=str(tp.partition)).set(hi - tp.offset)
         except Exception:
             pass  # best-effort lag tracking
@@ -79,6 +109,7 @@ def main():
     pending_records = 0
     offsets: dict[tuple[str, int], int] = {}  # (topic, partition) -> max offset
     last_flush = time.monotonic()
+    last_lag_sample = 0.0  # force immediate first sample
 
     try:
         while not shutdown:
@@ -122,6 +153,16 @@ def main():
             if should_flush:
                 consolidated = pa.concat_tables(pending, promote_options="default")
                 _flush(db, cfg, kafka, consolidated, pending_bytes, pending_records, offsets, elapsed, schema_mgr)
+
+                # Sample lag metrics periodically, not on every flush
+                now = time.monotonic()
+                if now - last_lag_sample >= _LAG_SAMPLE_INTERVAL_S:
+                    tp_offsets = [
+                        TopicPartition(topic, partition, offset + 1) for (topic, partition), offset in offsets.items()
+                    ]
+                    _update_lag_metrics(kafka, tp_offsets)
+                    last_lag_sample = now
+
                 pending.clear()
                 pending_bytes = 0
                 pending_records = 0

--- a/millpond/main.py
+++ b/millpond/main.py
@@ -120,7 +120,7 @@ def main():
             should_flush = pending_records > 0 and (pending_bytes >= cfg.flush_size or elapsed >= cfg.flush_interval_s)
 
             if should_flush:
-                consolidated = pa.concat_tables(pending)
+                consolidated = pa.concat_tables(pending, promote_options="default")
                 _flush(db, cfg, kafka, consolidated, pending_bytes, pending_records, offsets, elapsed, schema_mgr)
                 pending.clear()
                 pending_bytes = 0
@@ -135,7 +135,7 @@ def main():
     finally:
         if pending_records > 0:
             try:
-                consolidated = pa.concat_tables(pending)
+                consolidated = pa.concat_tables(pending, promote_options="default")
                 elapsed = time.monotonic() - last_flush
                 log.info("Final flush: %d records, %d bytes", len(consolidated), pending_bytes)
                 _flush(db, cfg, kafka, consolidated, pending_bytes, pending_records, offsets, elapsed, schema_mgr)

--- a/millpond/schema.py
+++ b/millpond/schema.py
@@ -64,6 +64,18 @@ def _arrow_type_to_duckdb(arrow_type: pa.DataType) -> str:
     return "VARCHAR"
 
 
+# DuckDB information_schema may return different type names than our _ARROW_TO_DUCKDB mapping.
+# Normalize to our canonical names to prevent spurious ALTER TABLE on every flush.
+_INFO_SCHEMA_TO_CANONICAL: dict[str, str] = {
+    "TIMESTAMP WITH TIME ZONE": "TIMESTAMPTZ",
+}
+
+
+def _normalize_duckdb_type(type_name: str) -> str:
+    """Normalize a DuckDB type name from information_schema to our canonical form."""
+    return _INFO_SCHEMA_TO_CANONICAL.get(type_name, type_name)
+
+
 class SchemaManager:
     """Tracks the DuckLake table schema and evolves it as needed."""
 
@@ -80,7 +92,7 @@ class SchemaManager:
                 f"SELECT column_name, data_type FROM information_schema.columns "
                 f"WHERE table_catalog = 'lake' AND table_schema = 'main' AND table_name = '{self._table_name}'"
             ).fetchall()
-            self._known_columns = {row[0]: row[1] for row in result}
+            self._known_columns = {row[0]: _normalize_duckdb_type(row[1]) for row in result}
             self._initialized = True
         except duckdb.CatalogException:
             # Table doesn't exist yet

--- a/millpond/server.py
+++ b/millpond/server.py
@@ -17,26 +17,41 @@ class _HealthState:
         self._last_poll: float = 0
         self._last_flush: float = 0
         self._started: bool = False
+        self._has_flushed: bool = False
 
     def record_poll(self) -> None:
         self._last_poll = time.monotonic()
 
     def record_flush(self) -> None:
         self._last_flush = time.monotonic()
+        self._has_flushed = True
 
     def mark_started(self) -> None:
         now = time.monotonic()
         self._last_poll = now
-        self._last_flush = now
         self._started = True
 
-    def is_healthy(self) -> bool:
+    def is_alive(self) -> bool:
+        """Liveness: is the process started and actively polling?"""
         if not self._started:
             return False
         now = time.monotonic()
-        poll_ok = (now - self._last_poll) < self.max_poll_age_s
-        flush_ok = (now - self._last_flush) < self.max_flush_age_s
-        return poll_ok and flush_ok
+        return (now - self._last_poll) < self.max_poll_age_s
+
+    def is_ready(self) -> bool:
+        """Readiness: is the process healthy and keeping up?"""
+        if not self.is_alive():
+            return False
+        # Only check flush recency if at least one flush has occurred.
+        # Idle topics with no messages should not fail readiness for not flushing.
+        if self._has_flushed:
+            now = time.monotonic()
+            return (now - self._last_flush) < self.max_flush_age_s
+        return True
+
+    def is_healthy(self) -> bool:
+        """Backward-compatible: same as is_ready()."""
+        return self.is_ready()
 
 
 health = _HealthState()
@@ -53,7 +68,7 @@ def _make_handler():
                 self.end_headers()
                 self.wfile.write(payload)
             elif self.path == "/healthz":
-                if health.is_healthy():
+                if health.is_alive():
                     self.send_response(200)
                     self.end_headers()
                     self.wfile.write(b"ok\n")
@@ -61,6 +76,15 @@ def _make_handler():
                     self.send_response(503)
                     self.end_headers()
                     self.wfile.write(b"unhealthy\n")
+            elif self.path == "/readyz":
+                if health.is_ready():
+                    self.send_response(200)
+                    self.end_headers()
+                    self.wfile.write(b"ok\n")
+                else:
+                    self.send_response(503)
+                    self.end_headers()
+                    self.wfile.write(b"not ready\n")
             else:
                 self.send_response(404)
                 self.end_headers()
@@ -76,5 +100,5 @@ def start(port: int = 8000) -> HTTPServer:
     server = HTTPServer(("", port), _make_handler())
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
-    log.info("HTTP server listening on port %d (/metrics, /healthz)", port)
+    log.info("HTTP server listening on port %d (/metrics, /healthz, /readyz)", port)
     return server

--- a/tests/test_arrow_converter.py
+++ b/tests/test_arrow_converter.py
@@ -100,3 +100,15 @@ class TestConvert:
         table = convert(messages)
         assert table is not None
         assert table.schema.field("flag").type == pa.bool_()
+
+    def test_cross_batch_concat_with_promote(self):
+        """Tables from separate convert() calls may have different schemas.
+        pa.concat_tables must use promote_options to handle this."""
+        batch1 = convert([orjson.dumps({"a": 1})])
+        batch2 = convert([orjson.dumps({"a": 2, "b": "new"})])
+        assert batch1 is not None and batch2 is not None
+        # Without promote_options="default", this would raise ArrowInvalid
+        merged = pa.concat_tables([batch1, batch2], promote_options="default")
+        assert len(merged) == 2
+        assert "b" in merged.schema.names
+        assert merged.column("b").to_pylist() == [None, "new"]

--- a/tests/test_arrow_converter.py
+++ b/tests/test_arrow_converter.py
@@ -15,18 +15,18 @@ class TestConvert:
         assert len(table) == 2
         assert table.column("name").to_pylist() == ["alice", "bob"]
 
-    def test_numeric_cast_to_double(self):
+    def test_numeric_type_normalization(self):
         messages = [orjson.dumps({"x": 42, "y": 3.14})]
         table = convert(messages)
         assert table is not None
-        assert table.schema.field("x").type == pa.float64()
+        assert table.schema.field("x").type == pa.int64()
         assert table.schema.field("y").type == pa.float64()
 
-    def test_integer_only_still_double(self):
+    def test_integer_normalized_to_int64(self):
         messages = [orjson.dumps({"count": 100})]
         table = convert(messages)
         assert table is not None
-        assert table.schema.field("count").type == pa.float64()
+        assert table.schema.field("count").type == pa.int64()
 
     def test_heterogeneous_schemas(self):
         # Field "b" only appears in the second record — must still be included
@@ -100,6 +100,29 @@ class TestConvert:
         table = convert(messages)
         assert table is not None
         assert table.schema.field("flag").type == pa.bool_()
+
+    def test_large_integer_precision_preserved(self):
+        """Integers > 2^53 must not lose precision via float64 cast."""
+        large_id = 2**53 + 1  # 9007199254740993 — not representable in float64
+        messages = [orjson.dumps({"id": large_id})]
+        table = convert(messages)
+        assert table is not None
+        assert table.column("id").to_pylist() == [large_id]
+        assert table.schema.field("id").type == pa.int64()
+
+    def test_integers_cast_to_int64(self):
+        """Pure integer columns should be int64, not float64."""
+        messages = [orjson.dumps({"count": 42})]
+        table = convert(messages)
+        assert table is not None
+        assert table.schema.field("count").type == pa.int64()
+
+    def test_floats_cast_to_float64(self):
+        """Float columns should remain float64."""
+        messages = [orjson.dumps({"price": 3.14})]
+        table = convert(messages)
+        assert table is not None
+        assert table.schema.field("price").type == pa.float64()
 
     def test_cross_batch_concat_with_promote(self):
         """Tables from separate convert() calls may have different schemas.

--- a/tests/test_arrow_converter.py
+++ b/tests/test_arrow_converter.py
@@ -101,6 +101,19 @@ class TestConvert:
         assert table is not None
         assert table.schema.field("flag").type == pa.bool_()
 
+    def test_nested_struct_with_null_inner_field(self):
+        """A struct field where the first sample has a null inner value must not
+        crash. This happens when _build_schema picks a sample like
+        {"referrer": null, "screen_width": 1920} — pa.array infers referrer as
+        null type, which then rejects string values in later records."""
+        messages = [
+            orjson.dumps({"props": {"referrer": None, "width": 1920}}),
+            orjson.dumps({"props": {"referrer": "google", "width": 1440}}),
+        ]
+        table = convert(messages)
+        assert table is not None
+        assert len(table) == 2
+
     def test_large_integer_precision_preserved(self):
         """Integers > 2^53 must not lose precision via float64 cast."""
         large_id = 2**53 + 1  # 9007199254740993 — not representable in float64

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from millpond.config import _parse_ordinal, load
@@ -65,3 +64,19 @@ class TestLoad:
         monkeypatch.delenv("KAFKA_TOPIC")
         with pytest.raises(RuntimeError, match="KAFKA_TOPIC"):
             load()
+
+    def test_unsafe_table_name_rejected(self, monkeypatch):
+        monkeypatch.setenv("DUCKLAKE_TABLE", "events; DROP TABLE x")
+        with pytest.raises(RuntimeError, match="unsafe characters"):
+            load()
+
+    def test_table_name_with_sql_injection(self, monkeypatch):
+        monkeypatch.setenv("DUCKLAKE_TABLE", "x--")
+        with pytest.raises(RuntimeError, match="unsafe characters"):
+            load()
+
+    def test_valid_table_names(self, monkeypatch):
+        for name in ["events", "my_table", "_private", "Events123"]:
+            monkeypatch.setenv("DUCKLAKE_TABLE", name)
+            cfg = load()
+            assert cfg.ducklake_table == name

--- a/tests/test_ducklake.py
+++ b/tests/test_ducklake.py
@@ -1,0 +1,35 @@
+import pytest
+
+from millpond.ducklake import _sanitize_setting_value
+
+
+class TestSanitizeSettingValue:
+    def test_plain_value(self):
+        assert _sanitize_setting_value("us-east-1") == "us-east-1"
+
+    def test_sql_injection_rejected(self):
+        with pytest.raises(ValueError, match="Illegal character"):
+            _sanitize_setting_value("us-east-1'; DROP TABLE x; --")
+
+    def test_single_quote_rejected(self):
+        with pytest.raises(ValueError, match="Illegal character"):
+            _sanitize_setting_value("it's")
+
+    def test_normal_s3_values(self):
+        assert _sanitize_setting_value("minioadmin") == "minioadmin"
+        assert _sanitize_setting_value("false") == "false"
+        assert _sanitize_setting_value("path") == "path"
+        assert _sanitize_setting_value("minio:9000") == "minio:9000"
+
+    def test_url_style_values(self):
+        assert _sanitize_setting_value("s3.amazonaws.com") == "s3.amazonaws.com"
+
+    def test_access_key_with_slashes(self):
+        assert _sanitize_setting_value("ABC/def123+key") == "ABC/def123+key"
+
+    def test_base64_padding(self):
+        assert _sanitize_setting_value("abc123==") == "abc123=="
+
+    def test_empty_rejected(self):
+        with pytest.raises(ValueError, match="Illegal character"):
+            _sanitize_setting_value("")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,47 @@
+from unittest.mock import MagicMock, patch
+
+import pyarrow as pa
+
+from millpond.main import _write_with_retry
+
+
+class TestWriteWithRetry:
+    def test_succeeds_first_try(self):
+        db = MagicMock()
+        schema_mgr = MagicMock()
+        table = pa.table({"a": [1]})
+        with patch("millpond.main.ducklake") as mock_dl:
+            _write_with_retry(db, "test", table, schema_mgr)
+            assert mock_dl.write.call_count == 1
+
+    def test_retries_on_failure(self):
+        db = MagicMock()
+        schema_mgr = MagicMock()
+        table = pa.table({"a": [1]})
+        with patch("millpond.main.ducklake") as mock_dl, patch("millpond.main.time") as mock_time:
+            mock_dl.write.side_effect = [OSError("S3 timeout"), None]
+            _write_with_retry(db, "test", table, schema_mgr)
+            assert mock_dl.write.call_count == 2
+            mock_time.sleep.assert_called_once_with(1.0)
+
+    def test_raises_after_max_retries(self):
+        db = MagicMock()
+        schema_mgr = MagicMock()
+        table = pa.table({"a": [1]})
+        with patch("millpond.main.ducklake") as mock_dl, patch("millpond.main.time"):
+            mock_dl.write.side_effect = OSError("persistent failure")
+            try:
+                _write_with_retry(db, "test", table, schema_mgr)
+                assert False, "Should have raised"
+            except OSError:
+                assert mock_dl.write.call_count == 3
+
+    def test_exponential_backoff(self):
+        db = MagicMock()
+        schema_mgr = MagicMock()
+        table = pa.table({"a": [1]})
+        with patch("millpond.main.ducklake") as mock_dl, patch("millpond.main.time") as mock_time:
+            mock_dl.write.side_effect = [OSError(), OSError(), None]
+            _write_with_retry(db, "test", table, schema_mgr)
+            calls = [c.args[0] for c in mock_time.sleep.call_args_list]
+            assert calls == [1.0, 2.0]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,15 @@
 import pyarrow as pa
 
-from millpond.schema import _arrow_type_to_duckdb
+from millpond.schema import _arrow_type_to_duckdb, _normalize_duckdb_type
+
+
+class TestNormalizeDuckdbType:
+    def test_timestamp_with_time_zone(self):
+        assert _normalize_duckdb_type("TIMESTAMP WITH TIME ZONE") == "TIMESTAMPTZ"
+
+    def test_passthrough(self):
+        for t in ["BIGINT", "DOUBLE", "VARCHAR", "BOOLEAN", "FLOAT", "INTEGER", "TIMESTAMPTZ", "JSON"]:
+            assert _normalize_duckdb_type(t) == t
 
 
 class TestArrowTypeToDuckdb:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,38 +3,77 @@ import time
 from millpond.server import _HealthState
 
 
-class TestHealthState:
-    def test_not_started_is_unhealthy(self):
+class TestLiveness:
+    def test_not_started(self):
         h = _HealthState()
-        assert not h.is_healthy()
+        assert not h.is_alive()
 
-    def test_started_is_healthy(self):
+    def test_started(self):
         h = _HealthState()
         h.mark_started()
-        assert h.is_healthy()
+        assert h.is_alive()
 
-    def test_stale_poll_is_unhealthy(self):
+    def test_stale_poll(self):
         h = _HealthState(max_poll_age_s=0.01)
         h.mark_started()
         time.sleep(0.02)
-        assert not h.is_healthy()
+        assert not h.is_alive()
 
     def test_poll_refreshes(self):
         h = _HealthState(max_poll_age_s=0.05)
         h.mark_started()
         time.sleep(0.03)
         h.record_poll()
-        assert h.is_healthy()
+        assert h.is_alive()
 
-    def test_stale_flush_is_unhealthy(self):
+    def test_liveness_ignores_flush(self):
+        """Liveness doesn't care about flush recency."""
+        h = _HealthState(max_flush_age_s=0.01)
+        h.mark_started()
+        h.record_flush()
+        time.sleep(0.02)
+        h.record_poll()
+        assert h.is_alive()
+
+
+class TestReadiness:
+    def test_not_started(self):
+        h = _HealthState()
+        assert not h.is_ready()
+
+    def test_started_no_flush(self):
+        h = _HealthState()
+        h.mark_started()
+        assert h.is_ready()
+
+    def test_idle_topic_stays_ready(self):
+        """Pod with no messages (no flush ever) stays ready as long as polling."""
         h = _HealthState(max_flush_age_s=0.01)
         h.mark_started()
         time.sleep(0.02)
-        assert not h.is_healthy()
+        h.record_poll()
+        assert h.is_ready()
+
+    def test_stale_flush_after_first_flush(self):
+        """Once a flush has occurred, stale flush marks not ready."""
+        h = _HealthState(max_flush_age_s=0.01)
+        h.mark_started()
+        h.record_flush()
+        time.sleep(0.02)
+        h.record_poll()
+        assert not h.is_ready()
 
     def test_flush_refreshes(self):
         h = _HealthState(max_flush_age_s=0.05)
         h.mark_started()
+        h.record_flush()
         time.sleep(0.03)
         h.record_flush()
-        assert h.is_healthy()
+        assert h.is_ready()
+
+
+class TestHealthBackcompat:
+    def test_is_healthy_matches_is_ready(self):
+        h = _HealthState()
+        h.mark_started()
+        assert h.is_healthy() == h.is_ready()


### PR DESCRIPTION
## Summary

Implements all 15 items from the code review findings (`todo.md`), plus two bugs found during integration testing.

### Correctness (Critical)
- **#1** `pa.concat_tables` crash on heterogeneous schemas — add `promote_options="default"`
- **#2** JDBC prefix in k8s manifest breaks `urlparse` — remove `jdbc:` prefix
- **DuckLake metadata not persisting to Postgres** — ATTACH string was missing `postgres:` prefix, so metadata was ephemeral to each pod's in-memory DuckDB

### Security (Medium)
- **#3** SQL injection via env vars in DuckDB SET statements — whitelist regex validation
- **#4** Table name not sanitized in SQL — validate against safe identifier regex at config load

### Correctness (Medium)
- **#5** `_cast_numeric_to_double` silently corrupts large integers — cast int→int64, float→float64 instead of everything→float64
- **#6** Schema evolution type comparison thrash — normalize `TIMESTAMP WITH TIME ZONE` → `TIMESTAMPTZ`
- **ArrowInvalid crash on nested structs** — prefer dict samples with non-null inner values during schema inference

### Performance
- **#7/#8** `_build_schema` O(keys×records) + pa.Table-per-field — single-pass with `pa.array().type`
- **#9** N table copies in numeric cast loop — single-pass column construction (folded into #5)
- **#10** `_ensure_table` every flush — cache after first success
- **#11** `get_watermark_offsets` per partition per flush — time-gate to every 60s

### Architecture
- **#12** No retry/backoff on write failure — 3 retries with exponential backoff
- **#13** Duplicate rows on crash — confirmed by-design (at-least-once), no change
- **#14** Health check kills pods on idle topics — only check flush recency after first flush
- **#15** No readiness vs liveness separation — add `/readyz`, split `is_alive()`/`is_ready()`

## Test plan

- [x] Unit tests: 42 → 69, all passing
- [x] Lint clean (`ruff check`)
- [x] Docker-compose e2e: 10,000 records produced → 10,000 rows in DuckLake, verified via `SELECT count(*) FROM lake.main.events`
- [x] No data loss (distinct sequences 0-9999)
- [x] No duplicates
- [x] Column types correct (BIGINT not DOUBLE for integers)
- [x] Health endpoints (`/healthz`, `/readyz`) return 200
- [x] DuckLake metadata persists to Postgres (queryable from separate connection)