### PR TITLE
Expand Grafana dashboard with full-stack observability

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,7 +78,11 @@ services:
       - |
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9094 --create --if-not-exists --topic test-events --partitions 8 --replication-factor 1 &&
         echo "Waiting for consumer group coordinator..." &&
-        /opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server kafka:9094 --group millpond-test-events-events --describe 2>&1 || true
+        for i in $(seq 1 20); do
+          /opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server kafka:9094 --group millpond-test-events-events --describe >/dev/null 2>&1 && echo "Coordinator ready." && break
+          echo "  attempt $i/20..."
+          sleep 1
+        done
 
   # --- Producer: writes sample JSON to Kafka ---
 
@@ -136,7 +140,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    entrypoint: ["sh", "-c", "sleep 2 && millpond"]
+    entrypoint: ["sh", "-c", "sleep 2 && exec millpond"]
     depends_on:
       kafka-init:
         condition: service_completed_successfully

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,6 +45,7 @@ services:
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
+      MINIO_PROMETHEUS_AUTH_TYPE: public
     command: server /data --console-address ":9001"
     healthcheck:
       test: mc ready local
@@ -71,7 +72,13 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
-    entrypoint: ["/bin/sh", "-c", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9094 --create --if-not-exists --topic test-events --partitions 8 --replication-factor 1"]
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9094 --create --if-not-exists --topic test-events --partitions 8 --replication-factor 1 &&
+        echo "Waiting for consumer group coordinator..." &&
+        /opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server kafka:9094 --group millpond-test-events-events --describe 2>&1 || true
 
   # --- Producer: writes sample JSON to Kafka ---
 
@@ -129,6 +136,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    entrypoint: ["sh", "-c", "sleep 2 && millpond"]
     depends_on:
       kafka-init:
         condition: service_completed_successfully
@@ -139,6 +147,23 @@ services:
     environment:
       <<: *millpond-env
       POD_NAME: millpond-test-1
+
+  # --- Metrics Exporters ---
+
+  kafka-exporter:
+    image: danielqsj/kafka-exporter:latest
+    depends_on:
+      kafka:
+        condition: service_healthy
+    command: ["--kafka.server=kafka:9094"]
+
+  postgres-exporter:
+    image: prometheuscommunity/postgres-exporter:latest
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATA_SOURCE_NAME: "postgresql://ducklake:ducklake@postgres:5432/ducklake?sslmode=disable"
 
   # --- Metrics & Dashboarding ---
 
@@ -177,6 +202,16 @@ configs:
             - targets:
                 - millpond-0:8000
                 - millpond-1:8000
+        - job_name: kafka
+          static_configs:
+            - targets: ["kafka-exporter:9308"]
+        - job_name: postgres
+          static_configs:
+            - targets: ["postgres-exporter:9187"]
+        - job_name: minio
+          metrics_path: /minio/v2/metrics/cluster
+          static_configs:
+            - targets: ["minio:9000"]
 
   grafana-datasources:
     content: |

--- a/grafana/dashboards/millpond.json
+++ b/grafana/dashboards/millpond.json
@@ -6,31 +6,297 @@
   "links": [],
   "panels": [
     {
-      "title": "Records Consumed (rate/s)",
-      "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "title": "Overview",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "Total Records Consumed (rate/s)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
       "targets": [
         {
-          "expr": "sum(rate(millpond_records_consumed_total[1m])) by (partition)",
-          "legendFormat": "partition {{partition}}"
+          "expr": "sum(rate(millpond_records_consumed_total[1m]))",
+          "legendFormat": "consumed/s"
         }
       ]
     },
     {
-      "title": "Records Written (rate/s)",
-      "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "title": "Total Records Written (rate/s)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
       "targets": [
         {
           "expr": "sum(rate(millpond_records_written_total[1m]))",
-          "legendFormat": "written"
+          "legendFormat": "written/s"
         }
       ]
     },
     {
-      "title": "Flush Duration (p50 / p95 / p99)",
+      "title": "Flushes/s",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(millpond_batches_flushed_total[1m]))",
+          "legendFormat": "flushes/s"
+        }
+      ]
+    },
+    {
+      "title": "Pending Bytes",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 104857600 },
+              { "color": "red", "value": 536870912 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "millpond_pending_bytes",
+          "legendFormat": "pending"
+        }
+      ]
+    },
+    {
+      "title": "Total Consumer Lag",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10000 },
+              { "color": "red", "value": 100000 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(kafka_consumergroup_lag)",
+          "legendFormat": "lag"
+        }
+      ]
+    },
+    {
+      "title": "Error Rate",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(millpond_errors_total[1m]))",
+          "legendFormat": "errors/s"
+        }
+      ]
+    },
+    {
+      "title": "Millpond Consumers",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "Records Consumed/s by Partition",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 6 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(millpond_records_consumed_total[1m])) by (partition)",
+          "legendFormat": "p{{partition}}"
+        }
+      ]
+    },
+    {
+      "title": "Records Consumed/s by Pod",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 6 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(millpond_records_consumed_total[1m])) by (instance)",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    },
+    {
+      "title": "Records Written/s by Pod",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 6 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(millpond_records_written_total[1m])) by (instance)",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    },
+    {
+      "title": "Flush Duration p50/p95/p99",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
       "targets": [
         {
           "expr": "histogram_quantile(0.50, sum(rate(millpond_flush_duration_seconds_bucket[5m])) by (le))",
@@ -44,17 +310,27 @@
           "expr": "histogram_quantile(0.99, sum(rate(millpond_flush_duration_seconds_bucket[5m])) by (le))",
           "legendFormat": "p99"
         }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "s"
-        }
-      }
+      ]
     },
     {
-      "title": "Flush Size (bytes)",
+      "title": "Flush Size bytes p50/p95",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
       "targets": [
         {
           "expr": "histogram_quantile(0.50, sum(rate(millpond_flush_size_bytes_bucket[5m])) by (le))",
@@ -64,17 +340,60 @@
           "expr": "histogram_quantile(0.95, sum(rate(millpond_flush_size_bytes_bucket[5m])) by (le))",
           "legendFormat": "p95"
         }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes"
-        }
-      }
+      ]
     },
     {
-      "title": "Consumer Lag (by partition)",
+      "title": "Consumer Lag & Offsets",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "Consumer Lag by Partition (kafka-exporter)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 23 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "kafka_consumergroup_lag{topic=\"test-events\"}",
+          "legendFormat": "p{{partition}}"
+        }
+      ]
+    },
+    {
+      "title": "Millpond Consumer Lag",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 23 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
       "targets": [
         {
           "expr": "millpond_consumer_lag",
@@ -83,25 +402,286 @@
       ]
     },
     {
-      "title": "Pending Bytes",
-      "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
-      "targets": [
-        {
-          "expr": "millpond_pending_bytes",
-          "legendFormat": "pending"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes"
-        }
-      }
+      "title": "Kafka Broker",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 31 },
+      "collapsed": false,
+      "panels": []
     },
     {
-      "title": "Errors (rate/s)",
+      "title": "Topic Offset Rate",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(kafka_topic_partition_current_offset[1m])) by (topic)",
+          "legendFormat": "{{topic}}"
+        }
+      ]
+    },
+    {
+      "title": "Messages In/s",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(kafka_topic_partition_current_offset[1m]))",
+          "legendFormat": "messages/s"
+        }
+      ]
+    },
+    {
+      "title": "MinIO / S3",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 40 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "S3 Request Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 41 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(minio_s3_requests_total[1m])) by (api)",
+          "legendFormat": "{{api}}"
+        }
+      ]
+    },
+    {
+      "title": "Bucket Size",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 41 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "minio_cluster_usage_total_bytes",
+          "legendFormat": "ducklake"
+        }
+      ]
+    },
+    {
+      "title": "Object Count",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 49 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "minio_cluster_usage_object_total",
+          "legendFormat": "objects"
+        }
+      ]
+    },
+    {
+      "title": "S3 Traffic Received",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 49 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "rate(minio_s3_traffic_received_bytes[1m])",
+          "legendFormat": "received"
+        }
+      ]
+    },
+    {
+      "title": "Postgres (DuckLake Metadata)",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 57 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "Transactions/s",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 58 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "rate(pg_stat_database_xact_commit{datname=\"ducklake\"}[1m])",
+          "legendFormat": "commits/s"
+        }
+      ]
+    },
+    {
+      "title": "Active Connections",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 58 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "pg_stat_database_numbackends{datname=\"ducklake\"}",
+          "legendFormat": "connections"
+        }
+      ]
+    },
+    {
+      "title": "Database Size",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 58 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "pg_database_size_bytes{datname=\"ducklake\"}",
+          "legendFormat": "size"
+        }
+      ]
+    },
+    {
+      "title": "Errors & Skipped",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 66 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "title": "Errors by Type",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 67 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
       "targets": [
         {
           "expr": "sum(rate(millpond_errors_total[1m])) by (type)",
@@ -110,35 +690,28 @@
       ]
     },
     {
-      "title": "Records Skipped (rate/s)",
+      "title": "Records Skipped",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 67 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
       "targets": [
         {
           "expr": "sum(rate(millpond_records_skipped_total[1m])) by (reason)",
           "legendFormat": "{{reason}}"
-        }
-      ]
-    },
-    {
-      "title": "Batches Flushed (rate/s)",
-      "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 32 },
-      "targets": [
-        {
-          "expr": "sum(rate(millpond_batches_flushed_total[1m]))",
-          "legendFormat": "flushes/s"
-        }
-      ]
-    },
-    {
-      "title": "Flush Size (records, p50)",
-      "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 32 },
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.50, sum(rate(millpond_flush_size_records_bucket[5m])) by (le))",
-          "legendFormat": "records"
         }
       ]
     }

--- a/grafana/dashboards/millpond.json
+++ b/grafana/dashboards/millpond.json
@@ -158,7 +158,7 @@
       },
       "targets": [
         {
-          "expr": "sum(kafka_consumergroup_lag)",
+          "expr": "sum(kafka_consumergroup_lag{consumergroup=~\"millpond-.*\"})",
           "legendFormat": "lag"
         }
       ]
@@ -370,7 +370,7 @@
       },
       "targets": [
         {
-          "expr": "kafka_consumergroup_lag{topic=\"test-events\"}",
+          "expr": "kafka_consumergroup_lag{topic=\"test-events\",consumergroup=~\"millpond-.*\"}",
           "legendFormat": "p{{partition}}"
         }
       ]
@@ -494,7 +494,7 @@
       ]
     },
     {
-      "title": "Bucket Size",
+      "title": "Total Storage Size",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 41 },
       "fieldConfig": {

--- a/justfile
+++ b/justfile
@@ -70,6 +70,11 @@ down:
 duck:
     duckdb -init test/ducklake-init.sql
 
+# Open the Grafana dashboard (requires `just up` first)
+[group('docker')]
+dashboard:
+    open http://localhost:3000/d/millpond/millpond
+
 # === Build ===
 
 # Build Docker image


### PR DESCRIPTION
## Summary

Expand the Grafana dashboard from 8 panels to 30, covering the full stack. Add metric exporters for Kafka, Postgres, and MinIO.

### New infrastructure
- **kafka-exporter** — consumer group lag, topic offset rates
- **postgres-exporter** — transactions/s, connections, database size for DuckLake metadata
- **MinIO metrics** — S3 request rates by API, storage size, object count, traffic

### Dashboard layout (7 rows, 30 panels)

| Row | Panels |
|-----|--------|
| Overview | 6 stat panels: consumed/s, written/s, flushes/s, pending bytes, consumer lag, error rate |
| Millpond Consumers | consumed/s by partition, consumed/s by pod, written/s by pod |
| Consumer Lag | kafka-exporter lag by partition, millpond lag by partition |
| Kafka Broker | topic offset rate, messages in/s |
| MinIO / S3 | request rate by API, storage size, object count, traffic received |
| Postgres | transactions/s, active connections, database size |
| Errors | errors by type, records skipped by reason |

### Startup fixes
- Warm Kafka consumer group coordinator in `kafka-init` to eliminate NOT_COORDINATOR errors
- Stagger millpond-1 start by 2s to avoid DuckLake metadata table creation race
- `just dashboard` recipe to open Grafana

## Test plan

- [x] All 5 Prometheus targets up (millpond x2, kafka, minio, postgres)
- [x] All metric sources returning data
- [x] Dashboard loads at http://localhost:3000/d/millpond/millpond
- [x] Both consumers start cleanly without coordinator errors or DuckLake race