### PR TITLE
Address Wiz and CodeQL code scanning alerts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/AGENT.md
+++ b/AGENT.md
@@ -310,7 +310,8 @@ millpond/
 ├── docker-compose.yaml       # Full dev stack (Kafka, Postgres, MinIO, Grafana)
 ├── k8s/
 │   ├── statefulset.yaml
-│   └── service.yaml          # Headless service for StatefulSet
+│   ├── service.yaml          # Headless service for StatefulSet
+│   └── pdb.yaml              # PodDisruptionBudget
 ├── millpond/
 │   ├── __init__.py
 │   ├── main.py               # Entry point, main loop, signal handling

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
+FROM ghcr.io/astral-sh/uv:0.7 AS uv
 FROM python:3.12-slim AS builder
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=uv /uv /usr/local/bin/uv
 
 WORKDIR /app
 COPY pyproject.toml uv.lock ./
@@ -20,5 +21,11 @@ ENV PATH="/app/.venv/bin:$PATH"
 # httpfs must be installed before ducklake — there's a race condition with S3 access
 # if ducklake loads first and tries to use httpfs before it's available.
 RUN python -c "import duckdb; c = duckdb.connect(); c.execute('INSTALL httpfs'); c.execute('INSTALL ducklake'); c.execute('INSTALL postgres')"
+
+RUN useradd --create-home --shell /bin/false millpond
+USER millpond
+
+# Health check for non-K8s environments (K8s uses liveness/readiness probes in statefulset.yaml)
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz')"]
 
 ENTRYPOINT ["millpond"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,14 @@ COPY --from=builder /app/millpond /app/millpond
 
 ENV PATH="/app/.venv/bin:$PATH"
 
+RUN useradd --create-home --shell /bin/false millpond
+USER millpond
+
 # Pre-install DuckDB extensions at build time to avoid runtime network dependency.
+# Must run as millpond user so extensions land in ~/.duckdb/extensions/ (not /root/).
 # httpfs must be installed before ducklake — there's a race condition with S3 access
 # if ducklake loads first and tries to use httpfs before it's available.
 RUN python -c "import duckdb; c = duckdb.connect(); c.execute('INSTALL httpfs'); c.execute('INSTALL ducklake'); c.execute('INSTALL postgres')"
-
-RUN useradd --create-home --shell /bin/false millpond
-USER millpond
 
 # Health check for non-K8s environments (K8s uses liveness/readiness probes in statefulset.yaml)
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz')"]

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ All configuration via environment variables:
 ```bash
 just build        # build Docker image
 kubectl apply -f k8s/service.yaml
+kubectl apply -f k8s/pdb.yaml
 kubectl apply -f k8s/statefulset.yaml
 ```
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -103,6 +103,9 @@ services:
       KAFKA_PARTITION_COUNT: 8
       RECORDS_PER_SECOND: 1000
       TOTAL_RECORDS: -1
+    healthcheck:
+      test: ["CMD-SHELL", "true"]  # producer has no HTTP server; override Dockerfile HEALTHCHECK
+      interval: 10s
     volumes:
       - ./test:/app/test:ro
 

--- a/k8s/pdb.yaml
+++ b/k8s/pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: millpond-events  # change per topic
+spec:
+  # Allow at most one pod unavailable at a time during voluntary disruptions
+  # (node drain, cluster upgrade). Kafka buffers during downtime.
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: millpond-events

--- a/k8s/statefulset.yaml
+++ b/k8s/statefulset.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: millpond-events  # change per topic
+  # wiz-scan: ResourceQuota and LimitRange are namespace-level policies (managed by platform team)
+  # wiz-scan: serviceName references headless Service defined in service.yaml (clusterIP: None)
 spec:
   replicas: 8
   serviceName: millpond-events
@@ -17,10 +19,20 @@ spec:
         prometheus.io/port: "8000"
         prometheus.io/path: "/metrics"
     spec:
+      automountServiceAccountToken: false
       terminationGracePeriodSeconds: 120  # time to flush pending writes
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: millpond-events
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: millpond
-        image: millpond:latest
+        image: millpond:v0.0.0  # placeholder — Helm sets the real tag
         ports:
         - name: metrics
           containerPort: 8000
@@ -43,6 +55,14 @@ spec:
           value: "104857600"  # 100MB
         - name: FLUSH_INTERVAL_MS
           value: "60000"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp  # DuckDB spill-to-disk under memory pressure
         resources:
           requests:
             memory: "256Mi"
@@ -61,3 +81,6 @@ spec:
             port: 8000
           initialDelaySeconds: 5
           periodSeconds: 10
+      volumes:
+      - name: tmp
+        emptyDir: {}  # disk-backed, not RAM — spill shouldn't count against memory limit


### PR DESCRIPTION
## Summary
- **CI**: scope `GITHUB_TOKEN` to `contents: read`
- **Dockerfile**: non-root `USER`, pinned uv stage alias, `HEALTHCHECK` for non-K8s environments, install DuckDB extensions as millpond user
- **StatefulSet**: `securityContext` (drop ALL caps, read-only root filesystem, no privilege escalation), `automountServiceAccountToken: false`, soft pod anti-affinity, placeholder image tag, disk-backed `emptyDir` volume at `/tmp` for DuckDB spill-to-disk (not tmpfs — spill shouldn't count against memory limit)
- **PodDisruptionBudget**: `maxUnavailable: 1`
- **docker-compose**: override Dockerfile HEALTHCHECK on producer (no HTTP server)

## Alerts addressed

| # | Severity | Tool | Fix |
|---|----------|------|-----|
| 1-2 | Medium | CodeQL | `permissions: {contents: read}` on workflow |
| 14 | High | Wiz | `USER millpond` in Dockerfile |
| 12 | Medium | Wiz | Pinned uv to named stage alias |
| 13 | Medium | Wiz | `automountServiceAccountToken: false` |
| 3-4 | Low | Wiz | `HEALTHCHECK` in Dockerfile |
| 5 | Low | Wiz | `image: millpond:v0.0.0` placeholder |
| 8 | Low | Wiz | `securityContext` with `capabilities.drop: [ALL]` |
| 9 | Low | Wiz | Soft pod anti-affinity |
| 10 | Low | Wiz | PodDisruptionBudget |
| 6-7 | Low | Wiz | Annotated — namespace-level policies (platform team) |
| 11 | Low | Wiz | Annotated — false positive, service.yaml has `clusterIP: None` |

## Test plan
- [x] Docker build succeeds
- [x] E2E tests pass (4/4) against full docker-compose stack
- [x] DuckDB extensions load correctly as non-root millpond user