### PR TITLE
Add pipeline metrics, HSP partitioning, sizing guide, release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,4 +44,4 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Build Docker image
-      run: docker build --build-arg MILLPOND_VERSION=0.0.0-ci -t millpond .
+      run: docker build --build-arg MILLPOND_VERSION=0.0.0.dev0 -t millpond .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,4 +44,4 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Build Docker image
-      run: docker build -t millpond .
+      run: docker build --build-arg MILLPOND_VERSION=0.0.0-ci -t millpond .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,17 @@ jobs:
     - name: Unit tests
       run: uv run pytest -m "not integration and not e2e"
 
+  dependency-review:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+    - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+      with:
+        fail-on-severity: moderate
+        allow-licenses: Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, PSF-2.0
+
   build:
     runs-on: ubuntu-latest
     needs: check

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,33 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths: [tools/**]
+
+permissions:
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+    - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
+    - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      with:
+        path: tools/
+
+    - name: Deploy
+      id: deploy
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac2b3c603fc # v4

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -6,6 +6,7 @@ on:
     paths: [tools/**]
 
 permissions:
+  contents: read
   pages: write
   id-token: write
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 permissions:
   contents: write
   packages: write
@@ -59,9 +63,17 @@ jobs:
     - name: Build release tarball
       env:
         NEXT_TAG: ${{ steps.next_tag.outputs.tag }}
+        NEXT_VERSION: ${{ steps.next_tag.outputs.version }}
       run: |
-        git archive --format=tar.gz --prefix="millpond-${NEXT_TAG}/" HEAD \
-          -o "millpond-${NEXT_TAG}.tar.gz"
+        # Write version file so tarball consumers don't need .git history
+        echo "__version__ = \"${NEXT_VERSION}\"" > millpond/_version.py
+        # git archive doesn't include untracked files, so use tar directly
+        tar czf "millpond-${NEXT_TAG}.tar.gz" \
+          --transform "s,^,millpond-${NEXT_TAG}/," \
+          --exclude='.git' --exclude='*.pyc' --exclude='__pycache__' \
+          --exclude='.venv' --exclude='.flox' \
+          pyproject.toml uv.lock LICENSE README.md Dockerfile \
+          millpond/ tests/ test/
 
     - name: Create git tag
       env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,6 +109,8 @@ jobs:
       with:
         context: .
         push: true
+        build-args: |
+          MILLPOND_VERSION=${{ steps.next_tag.outputs.version }}
         tags: |
           ghcr.io/posthog/millpond:${{ steps.next_tag.outputs.tag }}
           ghcr.io/posthog/millpond:latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,10 +24,10 @@ jobs:
 
     - name: Bump patch version
       id: next_tag
+      env:
+        CURRENT_TAG: ${{ steps.latest_tag.outputs.tag }}
       run: |
-        current="${{ steps.latest_tag.outputs.tag }}"
-        # Strip v prefix, split, bump patch
-        version="${current#v}"
+        version="${CURRENT_TAG#v}"
         IFS='.' read -r major minor patch <<< "$version"
         next="v${major}.${minor}.$((patch + 1))"
         echo "tag=$next" >> "$GITHUB_OUTPUT"
@@ -35,49 +35,52 @@ jobs:
 
     - name: Generate changelog
       id: changelog
+      env:
+        PREV_TAG: ${{ steps.latest_tag.outputs.tag }}
+        COMMIT_SHA: ${{ github.sha }}
       run: |
-        prev="${{ steps.latest_tag.outputs.tag }}"
-        next="${{ steps.next_tag.outputs.tag }}"
-        sha="${{ github.sha }}"
-        short_sha="${sha:0:7}"
-
         {
           echo "body<<CHANGELOG_EOF"
           echo "## Changes"
           echo ""
-          if [ "$prev" = "v0.0.0" ]; then
+          if [ "$PREV_TAG" = "v0.0.0" ]; then
             git log --pretty=format:"- %s (%h)" HEAD
           else
-            git log --pretty=format:"- %s (%h)" "${prev}..HEAD"
+            git log --pretty=format:"- %s (%h)" "${PREV_TAG}..HEAD"
           fi
           echo ""
           echo ""
           echo "---"
-          echo "**Commit:** ${sha}"
+          echo "**Commit:** ${COMMIT_SHA}"
           echo "**Author:** $(git log -1 --pretty=format:'%an')"
           echo "CHANGELOG_EOF"
         } >> "$GITHUB_OUTPUT"
 
     - name: Build release tarball
+      env:
+        NEXT_TAG: ${{ steps.next_tag.outputs.tag }}
       run: |
-        tag="${{ steps.next_tag.outputs.tag }}"
-        # Archive source + lockfile (everything needed for a locked install)
-        git archive --format=tar.gz --prefix="millpond-${tag}/" HEAD \
-          -o "millpond-${tag}.tar.gz"
+        git archive --format=tar.gz --prefix="millpond-${NEXT_TAG}/" HEAD \
+          -o "millpond-${NEXT_TAG}.tar.gz"
 
     - name: Create git tag
+      env:
+        NEXT_TAG: ${{ steps.next_tag.outputs.tag }}
       run: |
-        git tag "${{ steps.next_tag.outputs.tag }}"
-        git push origin "${{ steps.next_tag.outputs.tag }}"
+        git tag "$NEXT_TAG"
+        git push origin "$NEXT_TAG"
 
     - name: Create GitHub release
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NEXT_TAG: ${{ steps.next_tag.outputs.tag }}
+        COMMIT_SHA: ${{ github.sha }}
+        CHANGELOG_BODY: ${{ steps.changelog.outputs.body }}
       run: |
-        gh release create "${{ steps.next_tag.outputs.tag }}" \
-          --title "${{ steps.next_tag.outputs.tag }} (${{ github.sha }})" \
-          --notes "${{ steps.changelog.outputs.body }}" \
-          "millpond-${{ steps.next_tag.outputs.tag }}.tar.gz"
+        gh release create "$NEXT_TAG" \
+          --title "${NEXT_TAG} (${COMMIT_SHA})" \
+          --notes "$CHANGELOG_BODY" \
+          "millpond-${NEXT_TAG}.tar.gz"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,101 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        fetch-depth: 0  # need full history for changelog and tag lookup
+
+    - name: Get latest tag
+      id: latest_tag
+      run: |
+        tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+    - name: Bump patch version
+      id: next_tag
+      run: |
+        current="${{ steps.latest_tag.outputs.tag }}"
+        # Strip v prefix, split, bump patch
+        version="${current#v}"
+        IFS='.' read -r major minor patch <<< "$version"
+        next="v${major}.${minor}.$((patch + 1))"
+        echo "tag=$next" >> "$GITHUB_OUTPUT"
+        echo "version=${next#v}" >> "$GITHUB_OUTPUT"
+
+    - name: Generate changelog
+      id: changelog
+      run: |
+        prev="${{ steps.latest_tag.outputs.tag }}"
+        next="${{ steps.next_tag.outputs.tag }}"
+        sha="${{ github.sha }}"
+        short_sha="${sha:0:7}"
+
+        {
+          echo "body<<CHANGELOG_EOF"
+          echo "## Changes"
+          echo ""
+          if [ "$prev" = "v0.0.0" ]; then
+            git log --pretty=format:"- %s (%h)" HEAD
+          else
+            git log --pretty=format:"- %s (%h)" "${prev}..HEAD"
+          fi
+          echo ""
+          echo ""
+          echo "---"
+          echo "**Commit:** ${sha}"
+          echo "**Author:** $(git log -1 --pretty=format:'%an')"
+          echo "CHANGELOG_EOF"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Build release tarball
+      run: |
+        tag="${{ steps.next_tag.outputs.tag }}"
+        # Archive source + lockfile (everything needed for a locked install)
+        git archive --format=tar.gz --prefix="millpond-${tag}/" HEAD \
+          -o "millpond-${tag}.tar.gz"
+
+    - name: Create git tag
+      run: |
+        git tag "${{ steps.next_tag.outputs.tag }}"
+        git push origin "${{ steps.next_tag.outputs.tag }}"
+
+    - name: Create GitHub release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release create "${{ steps.next_tag.outputs.tag }}" \
+          --title "${{ steps.next_tag.outputs.tag }} (${{ github.sha }})" \
+          --notes "${{ steps.changelog.outputs.body }}" \
+          "millpond-${{ steps.next_tag.outputs.tag }}.tar.gz"
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
+
+    - name: Log in to GHCR
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198e19c816612b # v6
+      with:
+        context: .
+        push: true
+        tags: |
+          ghcr.io/posthog/millpond:${{ steps.next_tag.outputs.tag }}
+          ghcr.io/posthog/millpond:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,25 +75,8 @@ jobs:
           pyproject.toml uv.lock LICENSE README.md Dockerfile \
           millpond/ tests/ test/
 
-    - name: Create git tag
-      env:
-        NEXT_TAG: ${{ steps.next_tag.outputs.tag }}
-      run: |
-        git tag "$NEXT_TAG"
-        git push origin "$NEXT_TAG"
-
-    - name: Create GitHub release
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NEXT_TAG: ${{ steps.next_tag.outputs.tag }}
-        COMMIT_SHA: ${{ github.sha }}
-        CHANGELOG_BODY: ${{ steps.changelog.outputs.body }}
-      run: |
-        gh release create "$NEXT_TAG" \
-          --title "${NEXT_TAG} (${COMMIT_SHA})" \
-          --notes "$CHANGELOG_BODY" \
-          "millpond-${NEXT_TAG}.tar.gz"
-
+    # Build and push Docker image before creating the release —
+    # if the image fails, we don't end up with an orphaned release/tag.
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
@@ -116,3 +99,22 @@ jobs:
           ghcr.io/posthog/millpond:latest
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+    - name: Create git tag
+      env:
+        NEXT_TAG: ${{ steps.next_tag.outputs.tag }}
+      run: |
+        git tag "$NEXT_TAG"
+        git push origin "$NEXT_TAG"
+
+    - name: Create GitHub release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NEXT_TAG: ${{ steps.next_tag.outputs.tag }}
+        COMMIT_SHA: ${{ github.sha }}
+        CHANGELOG_BODY: ${{ steps.changelog.outputs.body }}
+      run: |
+        gh release create "$NEXT_TAG" \
+          --title "${NEXT_TAG} (${COMMIT_SHA})" \
+          --notes "$CHANGELOG_BODY" \
+          "millpond-${NEXT_TAG}.tar.gz"

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -27,7 +27,6 @@ jobs:
             --config "p/python" \
             --config "p/owasp-top-ten" \
             --config "p/security-audit" \
-            --config "p/trailofbits" \
             --error \
             --metrics=off \
             --verbose \

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,0 +1,56 @@
+name: Semgrep
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  SEMGREP_ENABLE_VERSION_CHECK: 'false'
+
+jobs:
+  semgrep-python:
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Run Semgrep
+        run: |
+          semgrep \
+            --config "p/python" \
+            --config "p/owasp-top-ten" \
+            --config "p/security-audit" \
+            --config "p/trailofbits" \
+            --error \
+            --metrics=off \
+            --verbose \
+            millpond/
+
+  semgrep-general:
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Run Semgrep
+        run: |
+          semgrep \
+            --config "p/owasp-top-ten" \
+            --config "p/security-audit" \
+            --config "p/trailofbits" \
+            --config "p/github-actions" \
+            --error \
+            --metrics=off \
+            --verbose \
+            --exclude ./millpond/ \
+            .

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -15,7 +15,7 @@ jobs:
   semgrep-python:
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep@sha256:3dab091ee3247fce7e4ed3df9f92b3bd72692c083295f53cec3f135b86404db1
 
     steps:
       - name: Checkout
@@ -35,7 +35,7 @@ jobs:
   semgrep-general:
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep@sha256:3dab091ee3247fce7e4ed3df9f92b3bd72692c083295f53cec3f135b86404db1
 
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.pyc
 *.egg-info/
+millpond/_version.py
 dist/
 .ruff_cache/
 .pytest_cache/

--- a/AGENT.md
+++ b/AGENT.md
@@ -127,6 +127,16 @@ conn.unregister('arrow_batch')
 
 Zero-copy Arrow scan. Table auto-created and evolved (ADD COLUMN, ALTER COLUMN SET DATA TYPE) to match Arrow schema.
 
+### Hive-Style Partitioning
+
+If `DUCKLAKE_PARTITION_BY` is set, `_ensure_table()` runs `ALTER TABLE SET PARTITIONED BY (...)` after table creation. DuckLake writes files into Hive-style directories (`year=2026/month=3/day=23/hour=21/*.parquet`).
+
+- Partitioning is applied once on first write (idempotent — DuckLake ignores if already partitioned)
+- Typical expression: `year(_inserted_at),month(_inserted_at),day(_inserted_at),hour(_inserted_at)`
+- `_inserted_at` is always a TIMESTAMP (set at write time via `NOW()`), so temporal functions work reliably
+- Source `timestamp` fields are VARCHAR (not TIMESTAMP), so partition on `_inserted_at` not `timestamp`
+- DuckLake handles partition routing automatically on INSERT — no changes to write path
+
 ### Table Schema Evolution
 
 The ducklake-kafka-connect connector has two custom layers for schema evolution:

--- a/AGENT.md
+++ b/AGENT.md
@@ -330,6 +330,8 @@ millpond/
 │   ├── ducklake.py           # DuckDB/DuckLake connection, table mgmt, writes
 │   ├── metrics.py            # Prometheus metric definitions
 │   └── server.py             # HTTP server for /metrics and /healthz
+├── tools/
+│   └── sizing-calculator.html  # Interactive flush/object sizing calculator
 ├── tests/
 │   ├── unit/                 # Fast, no external deps
 │   ├── integration/          # Local DuckDB write path + schema evolution

--- a/AGENT.md
+++ b/AGENT.md
@@ -275,6 +275,17 @@ Unlike the JVM client (which supports custom log storage callbacks — see `duck
 
 For now, DuckDB logging is left at defaults. If needed, enable with `CALL enable_logging(storage='stdout')` and DuckDB will write to stderr in CSV format alongside Python's structured logs.
 
+## Releases
+
+Every merge to `main` triggers `.github/workflows/release.yaml`:
+
+1. Auto-bumps patch version from latest git tag (`v0.0.1` → `v0.0.2`)
+2. Builds a source tarball (`millpond-v0.0.X.tar.gz`) containing `pyproject.toml`, `uv.lock`, and all source — attached to the GitHub release
+3. Builds and pushes Docker image to `ghcr.io/posthog/millpond:<tag>` and `:latest`
+4. Creates GitHub release with auto-generated changelog
+
+The tarball is the primary artifact for external Docker builds (e.g. `posthog-cloud-infra`). It includes the lockfile so `uv sync --frozen` produces reproducible installs with pinned binary wheels. Do not distribute standalone wheels — they lack the lockfile and resolve unpinned deps from PyPI.
+
 ## Deployment Strategy
 
 Rolling updates are a poor fit for static partition assignment — during the roll, pods run with different `REPLICA_COUNT` values, causing temporary double-assignment (duplicate writes) or gaps. Since Kafka is the durable buffer, a simpler strategy works:
@@ -316,6 +327,9 @@ millpond/
 ├── pyproject.toml            # Dependencies and metadata (uv source of truth)
 ├── uv.lock                   # Resolved dependency lock (committed)
 ├── .flox/                    # Flox environment
+├── .github/workflows/
+│   ├── ci.yaml               # Format, lint, unit tests on PR/push
+│   └── release.yaml          # Auto-version, tarball, Docker image, GitHub release
 ├── Dockerfile
 ├── docker-compose.yaml       # Full dev stack (Kafka, Postgres, MinIO, Grafana)
 ├── k8s/

--- a/AGENT.md
+++ b/AGENT.md
@@ -131,7 +131,7 @@ Zero-copy Arrow scan. Table auto-created and evolved (ADD COLUMN, ALTER COLUMN S
 
 If `DUCKLAKE_PARTITION_BY` is set, `_ensure_table()` runs `ALTER TABLE SET PARTITIONED BY (...)` after table creation. DuckLake writes files into Hive-style directories (`year=2026/month=3/day=23/hour=21/*.parquet`).
 
-- Partitioning is applied once on first write (idempotent — DuckLake ignores if already partitioned)
+- Partitioning is applied on first write per pod lifetime (idempotent — `SET PARTITIONED BY` with the same expression is a no-op, safe for multiple pods and restarts)
 - Typical expression: `year(_inserted_at),month(_inserted_at),day(_inserted_at),hour(_inserted_at)`
 - `_inserted_at` is always a TIMESTAMP (set at write time via `NOW()`), so temporal functions work reliably
 - Source `timestamp` fields are VARCHAR (not TIMESTAMP), so partition on `_inserted_at` not `timestamp`

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY pyproject.toml uv.lock LICENSE ./
 RUN uv sync --frozen --no-dev --no-install-project
 
 COPY millpond/ millpond/
-ARG MILLPOND_VERSION=0.0.0
+ARG MILLPOND_VERSION=0.0.0.dev0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$MILLPOND_VERSION
 RUN uv sync --frozen --no-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.12-slim AS builder
 COPY --from=uv /uv /usr/local/bin/uv
 
 WORKDIR /app
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml uv.lock LICENSE ./
 RUN uv sync --frozen --no-dev --no-install-project
 
 COPY millpond/ millpond/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project
 
 COPY millpond/ millpond/
+ARG MILLPOND_VERSION=0.0.0
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=$MILLPOND_VERSION
 RUN uv sync --frozen --no-dev
 
 FROM python:3.12-slim

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PostHog, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ All configuration via environment variables:
 | `DUCKLAKE_DATA_PATH` | yes | | S3 path for DuckLake data files |
 | `DUCKLAKE_METADATA_URL` | yes | | Postgres URL for DuckLake metadata (`postgresql://user:pass@host:5432/db`) |
 | `DUCKLAKE_CONNECTION` | yes | | DuckDB connection string |
+| `DUCKLAKE_PARTITION_BY` | no | | Hive-style partition expression (e.g. `year(_inserted_at),month(_inserted_at),day(_inserted_at),hour(_inserted_at)`). Applied via `ALTER TABLE SET PARTITIONED BY` on first write. |
 | `FLUSH_SIZE` | no | `104857600` | Flush after this many bytes of accumulated Arrow data (default 100MB) |
 | `FLUSH_INTERVAL_MS` | no | `60000` | Flush after this many ms |
 | `GROUP_ID` | no | `millpond-{topic}-{table}` | Kafka group.id — used for offset storage in `__consumer_offsets` only, no consumer group semantics. Changing this loses committed offsets and triggers full replay. |
@@ -119,6 +120,16 @@ Rolling updates are a poor fit — pods with different `REPLICA_COUNT` values ca
 Downtime = drain time + startup time (~2-3 min). Kafka buffers trivially.
 
 **Never `kubectl scale` without updating `REPLICA_COUNT`.** Use Helm to manage both atomically.
+
+## Partitioning
+
+Set `DUCKLAKE_PARTITION_BY` to enable Hive-style partitioning on S3. Files are written into `key=value/` directories (e.g. `year=2026/month=3/day=23/hour=21/*.parquet`), enabling S3 prefix filtering, bulk lifecycle rules, and partition discovery by external tools.
+
+```bash
+DUCKLAKE_PARTITION_BY="year(_inserted_at),month(_inserted_at),day(_inserted_at),hour(_inserted_at)"
+```
+
+Partition on `_inserted_at` (always a real TIMESTAMP), not source `timestamp` fields (typically VARCHAR).
 
 ## Error Handling and Retries
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ CALL ducklake_merge_adjacent_files('lake', 'events');
 
 This is an out-of-band maintenance operation, not part of the hot path.
 
-See the [sizing calculator](tools/sizing-calculator.html) for interactive estimates.
+See the [sizing calculator](https://posthog.github.io/millpond/sizing-calculator.html) for interactive estimates.
 
 ## Error Handling and Retries
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Set `DUCKLAKE_PARTITION_BY` to enable Hive-style partitioning on S3. Files are w
 DUCKLAKE_PARTITION_BY="year(_inserted_at),month(_inserted_at),day(_inserted_at),hour(_inserted_at)"
 ```
 
-Partition on `_inserted_at` (always a real TIMESTAMP), not source `timestamp` fields (typically VARCHAR).
+Partition on `_inserted_at` (always a real TIMESTAMP), not source `timestamp` fields (typically VARCHAR). Applied via `ALTER TABLE SET PARTITIONED BY` on first write — idempotent, safe for multiple pods and restarts. If added to an existing unpartitioned table, new files get HSP layout while old files remain flat; DuckLake queries both transparently via metadata.
 
 ## Error Handling and Retries
 

--- a/README.md
+++ b/README.md
@@ -94,10 +94,18 @@ All configuration via environment variables:
 | `STATS_INTERVAL_MS` | no | `5000` | librdkafka internal stats emission interval (0 to disable) |
 | `LOG_LEVEL` | no | `INFO` | Python log level (DEBUG, INFO, WARNING, ERROR) |
 
+## Releases
+
+Every merge to `main` automatically:
+1. Bumps the patch version (`v0.0.1` → `v0.0.2`)
+2. Builds and pushes a Docker image to `ghcr.io/posthog/millpond:<tag>`
+3. Creates a GitHub release with changelog
+
+Images: `ghcr.io/posthog/millpond:v0.0.X` or `ghcr.io/posthog/millpond:latest`
+
 ## Deployment
 
 ```bash
-just build        # build Docker image
 kubectl apply -f k8s/service.yaml
 kubectl apply -f k8s/pdb.yaml
 kubectl apply -f k8s/statefulset.yaml

--- a/README.md
+++ b/README.md
@@ -131,6 +131,49 @@ DUCKLAKE_PARTITION_BY="year(_inserted_at),month(_inserted_at),day(_inserted_at),
 
 Partition on `_inserted_at` (always a real TIMESTAMP), not source `timestamp` fields (typically VARCHAR). Applied via `ALTER TABLE SET PARTITIONED BY` on first write — idempotent, safe for multiple pods and restarts. If added to an existing unpartitioned table, new files get HSP layout while old files remain flat; DuckLake queries both transparently via metadata.
 
+## Object Sizing
+
+S3 throughput scales with object size — small objects (<1MB) waste per-request overhead, while larger objects (128MB+) maximize GET/PUT throughput. Millpond flushes are triggered by whichever comes first: `FLUSH_SIZE` (Arrow bytes in memory) or `FLUSH_INTERVAL_MS` (wall clock). The resulting Parquet file is typically **3-4x smaller** than the Arrow representation due to columnar encoding and compression.
+
+At steady state with moderate volume, most flushes are **time-triggered** — the interval expires before the size ceiling is hit. Object size is therefore driven by: `(msgs/s per pod) × (bytes/msg as Parquet) × (flush interval)`.
+
+### Sizing by volume
+
+Assuming ~366 bytes/row in Parquet (7-column event schema), 512 partitions, 8 replicas (64 partitions/pod):
+
+| Per-partition msg/s | Total msg/s | Per-pod msg/s | Parquet/file @60s | Parquet/file @90s | Memory/pod @90s |
+|---|---|---|---|---|---|
+| 500 | 256K | 32K | ~11MB | ~17MB | 512Mi |
+| 1K | 512K | 64K | ~23MB | ~34MB | 512Mi |
+| 2K | 1M | 128K | ~45MB | ~68MB | 512Mi |
+| 4K | 2M | 256K | ~90MB | ~135MB | 640Mi |
+| 9.5K (peak) | 4.9M | 608K | ~213MB | ~320MB | 1Gi |
+
+### Recommended settings for ~128MB target objects
+
+For a pipeline averaging 4K msg/s per partition with 512 partitions and 8 replicas:
+
+```yaml
+FLUSH_SIZE: "1073741824"       # 1GB Arrow ceiling (safety valve for burst/catchup)
+FLUSH_INTERVAL_MS: "90000"     # 90s — produces ~135MB Parquet at mean volume
+```
+
+Memory limit: 640Mi (90s × 256K msg/s × ~1KB Arrow/msg ≈ ~230MB Arrow + DuckDB + librdkafka overhead).
+
+At peak (9.5K/partition), the size trigger fires at ~35s producing ~320MB objects — acceptable, and the pod stays within 1Gi.
+
+### When to add a merge job
+
+If your volume is low enough that time-triggered flushes produce <10MB objects, consider running `ducklake_merge_adjacent_files()` periodically to compact small files:
+
+```sql
+CALL ducklake_merge_adjacent_files('lake', 'events');
+```
+
+This is an out-of-band maintenance operation, not part of the hot path.
+
+See the [sizing calculator](tools/sizing-calculator.html) for interactive estimates.
+
 ## Error Handling and Retries
 
 The flush path has two failure points, each with its own retry policy:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -91,7 +91,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        MILLPOND_VERSION: "0.0.0-dev"
+        MILLPOND_VERSION: "0.0.0.dev0"
     depends_on:
       kafka-init:
         condition: service_completed_successfully
@@ -118,7 +118,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        MILLPOND_VERSION: "0.0.0-dev"
+        MILLPOND_VERSION: "0.0.0.dev0"
     depends_on:
       kafka-init:
         condition: service_completed_successfully
@@ -149,7 +149,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        MILLPOND_VERSION: "0.0.0-dev"
+        MILLPOND_VERSION: "0.0.0.dev0"
     entrypoint: ["sh", "-c", "sleep 2 && exec millpond"]
     depends_on:
       kafka-init:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
     image: postgres:17
     hostname: postgres
     ports:
-      - "5433:5432"
+      - "127.0.0.1:5433:5432"
     environment:
       POSTGRES_USER: ducklake
       POSTGRES_PASSWORD: ducklake
@@ -40,8 +40,8 @@ services:
     image: minio/minio:latest
     hostname: minio
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
@@ -171,14 +171,15 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      DATA_SOURCE_NAME: "postgresql://ducklake:ducklake@postgres:5432/ducklake?sslmode=disable"
+      # nosemgrep: trailofbits.generic.postgres-insecure-sslmode.postgres-insecure-sslmode
+      DATA_SOURCE_NAME: "postgresql://ducklake:ducklake@postgres:5432/ducklake?sslmode=disable"  # local dev — no TLS available
 
   # --- Metrics & Dashboarding ---
 
   prometheus:
     image: prom/prometheus:latest
     ports:
-      - "9091:9090"
+      - "127.0.0.1:9091:9090"
     configs:
       - source: prometheus-config
         target: /etc/prometheus/prometheus.yml
@@ -186,7 +187,7 @@ services:
   grafana:
     image: grafana/grafana-oss:latest
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     environment:
       GF_AUTH_ANONYMOUS_ENABLED: "true"
       GF_AUTH_ANONYMOUS_ORG_ROLE: Admin

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -90,6 +90,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        MILLPOND_VERSION: "0.0.0-dev"
     depends_on:
       kafka-init:
         condition: service_completed_successfully
@@ -115,6 +117,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        MILLPOND_VERSION: "0.0.0-dev"
     depends_on:
       kafka-init:
         condition: service_completed_successfully
@@ -144,6 +148,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        MILLPOND_VERSION: "0.0.0-dev"
     entrypoint: ["sh", "-c", "sleep 2 && exec millpond"]
     depends_on:
       kafka-init:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -133,6 +133,7 @@ services:
       DUCKLAKE_CONNECTION: ":memory:"
       FLUSH_SIZE: 5000
       FLUSH_INTERVAL_MS: 5000
+      DUCKLAKE_PARTITION_BY: "year(_inserted_at),month(_inserted_at),day(_inserted_at),hour(_inserted_at)"
       DUCKDB_S3_ENDPOINT: minio:9000
       DUCKDB_S3_ACCESS_KEY_ID: minioadmin
       DUCKDB_S3_SECRET_ACCESS_KEY: minioadmin

--- a/justfile
+++ b/justfile
@@ -85,6 +85,11 @@ dashboard:
 minio:
     open http://localhost:9001
 
+# Open the sizing calculator
+[group('docker')]
+sizing:
+    open tools/sizing-calculator.html
+
 # === Build ===
 
 # Build Docker image

--- a/justfile
+++ b/justfile
@@ -80,6 +80,11 @@ duck:
 dashboard:
     open http://localhost:3000/d/millpond/millpond
 
+# Open the MinIO console (requires `just up` first, login: minioadmin/minioadmin)
+[group('docker')]
+minio:
+    open http://localhost:9001
+
 # === Build ===
 
 # Build Docker image

--- a/k8s/statefulset.yaml
+++ b/k8s/statefulset.yaml
@@ -32,7 +32,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: millpond
-        image: millpond:v0.0.0  # placeholder — Helm sets the real tag
+        image: ghcr.io/posthog/millpond:v0.0.0  # Helm sets the real tag
         ports:
         - name: metrics
           containerPort: 8000

--- a/millpond/config.py
+++ b/millpond/config.py
@@ -79,8 +79,7 @@ def load() -> Config:
     partition_by = os.environ.get("DUCKLAKE_PARTITION_BY", "").strip() or None
     if partition_by and not _SAFE_PARTITION_EXPR.match(partition_by):
         raise RuntimeError(
-            f"DUCKLAKE_PARTITION_BY {partition_by!r} contains unsafe characters "
-            "(must match [a-zA-Z0-9_(),\\s]+)"
+            f"DUCKLAKE_PARTITION_BY {partition_by!r} contains unsafe characters (must match [a-zA-Z0-9_(),\\s]+)"
         )
 
     cfg = Config(

--- a/millpond/config.py
+++ b/millpond/config.py
@@ -4,6 +4,7 @@ import re
 from dataclasses import dataclass
 
 _SAFE_TABLE_NAME = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+_SAFE_PARTITION_EXPR = re.compile(r"^[a-zA-Z0-9_(),\s]+$")
 
 log = logging.getLogger(__name__)
 
@@ -28,6 +29,9 @@ class Config:
     # Flush triggers
     flush_size: int  # bytes of accumulated Arrow data
     flush_interval_ms: int  # ms since last flush
+
+    # Partitioning
+    partition_by: str | None  # e.g. "year(timestamp),month(timestamp),day(timestamp),hour(timestamp)"
 
     # Consumer tuning
     fetch_min_bytes: int
@@ -72,6 +76,13 @@ def load() -> Config:
 
     group_id = os.environ.get("GROUP_ID", f"millpond-{topic}-{ducklake_table}")
 
+    partition_by = os.environ.get("DUCKLAKE_PARTITION_BY", "").strip() or None
+    if partition_by and not _SAFE_PARTITION_EXPR.match(partition_by):
+        raise RuntimeError(
+            f"DUCKLAKE_PARTITION_BY {partition_by!r} contains unsafe characters "
+            "(must match [a-zA-Z0-9_(),\\s]+)"
+        )
+
     cfg = Config(
         bootstrap_servers=_require("KAFKA_BOOTSTRAP_SERVERS"),
         topic=topic,
@@ -82,6 +93,7 @@ def load() -> Config:
         ducklake_data_path=_require("DUCKLAKE_DATA_PATH"),
         ducklake_metadata_url=_require("DUCKLAKE_METADATA_URL"),
         ducklake_connection=_require("DUCKLAKE_CONNECTION"),
+        partition_by=partition_by,
         flush_size=int(os.environ.get("FLUSH_SIZE", "104857600")),
         flush_interval_ms=int(os.environ.get("FLUSH_INTERVAL_MS", "60000")),
         fetch_min_bytes=int(os.environ.get("FETCH_MIN_BYTES", "1048576")),

--- a/millpond/config.py
+++ b/millpond/config.py
@@ -4,7 +4,9 @@ import re
 from dataclasses import dataclass
 
 _SAFE_TABLE_NAME = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
-_SAFE_PARTITION_EXPR = re.compile(r"^[a-zA-Z0-9_(),\s]+$")
+
+# Shared with ducklake._validate_partition_expr — keep in sync or import from here.
+SAFE_PARTITION_EXPR = re.compile(r"^[a-zA-Z0-9_(),\s]+$")
 
 log = logging.getLogger(__name__)
 
@@ -77,7 +79,7 @@ def load() -> Config:
     group_id = os.environ.get("GROUP_ID", f"millpond-{topic}-{ducklake_table}")
 
     partition_by = os.environ.get("DUCKLAKE_PARTITION_BY", "").strip() or None
-    if partition_by and not _SAFE_PARTITION_EXPR.match(partition_by):
+    if partition_by and not SAFE_PARTITION_EXPR.match(partition_by):
         raise RuntimeError(
             f"DUCKLAKE_PARTITION_BY {partition_by!r} contains unsafe characters (must match [a-zA-Z0-9_(),\\s]+)"
         )

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -12,7 +12,6 @@ from millpond.config import Config
 log = logging.getLogger(__name__)
 
 _SETTING_VALUE_RE = re.compile(r"^[a-zA-Z0-9_.:/\-@+=]+$")
-_SAFE_PARTITION_EXPR = re.compile(r"^[a-zA-Z0-9_(),\s]+$")
 
 
 def _escape_libpq(value: str | None) -> str:
@@ -81,7 +80,9 @@ def connect(cfg: Config) -> duckdb.DuckDBPyConnection:
 
 def _validate_partition_expr(expr: str) -> str:
     """Validate a partition expression to prevent SQL injection."""
-    if not _SAFE_PARTITION_EXPR.match(expr):
+    from millpond.config import SAFE_PARTITION_EXPR
+
+    if not SAFE_PARTITION_EXPR.match(expr):
         raise ValueError(f"Partition expression contains unsafe characters: {expr!r}")
     return expr
 

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -12,6 +12,7 @@ from millpond.config import Config
 log = logging.getLogger(__name__)
 
 _SETTING_VALUE_RE = re.compile(r"^[a-zA-Z0-9_.:/\-@+=]+$")
+_SAFE_PARTITION_EXPR = re.compile(r"^[a-zA-Z0-9_(),\s]+$")
 
 
 def _escape_libpq(value: str | None) -> str:
@@ -78,11 +79,23 @@ def connect(cfg: Config) -> duckdb.DuckDBPyConnection:
     return conn
 
 
+def _validate_partition_expr(expr: str) -> str:
+    """Validate a partition expression to prevent SQL injection."""
+    if not _SAFE_PARTITION_EXPR.match(expr):
+        raise ValueError(f"Partition expression contains unsafe characters: {expr!r}")
+    return expr
+
+
 # Assumes single connection for pod lifetime. Must be cleared if connection is ever recycled.
 _tables_ensured: set[str] = set()
 
 
-def _ensure_table(conn: duckdb.DuckDBPyConnection, table_name: str, batch: pa.Table) -> None:
+def _ensure_table(
+    conn: duckdb.DuckDBPyConnection,
+    table_name: str,
+    batch: pa.Table,
+    partition_by: str | None = None,
+) -> None:
     """Create the DuckLake table from Arrow schema if it doesn't exist. Cached after first call."""
     if table_name in _tables_ensured:
         return
@@ -94,6 +107,10 @@ def _ensure_table(conn: duckdb.DuckDBPyConnection, table_name: str, batch: pa.Ta
         )
     finally:
         conn.unregister("_schema_batch")
+    if partition_by is not None:
+        _validate_partition_expr(partition_by)
+        conn.execute(f"ALTER TABLE lake.main.{table_name} SET PARTITIONED BY ({partition_by})")
+        log.info("Table %s partitioned by: %s", table_name, partition_by)
     _tables_ensured.add(table_name)
 
 
@@ -102,9 +119,10 @@ def write(
     table_name: str,
     batch: pa.Table,
     schema_mgr: "schema.SchemaManager | None" = None,
+    partition_by: str | None = None,
 ) -> None:
     """Write an Arrow table to DuckLake with _inserted_at timestamp."""
-    _ensure_table(conn, table_name, batch)
+    _ensure_table(conn, table_name, batch, partition_by)
     if schema_mgr is not None:
         schema_mgr.evolve(batch.schema)
     conn.register("_arrow_batch", batch)

--- a/millpond/main.py
+++ b/millpond/main.py
@@ -122,6 +122,7 @@ def main():
     log.info("millpond starting")
 
     cfg = config.load()
+    metrics.init(f"{cfg.topic}-{cfg.ducklake_table}")
     http = server.start()
 
     db = ducklake.connect(cfg)

--- a/millpond/main.py
+++ b/millpond/main.py
@@ -27,11 +27,11 @@ def _convert_batch(values: list[bytes]) -> pa.Table | None:
     return table
 
 
-def _write_with_retry(db, table_name, consolidated, schema_mgr):
+def _write_with_retry(db, table_name, consolidated, schema_mgr, partition_by=None):
     """Write to DuckLake with exponential backoff on transient failures."""
     for attempt in range(_WRITE_MAX_RETRIES):
         try:
-            ducklake.write(db, table_name, consolidated, schema_mgr)
+            ducklake.write(db, table_name, consolidated, schema_mgr, partition_by)
             return
         except Exception:
             metrics.errors_total.labels(type="write_retry").inc()
@@ -55,7 +55,7 @@ def _write_with_retry(db, table_name, consolidated, schema_mgr):
 def _flush(db, cfg, kafka, consolidated, pending_bytes, pending_records, offsets, elapsed, schema_mgr):
     """Write to DuckLake, commit offsets, update metrics."""
     t0 = time.monotonic()
-    _write_with_retry(db, cfg.ducklake_table, consolidated, schema_mgr)
+    _write_with_retry(db, cfg.ducklake_table, consolidated, schema_mgr, cfg.partition_by)
     write_duration = time.monotonic() - t0
 
     # Commit offsets synchronously — at-least-once requires knowing commit succeeded

--- a/millpond/metrics.py
+++ b/millpond/metrics.py
@@ -1,97 +1,175 @@
 from prometheus_client import Counter, Gauge, Histogram
 
-# Counters
-records_consumed_total = Counter(
+
+class _AutoPipelineLabels:
+    """Wrapper that auto-injects the pipeline label into .labels() calls."""
+
+    def __init__(self, metric, pipeline: str):
+        self._metric = metric
+        self._pipeline = pipeline
+
+    def labels(self, **kwargs):
+        return self._metric.labels(pipeline=self._pipeline, **kwargs)
+
+
+# --- Raw metric definitions (with pipeline as first label) ---
+
+_records_consumed_total = Counter(
     "millpond_records_consumed_total",
     "Records polled from Kafka",
-    ["partition"],
+    ["pipeline", "partition"],
 )
-records_written_total = Counter(
+_records_written_total = Counter(
     "millpond_records_written_total",
     "Records written to DuckLake",
+    ["pipeline"],
 )
-batches_flushed_total = Counter(
+_batches_flushed_total = Counter(
     "millpond_batches_flushed_total",
     "Flush cycles completed",
+    ["pipeline"],
 )
-records_skipped_total = Counter(
+_records_skipped_total = Counter(
     "millpond_records_skipped_total",
     "Records skipped",
-    ["reason"],
+    ["pipeline", "reason"],
 )
-errors_total = Counter(
+_errors_total = Counter(
     "millpond_errors_total",
     "Errors by type",
-    ["type"],
+    ["pipeline", "type"],
 )
 
-# Histograms
-flush_duration_seconds = Histogram(
+_flush_duration_seconds = Histogram(
     "millpond_flush_duration_seconds",
     "Time per DuckLake write",
+    ["pipeline"],
 )
-arrow_conversion_seconds = Histogram(
+_arrow_conversion_seconds = Histogram(
     "millpond_arrow_conversion_seconds",
     "Time to convert JSON to Arrow table",
+    ["pipeline"],
 )
-flush_size_bytes = Histogram(
+_flush_size_bytes = Histogram(
     "millpond_flush_size_bytes",
     "Arrow bytes per flush",
+    ["pipeline"],
     buckets=[1e6, 5e6, 10e6, 25e6, 50e6, 100e6, 250e6, 500e6, 1e9],
 )
-flush_size_records = Histogram(
+_flush_size_records = Histogram(
     "millpond_flush_size_records",
     "Records per flush",
+    ["pipeline"],
     buckets=[100, 500, 1000, 5000, 10000, 50000, 100000, 500000, 1000000],
 )
 
-# Gauges
-pending_bytes = Gauge(
+_pending_bytes = Gauge(
     "millpond_pending_bytes",
     "Current pending Arrow bytes awaiting flush",
+    ["pipeline"],
 )
-consumer_lag = Gauge(
+_consumer_lag = Gauge(
     "millpond_consumer_lag",
     "Highwater mark minus committed offset",
-    ["partition"],
+    ["pipeline", "partition"],
 )
-last_committed_offset = Gauge(
+_last_committed_offset = Gauge(
     "millpond_last_committed_offset",
     "Last committed offset",
-    ["partition"],
+    ["pipeline", "partition"],
 )
 
-# librdkafka internal stats (via statistics.interval.ms callback)
-# Schema evolution
-schema_columns_added_total = Counter(
+_schema_columns_added_total = Counter(
     "millpond_schema_columns_added_total",
     "Columns added via schema evolution",
+    ["pipeline"],
 )
-schema_columns_widened_total = Counter(
+_schema_columns_widened_total = Counter(
     "millpond_schema_columns_widened_total",
     "Columns widened via schema evolution",
+    ["pipeline"],
 )
 
 # librdkafka internal stats (via statistics.interval.ms callback)
-rdkafka_replyq = Gauge(
+_rdkafka_replyq = Gauge(
     "millpond_rdkafka_replyq",
     "Number of ops waiting for broker response",
+    ["pipeline"],
 )
-rdkafka_msg_cnt = Gauge(
+_rdkafka_msg_cnt = Gauge(
     "millpond_rdkafka_msg_cnt",
     "Messages in internal producer/consumer queues",
+    ["pipeline"],
 )
-rdkafka_msg_size = Gauge(
+_rdkafka_msg_size = Gauge(
     "millpond_rdkafka_msg_size",
     "Bytes in internal producer/consumer queues",
+    ["pipeline"],
 )
-rdkafka_broker_rtt_avg = Gauge(
+_rdkafka_broker_rtt_avg = Gauge(
     "millpond_rdkafka_broker_rtt_avg_seconds",
     "Broker round-trip time average",
-    ["broker"],
+    ["pipeline", "broker"],
 )
-rdkafka_broker_rtt_p99 = Gauge(
+_rdkafka_broker_rtt_p99 = Gauge(
     "millpond_rdkafka_broker_rtt_p99_seconds",
     "Broker round-trip time p99",
-    ["broker"],
+    ["pipeline", "broker"],
 )
+
+# --- Public names (replaced by init() with pipeline-bound instances) ---
+
+records_consumed_total = _records_consumed_total
+records_written_total = _records_written_total
+batches_flushed_total = _batches_flushed_total
+records_skipped_total = _records_skipped_total
+errors_total = _errors_total
+flush_duration_seconds = _flush_duration_seconds
+arrow_conversion_seconds = _arrow_conversion_seconds
+flush_size_bytes = _flush_size_bytes
+flush_size_records = _flush_size_records
+pending_bytes = _pending_bytes
+consumer_lag = _consumer_lag
+last_committed_offset = _last_committed_offset
+schema_columns_added_total = _schema_columns_added_total
+schema_columns_widened_total = _schema_columns_widened_total
+rdkafka_replyq = _rdkafka_replyq
+rdkafka_msg_cnt = _rdkafka_msg_cnt
+rdkafka_msg_size = _rdkafka_msg_size
+rdkafka_broker_rtt_avg = _rdkafka_broker_rtt_avg
+rdkafka_broker_rtt_p99 = _rdkafka_broker_rtt_p99
+
+
+def init(pipeline: str):
+    """Bind all metrics to a pipeline label. Must be called once at startup."""
+    global records_consumed_total, records_written_total, batches_flushed_total
+    global records_skipped_total, errors_total
+    global flush_duration_seconds, arrow_conversion_seconds
+    global flush_size_bytes, flush_size_records
+    global pending_bytes, consumer_lag, last_committed_offset
+    global schema_columns_added_total, schema_columns_widened_total
+    global rdkafka_replyq, rdkafka_msg_cnt, rdkafka_msg_size
+    global rdkafka_broker_rtt_avg, rdkafka_broker_rtt_p99
+
+    # Metrics with additional labels — wrap so .labels() auto-injects pipeline
+    records_consumed_total = _AutoPipelineLabels(_records_consumed_total, pipeline)
+    records_skipped_total = _AutoPipelineLabels(_records_skipped_total, pipeline)
+    errors_total = _AutoPipelineLabels(_errors_total, pipeline)
+    consumer_lag = _AutoPipelineLabels(_consumer_lag, pipeline)
+    last_committed_offset = _AutoPipelineLabels(_last_committed_offset, pipeline)
+    rdkafka_broker_rtt_avg = _AutoPipelineLabels(_rdkafka_broker_rtt_avg, pipeline)
+    rdkafka_broker_rtt_p99 = _AutoPipelineLabels(_rdkafka_broker_rtt_p99, pipeline)
+
+    # Metrics with no other labels — pre-label to get direct .inc()/.set()/.observe()
+    records_written_total = _records_written_total.labels(pipeline=pipeline)
+    batches_flushed_total = _batches_flushed_total.labels(pipeline=pipeline)
+    flush_duration_seconds = _flush_duration_seconds.labels(pipeline=pipeline)
+    arrow_conversion_seconds = _arrow_conversion_seconds.labels(pipeline=pipeline)
+    flush_size_bytes = _flush_size_bytes.labels(pipeline=pipeline)
+    flush_size_records = _flush_size_records.labels(pipeline=pipeline)
+    pending_bytes = _pending_bytes.labels(pipeline=pipeline)
+    schema_columns_added_total = _schema_columns_added_total.labels(pipeline=pipeline)
+    schema_columns_widened_total = _schema_columns_widened_total.labels(pipeline=pipeline)
+    rdkafka_replyq = _rdkafka_replyq.labels(pipeline=pipeline)
+    rdkafka_msg_cnt = _rdkafka_msg_cnt.labels(pipeline=pipeline)
+    rdkafka_msg_size = _rdkafka_msg_size.labels(pipeline=pipeline)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "hatchling.build"
 name = "millpond"
 version = "0.1.0"
 description = "Kafka to DuckLake"
+license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "confluent-kafka>=2.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ version-file = "millpond/_version.py"
 name = "millpond"
 dynamic = ["version"]
 description = "Kafka to DuckLake"
-license = "MIT"
+license = {file = "LICENSE"}
 requires-python = ">=3.12"
 dependencies = [
     "confluent-kafka>=2.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,16 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "millpond/_version.py"
 
 [project]
 name = "millpond"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Kafka to DuckLake"
 license = "MIT"
 requires-python = ">=3.12"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+from millpond import metrics
+
+# Initialize metrics with a test pipeline label so tests that don't mock metrics
+# can call .labels() without hitting "Incorrect label names" errors.
+metrics.init("test-topic-test-table")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -83,3 +83,34 @@ class TestLoad:
             monkeypatch.setenv("DUCKLAKE_TABLE", name)
             cfg = load()
             assert cfg.ducklake_table == name
+
+    def test_partition_by_default_none(self):
+        cfg = load()
+        assert cfg.partition_by is None
+
+    def test_partition_by_set(self, monkeypatch):
+        monkeypatch.setenv("DUCKLAKE_PARTITION_BY", "year(timestamp),month(timestamp)")
+        cfg = load()
+        assert cfg.partition_by == "year(timestamp),month(timestamp)"
+
+    def test_partition_by_valid_expressions(self, monkeypatch):
+        for expr in [
+            "region",
+            "year(ts)",
+            "year(ts),month(ts),day(ts),hour(ts)",
+            "year(created_at), month(created_at)",
+            "team_id,year(timestamp)",
+        ]:
+            monkeypatch.setenv("DUCKLAKE_PARTITION_BY", expr)
+            cfg = load()
+            assert cfg.partition_by == expr
+
+    def test_partition_by_sql_injection_rejected(self, monkeypatch):
+        monkeypatch.setenv("DUCKLAKE_PARTITION_BY", "year(ts); DROP TABLE x")
+        with pytest.raises(RuntimeError, match="unsafe"):
+            load()
+
+    def test_partition_by_empty_string_treated_as_none(self, monkeypatch):
+        monkeypatch.setenv("DUCKLAKE_PARTITION_BY", "")
+        cfg = load()
+        assert cfg.partition_by is None

--- a/tests/unit/test_ducklake.py
+++ b/tests/unit/test_ducklake.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 import pytest
 
 from millpond.ducklake import _escape_libpq, _sanitize_setting_value, _validate_partition_expr

--- a/tests/unit/test_ducklake.py
+++ b/tests/unit/test_ducklake.py
@@ -1,6 +1,8 @@
+from unittest.mock import MagicMock
+
 import pytest
 
-from millpond.ducklake import _escape_libpq, _sanitize_setting_value
+from millpond.ducklake import _escape_libpq, _sanitize_setting_value, _validate_partition_expr
 
 
 class TestSanitizeSettingValue:
@@ -33,6 +35,32 @@ class TestSanitizeSettingValue:
     def test_empty_rejected(self):
         with pytest.raises(ValueError, match="Illegal character"):
             _sanitize_setting_value("")
+
+
+class TestValidatePartitionExpr:
+    def test_simple_column(self):
+        assert _validate_partition_expr("region") == "region"
+
+    def test_temporal_functions(self):
+        assert _validate_partition_expr("year(ts),month(ts),day(ts),hour(ts)") == "year(ts),month(ts),day(ts),hour(ts)"
+
+    def test_mixed(self):
+        assert _validate_partition_expr("team_id,year(timestamp)") == "team_id,year(timestamp)"
+
+    def test_spaces_around_commas(self):
+        assert _validate_partition_expr("year(ts), month(ts)") == "year(ts), month(ts)"
+
+    def test_sql_injection_rejected(self):
+        with pytest.raises(ValueError, match="unsafe"):
+            _validate_partition_expr("year(ts); DROP TABLE x")
+
+    def test_comment_injection_rejected(self):
+        with pytest.raises(ValueError, match="unsafe"):
+            _validate_partition_expr("year(ts) -- comment")
+
+    def test_quoted_string_rejected(self):
+        with pytest.raises(ValueError, match="unsafe"):
+            _validate_partition_expr("'malicious'")
 
 
 class TestEscapeLibpq:

--- a/tools/sizing-calculator.html
+++ b/tools/sizing-calculator.html
@@ -40,24 +40,24 @@
 <div class="grid">
   <div class="card">
     <h2>Pipeline</h2>
-    <label>Messages per second (per partition)</label>
+    <label for="msgs_per_partition">Messages per second (per partition)</label>
     <input type="number" id="msgs_per_partition" value="4000" min="1">
-    <label>Partition count</label>
+    <label for="partitions">Partition count</label>
     <input type="number" id="partitions" value="512" min="1">
-    <label>Replica count</label>
+    <label for="replicas">Replica count</label>
     <input type="number" id="replicas" value="8" min="1">
-    <label>Parquet bytes per row</label>
+    <label for="parquet_bpr">Parquet bytes per row</label>
     <input type="number" id="parquet_bpr" value="366" min="1">
   </div>
   <div class="card">
     <h2>Configuration</h2>
-    <label>FLUSH_INTERVAL_MS</label>
+    <label for="flush_interval">FLUSH_INTERVAL_MS</label>
     <input type="number" id="flush_interval" value="60000" min="1000" step="1000">
-    <label>FLUSH_SIZE (Arrow bytes)</label>
+    <label for="flush_size">FLUSH_SIZE (Arrow bytes)</label>
     <input type="number" id="flush_size" value="104857600" min="1000000">
-    <label>Arrow-to-Parquet ratio</label>
+    <label for="compression">Arrow-to-Parquet ratio</label>
     <input type="number" id="compression" value="2.8" min="1" step="0.1">
-    <label>Target Parquet object size (MB)</label>
+    <label for="target_mb">Target Parquet object size (MB)</label>
     <input type="number" id="target_mb" value="128" min="1">
   </div>
 </div>
@@ -110,6 +110,30 @@ function memClass(bytes) {
   return '';
 }
 
+function makeCell(text, cls, extra) {
+  const td = document.createElement('td');
+  if (extra) td.className = extra;
+  if (cls) {
+    const span = document.createElement('span');
+    span.className = cls;
+    span.textContent = text;
+    td.appendChild(span);
+  } else {
+    td.textContent = text;
+  }
+  return td;
+}
+
+function makeRow(cells) {
+  const tr = document.createElement('tr');
+  cells.forEach(c => tr.appendChild(c));
+  return tr;
+}
+
+function clearAndAppend(parent, children) {
+  parent.replaceChildren(...children);
+}
+
 function calc() {
   const msgsPerPart = +document.getElementById('msgs_per_partition').value;
   const partitions = +document.getElementById('partitions').value;
@@ -148,68 +172,79 @@ function calc() {
   const overhead = 160 * 1024 * 1024;
   const memNeeded = actualArrow + overhead;
 
+  // --- Output table ---
   const out = document.getElementById('output');
-  const rows = [
-    ['Total throughput', fmtN(totalMsgs) + ' msg/s'],
-    ['Partitions per pod', fmtN(partsPerPod)],
-    ['Messages per pod', fmtN(msgsPerPod) + ' msg/s'],
-    ['Flush trigger', sizeTriggered ? '<span class="warn">size (' + actualInterval.toFixed(1) + 's)</span>' : 'time (' + intervalS + 's)'],
-    ['Rows per flush', fmtN(actualRows)],
-    ['Arrow per flush', '<span class="' + memClass(actualArrow) + '">' + fmt(actualArrow) + '</span>'],
-    ['Parquet per flush', '<span class="' + sizeClass(actualParquet, targetMb) + '">' + fmt(actualParquet) + '</span>'],
-    ['Est. memory per pod', '<span class="' + memClass(memNeeded) + '">' + fmt(memNeeded) + '</span>'],
-    ['Files per day (all pods)', fmtN(Math.round(filesPerDay))],
+  const triggerText = sizeTriggered
+    ? 'size (' + actualInterval.toFixed(1) + 's)'
+    : 'time (' + intervalS + 's)';
+  const outputRows = [
+    ['Total throughput', fmtN(totalMsgs) + ' msg/s', ''],
+    ['Partitions per pod', fmtN(partsPerPod), ''],
+    ['Messages per pod', fmtN(msgsPerPod) + ' msg/s', ''],
+    ['Flush trigger', triggerText, sizeTriggered ? 'warn' : ''],
+    ['Rows per flush', fmtN(actualRows), ''],
+    ['Arrow per flush', fmt(actualArrow), memClass(actualArrow)],
+    ['Parquet per flush', fmt(actualParquet), sizeClass(actualParquet, targetMb)],
+    ['Est. memory per pod', fmt(memNeeded), memClass(memNeeded)],
+    ['Files per day (all pods)', fmtN(Math.round(filesPerDay)), ''],
   ];
-  out.innerHTML = rows.map(r => '<tr><td>' + r[0] + '</td><td class="num">' + r[1] + '</td></tr>').join('');
+  clearAndAppend(out, outputRows.map(r =>
+    makeRow([makeCell(r[0], '', ''), makeCell(r[1], r[2], 'num')])
+  ));
 
   const note = document.getElementById('trigger_note');
-  note.innerHTML = sizeTriggered
+  note.textContent = sizeTriggered
     ? 'Size trigger fires at ' + actualInterval.toFixed(1) + 's before the ' + intervalS + 's interval expires.'
     : 'Time trigger fires at ' + intervalS + 's. FLUSH_SIZE ceiling (' + fmt(flushSize) + ' Arrow) is not reached.';
 
-  // Sensitivity table
+  // --- Sensitivity table ---
   const intervals = [30, 60, 90, 120, 180, 300];
   const sens = document.getElementById('sensitivity');
-  sens.innerHTML = intervals.map(s => {
-    const ms = s * 1000;
+  clearAndAppend(sens, intervals.map(s => {
     const tFill = flushSize / (msgsPerPod * arrowBpr);
     const triggered = tFill < s;
     const effInterval = triggered ? tFill : s;
     const pq = triggered ? (flushSize / ratio) : (msgsPerPod * s * parquetBpr);
     const ar = triggered ? flushSize : (msgsPerPod * s * arrowBpr);
     const fpd = Math.round((86400 / effInterval) * replicas);
-    const marker = (ms === flushInterval) ? ' *' : '';
-    return '<tr><td>' + s + 's' + marker + '</td>'
-      + '<td class="num"><span class="' + sizeClass(pq, targetMb) + '">' + fmt(pq) + '</span></td>'
-      + '<td class="num"><span class="' + memClass(ar) + '">' + fmt(ar) + '</span></td>'
-      + '<td class="num">' + fmtN(fpd) + '</td></tr>';
-  }).join('');
+    const marker = (s * 1000 === flushInterval) ? ' *' : '';
+    return makeRow([
+      makeCell(s + 's' + marker, '', ''),
+      makeCell(fmt(pq), sizeClass(pq, targetMb), 'num'),
+      makeCell(fmt(ar), memClass(ar), 'num'),
+      makeCell(fmtN(fpd), '', 'num'),
+    ]);
+  }));
 
-  // Recommendation
+  // --- Recommendation ---
   const rec = document.getElementById('recommendation');
   const targetParquet = targetMb * 1e6;
   const idealInterval = targetParquet / (msgsPerPod * parquetBpr);
   const idealArrow = msgsPerPod * idealInterval * arrowBpr;
   const idealMem = idealArrow + overhead;
-  const idealMemMi = Math.ceil(idealMem / (1024*1024) / 128) * 128; // round up to 128Mi
+  const idealMemMi = Math.ceil(idealMem / (1024*1024) / 128) * 128;
+
+  const h2 = document.createElement('h2');
+  const p = document.createElement('p');
 
   if (idealInterval < 10) {
-    rec.innerHTML = '<h2>Recommendation</h2>'
-      + '<p>At this volume, even a 10s interval exceeds ' + targetMb + 'MB. '
-      + 'Set <code>FLUSH_INTERVAL_MS=10000</code> and let the size trigger handle it. '
-      + 'Memory limit: <code>' + idealMemMi + 'Mi</code>.</p>';
+    h2.textContent = 'Recommendation';
+    p.textContent = 'At this volume, even a 10s interval exceeds ' + targetMb + 'MB. '
+      + 'Set FLUSH_INTERVAL_MS=10000 and let the size trigger handle it. '
+      + 'Memory limit: ' + idealMemMi + 'Mi.';
   } else if (idealInterval > 600) {
-    rec.innerHTML = '<h2>Recommendation</h2>'
-      + '<p>Volume is too low to reach ' + targetMb + 'MB within a reasonable interval. '
-      + 'Use <code>FLUSH_INTERVAL_MS=60000</code> and run <code>ducklake_merge_adjacent_files()</code> periodically to compact.</p>';
+    h2.textContent = 'Recommendation';
+    p.textContent = 'Volume is too low to reach ' + targetMb + 'MB within a reasonable interval. '
+      + 'Use FLUSH_INTERVAL_MS=60000 and run ducklake_merge_adjacent_files() periodically to compact.';
   } else {
-    const recIntervalMs = Math.round(idealInterval / 5) * 5 * 1000; // round to nearest 5s
-    rec.innerHTML = '<h2>Recommendation for ~' + targetMb + 'MB objects</h2>'
-      + '<p><code>FLUSH_INTERVAL_MS=' + recIntervalMs + '</code> &mdash; '
+    const recIntervalMs = Math.round(idealInterval / 5) * 5 * 1000;
+    h2.textContent = 'Recommendation for ~' + targetMb + 'MB objects';
+    p.textContent = 'FLUSH_INTERVAL_MS=' + recIntervalMs + ' \u2014 '
       + 'produces ~' + fmt(targetParquet) + ' Parquet per file at mean volume. '
-      + 'Memory limit: <code>' + idealMemMi + 'Mi</code>. '
-      + 'Set <code>FLUSH_SIZE</code> to <code>' + fmtN(Math.round(idealArrow * 2)) + '</code> as a burst ceiling.</p>';
+      + 'Memory limit: ' + idealMemMi + 'Mi. '
+      + 'Set FLUSH_SIZE to ' + fmtN(Math.round(idealArrow * 2)) + ' as a burst ceiling.';
   }
+  rec.replaceChildren(h2, p);
 }
 
 document.querySelectorAll('input').forEach(el => el.addEventListener('input', calc));

--- a/tools/sizing-calculator.html
+++ b/tools/sizing-calculator.html
@@ -161,9 +161,9 @@ function calc() {
   const sizeTriggered = timeToFillSize < intervalS;
 
   const actualInterval = sizeTriggered ? timeToFillSize : intervalS;
-  const actualParquet = sizeTriggered ? (flushSize / ratio) : parquetPerInterval;
-  const actualArrow = sizeTriggered ? flushSize : arrowPerInterval;
   const actualRows = sizeTriggered ? Math.floor(flushSize / arrowBpr) : rowsPerInterval;
+  const actualArrow = actualRows * arrowBpr;
+  const actualParquet = actualRows * parquetBpr;
 
   const filesPerPodPerDay = (86400 / actualInterval);
   const filesPerDay = filesPerPodPerDay * replicas;

--- a/tools/sizing-calculator.html
+++ b/tools/sizing-calculator.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Millpond Sizing Calculator</title>
+<style>
+  :root { --bg: #1a1a2e; --card: #16213e; --accent: #0f3460; --text: #e0e0e0; --hi: #e94560; --ok: #4ecca3; }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace; background: var(--bg); color: var(--text); padding: 2rem; max-width: 960px; margin: 0 auto; }
+  h1 { font-size: 1.4rem; margin-bottom: 0.3rem; }
+  h1 span { color: var(--hi); }
+  .subtitle { color: #888; font-size: 0.85rem; margin-bottom: 1.5rem; }
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; margin-bottom: 1.5rem; }
+  .card { background: var(--card); border-radius: 8px; padding: 1.2rem; }
+  .card h2 { font-size: 0.9rem; color: #888; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 1rem; }
+  label { display: block; font-size: 0.85rem; margin-bottom: 0.3rem; color: #aaa; }
+  input[type=number] { width: 100%; background: var(--accent); border: 1px solid #333; border-radius: 4px; padding: 0.5rem; color: var(--text); font-size: 1rem; font-family: inherit; margin-bottom: 0.8rem; }
+  input[type=number]:focus { outline: none; border-color: var(--hi); }
+  .results { background: var(--card); border-radius: 8px; padding: 1.2rem; margin-bottom: 1.5rem; }
+  .results h2 { font-size: 0.9rem; color: #888; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 1rem; }
+  table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+  th { text-align: left; padding: 0.4rem 0.6rem; color: #888; font-weight: normal; border-bottom: 1px solid #333; }
+  td { padding: 0.4rem 0.6rem; border-bottom: 1px solid #222; }
+  td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .warn { color: var(--hi); }
+  .good { color: var(--ok); }
+  .note { font-size: 0.8rem; color: #666; margin-top: 0.8rem; }
+  .rec { background: var(--accent); border-radius: 8px; padding: 1.2rem; border-left: 3px solid var(--ok); }
+  .rec h2 { font-size: 0.9rem; color: var(--ok); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.5rem; }
+  .rec code { background: #0a0a1a; padding: 0.15rem 0.4rem; border-radius: 3px; font-size: 0.85rem; }
+  @media (max-width: 600px) { .grid { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+
+<h1><span>Millpond</span> Sizing Calculator</h1>
+<p class="subtitle">Estimate Parquet object sizes, memory requirements, and flush behavior</p>
+
+<div class="grid">
+  <div class="card">
+    <h2>Pipeline</h2>
+    <label>Messages per second (per partition)</label>
+    <input type="number" id="msgs_per_partition" value="4000" min="1">
+    <label>Partition count</label>
+    <input type="number" id="partitions" value="512" min="1">
+    <label>Replica count</label>
+    <input type="number" id="replicas" value="8" min="1">
+    <label>Parquet bytes per row</label>
+    <input type="number" id="parquet_bpr" value="366" min="1">
+  </div>
+  <div class="card">
+    <h2>Configuration</h2>
+    <label>FLUSH_INTERVAL_MS</label>
+    <input type="number" id="flush_interval" value="60000" min="1000" step="1000">
+    <label>FLUSH_SIZE (Arrow bytes)</label>
+    <input type="number" id="flush_size" value="104857600" min="1000000">
+    <label>Arrow-to-Parquet ratio</label>
+    <input type="number" id="compression" value="2.8" min="1" step="0.1">
+    <label>Target Parquet object size (MB)</label>
+    <input type="number" id="target_mb" value="128" min="1">
+  </div>
+</div>
+
+<div class="results">
+  <h2>Flush Estimates</h2>
+  <table>
+    <thead>
+      <tr><th>Metric</th><th style="text-align:right">Value</th></tr>
+    </thead>
+    <tbody id="output"></tbody>
+  </table>
+  <p class="note" id="trigger_note"></p>
+</div>
+
+<div class="results">
+  <h2>Sensitivity — Parquet Size by Interval</h2>
+  <table>
+    <thead>
+      <tr><th>Interval</th><th style="text-align:right">Parquet/file</th><th style="text-align:right">Arrow in memory</th><th style="text-align:right">Files/day</th></tr>
+    </thead>
+    <tbody id="sensitivity"></tbody>
+  </table>
+</div>
+
+<div class="rec" id="recommendation"></div>
+
+<script>
+function fmt(bytes) {
+  if (bytes >= 1e9) return (bytes/1e9).toFixed(1) + ' GB';
+  if (bytes >= 1e6) return (bytes/1e6).toFixed(1) + ' MB';
+  if (bytes >= 1e3) return (bytes/1e3).toFixed(1) + ' KB';
+  return bytes.toFixed(0) + ' B';
+}
+
+function fmtN(n) {
+  return n.toLocaleString('en-US', {maximumFractionDigits: 0});
+}
+
+function sizeClass(bytes, target) {
+  const mb = bytes / 1e6;
+  if (mb < 1) return 'warn';
+  if (mb >= target * 0.7 && mb <= target * 1.5) return 'good';
+  return '';
+}
+
+function memClass(bytes) {
+  const mi = bytes / (1024*1024);
+  if (mi > 1024) return 'warn';
+  return '';
+}
+
+function calc() {
+  const msgsPerPart = +document.getElementById('msgs_per_partition').value;
+  const partitions = +document.getElementById('partitions').value;
+  const replicas = +document.getElementById('replicas').value;
+  const parquetBpr = +document.getElementById('parquet_bpr').value;
+  const flushInterval = +document.getElementById('flush_interval').value;
+  const flushSize = +document.getElementById('flush_size').value;
+  const ratio = +document.getElementById('compression').value;
+  const targetMb = +document.getElementById('target_mb').value;
+
+  const partsPerPod = Math.ceil(partitions / replicas);
+  const msgsPerPod = msgsPerPart * partsPerPod;
+  const totalMsgs = msgsPerPart * partitions;
+
+  const intervalS = flushInterval / 1000;
+  const arrowBpr = parquetBpr * ratio;
+
+  // Time-triggered scenario
+  const rowsPerInterval = msgsPerPod * intervalS;
+  const arrowPerInterval = rowsPerInterval * arrowBpr;
+  const parquetPerInterval = rowsPerInterval * parquetBpr;
+
+  // Size-triggered scenario
+  const timeToFillSize = flushSize / (msgsPerPod * arrowBpr);
+  const sizeTriggered = timeToFillSize < intervalS;
+
+  const actualInterval = sizeTriggered ? timeToFillSize : intervalS;
+  const actualParquet = sizeTriggered ? (flushSize / ratio) : parquetPerInterval;
+  const actualArrow = sizeTriggered ? flushSize : arrowPerInterval;
+  const actualRows = sizeTriggered ? Math.floor(flushSize / arrowBpr) : rowsPerInterval;
+
+  const filesPerPodPerDay = (86400 / actualInterval);
+  const filesPerDay = filesPerPodPerDay * replicas;
+
+  // Memory estimate: Arrow buffer + overhead (DuckDB ~30MB, librdkafka ~100MB, Python ~30MB)
+  const overhead = 160 * 1024 * 1024;
+  const memNeeded = actualArrow + overhead;
+
+  const out = document.getElementById('output');
+  const rows = [
+    ['Total throughput', fmtN(totalMsgs) + ' msg/s'],
+    ['Partitions per pod', fmtN(partsPerPod)],
+    ['Messages per pod', fmtN(msgsPerPod) + ' msg/s'],
+    ['Flush trigger', sizeTriggered ? '<span class="warn">size (' + actualInterval.toFixed(1) + 's)</span>' : 'time (' + intervalS + 's)'],
+    ['Rows per flush', fmtN(actualRows)],
+    ['Arrow per flush', '<span class="' + memClass(actualArrow) + '">' + fmt(actualArrow) + '</span>'],
+    ['Parquet per flush', '<span class="' + sizeClass(actualParquet, targetMb) + '">' + fmt(actualParquet) + '</span>'],
+    ['Est. memory per pod', '<span class="' + memClass(memNeeded) + '">' + fmt(memNeeded) + '</span>'],
+    ['Files per day (all pods)', fmtN(Math.round(filesPerDay))],
+  ];
+  out.innerHTML = rows.map(r => '<tr><td>' + r[0] + '</td><td class="num">' + r[1] + '</td></tr>').join('');
+
+  const note = document.getElementById('trigger_note');
+  note.innerHTML = sizeTriggered
+    ? 'Size trigger fires at ' + actualInterval.toFixed(1) + 's before the ' + intervalS + 's interval expires.'
+    : 'Time trigger fires at ' + intervalS + 's. FLUSH_SIZE ceiling (' + fmt(flushSize) + ' Arrow) is not reached.';
+
+  // Sensitivity table
+  const intervals = [30, 60, 90, 120, 180, 300];
+  const sens = document.getElementById('sensitivity');
+  sens.innerHTML = intervals.map(s => {
+    const ms = s * 1000;
+    const tFill = flushSize / (msgsPerPod * arrowBpr);
+    const triggered = tFill < s;
+    const effInterval = triggered ? tFill : s;
+    const pq = triggered ? (flushSize / ratio) : (msgsPerPod * s * parquetBpr);
+    const ar = triggered ? flushSize : (msgsPerPod * s * arrowBpr);
+    const fpd = Math.round((86400 / effInterval) * replicas);
+    const marker = (ms === flushInterval) ? ' *' : '';
+    return '<tr><td>' + s + 's' + marker + '</td>'
+      + '<td class="num"><span class="' + sizeClass(pq, targetMb) + '">' + fmt(pq) + '</span></td>'
+      + '<td class="num"><span class="' + memClass(ar) + '">' + fmt(ar) + '</span></td>'
+      + '<td class="num">' + fmtN(fpd) + '</td></tr>';
+  }).join('');
+
+  // Recommendation
+  const rec = document.getElementById('recommendation');
+  const targetParquet = targetMb * 1e6;
+  const idealInterval = targetParquet / (msgsPerPod * parquetBpr);
+  const idealArrow = msgsPerPod * idealInterval * arrowBpr;
+  const idealMem = idealArrow + overhead;
+  const idealMemMi = Math.ceil(idealMem / (1024*1024) / 128) * 128; // round up to 128Mi
+
+  if (idealInterval < 10) {
+    rec.innerHTML = '<h2>Recommendation</h2>'
+      + '<p>At this volume, even a 10s interval exceeds ' + targetMb + 'MB. '
+      + 'Set <code>FLUSH_INTERVAL_MS=10000</code> and let the size trigger handle it. '
+      + 'Memory limit: <code>' + idealMemMi + 'Mi</code>.</p>';
+  } else if (idealInterval > 600) {
+    rec.innerHTML = '<h2>Recommendation</h2>'
+      + '<p>Volume is too low to reach ' + targetMb + 'MB within a reasonable interval. '
+      + 'Use <code>FLUSH_INTERVAL_MS=60000</code> and run <code>ducklake_merge_adjacent_files()</code> periodically to compact.</p>';
+  } else {
+    const recIntervalMs = Math.round(idealInterval / 5) * 5 * 1000; // round to nearest 5s
+    rec.innerHTML = '<h2>Recommendation for ~' + targetMb + 'MB objects</h2>'
+      + '<p><code>FLUSH_INTERVAL_MS=' + recIntervalMs + '</code> &mdash; '
+      + 'produces ~' + fmt(targetParquet) + ' Parquet per file at mean volume. '
+      + 'Memory limit: <code>' + idealMemMi + 'Mi</code>. '
+      + 'Set <code>FLUSH_SIZE</code> to <code>' + fmtN(Math.round(idealArrow * 2)) + '</code> as a burst ceiling.</p>';
+  }
+}
+
+document.querySelectorAll('input').forEach(el => el.addEventListener('input', calc));
+calc();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- **Pipeline label on all metrics** — every Prometheus metric now carries `pipeline={topic}-{table}` for filtering across deployments in Grafana
- **Hive-style partitioning** — `DUCKLAKE_PARTITION_BY` env var triggers `ALTER TABLE SET PARTITIONED BY` on first write, producing `year=2026/month=3/day=23/hour=21/*.parquet` directory layout on S3. Idempotent, safe for multi-pod and restarts.
- **Object sizing guide** — README section with sizing tables by volume, recommended settings for ~128MB target objects, and guidance on when to use `ducklake_merge_adjacent_files()`
- **Interactive sizing calculator** — single-page HTML tool (`tools/sizing-calculator.html`) for estimating Parquet sizes, memory requirements, and flush behavior
- **Release workflow** — auto-bumps patch version on merge to main, builds source tarball with lockfile (for reproducible installs in external Dockerfiles), pushes Docker image to GHCR, creates GitHub release with changelog
- **Semgrep SAST** — Python + OWASP + security-audit + trailofbits + GitHub Actions rulesets
- **Dependency review** — blocks PRs with moderate+ severity vulnerabilities or unapproved licenses
- **MIT license**

## Test plan
- [x] 104 unit tests pass
- [x] 15 integration tests pass
- [x] 4 E2E tests pass
- [x] HSP verified against live docker-compose stack (`year=2026/month=3/day=23/hour=21/*.parquet`)
- [x] `SET PARTITIONED BY` confirmed idempotent on already-partitioned tables
- [x] Docker build succeeds