### PR TITLE
Fix deploy-pages action SHA pin

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -31,4 +31,4 @@ jobs:
 
     - name: Deploy
       id: deploy
-      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac2b3c603fc # v4
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Summary
- Fix incorrect SHA pin for `actions/deploy-pages` — was `...b3c603fc`, correct is `...b3c0c03e` (v4.0.5)

## Test plan
- [ ] Pages workflow succeeds on merge to main