### PR TITLE
Fix docker/build-push-action SHA pin

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,7 +88,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@263435318d21b8e681c14492fe198e19c816612b # v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: .
         push: true


### PR DESCRIPTION
## Summary
- The release workflow had a nonexistent SHA (`263435318d...`) for `docker/build-push-action@v6`, causing the release job to fail at setup
- Replaced with the correct commit SHA (`10e90e3645...`)