### PR TITLE
Address code scanning audit findings (1-14, except 13)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,9 @@ jobs:
         NEXT_TAG: ${{ steps.next_tag.outputs.tag }}
         NEXT_VERSION: ${{ steps.next_tag.outputs.version }}
       run: |
-        # Write version file so tarball consumers don't need .git history
+        # Write version file for reference — tarball consumers use
+        # SETUPTOOLS_SCM_PRETEND_VERSION at install time, which generates the
+        # full hatch-vcs _version.py with __version_tuple__ etc.
         echo "__version__ = \"${NEXT_VERSION}\"" > millpond/_version.py
         # git archive doesn't include untracked files, so use tar directly
         tar czf "millpond-${NEXT_TAG}.tar.gz" \

--- a/AGENT.md
+++ b/AGENT.md
@@ -84,6 +84,8 @@ Scaling requires updating both `spec.replicas` and the `REPLICA_COUNT` env var.
 
 **`group.id`**: defaults to `millpond-{topic}-{table}`. Used only for offset storage in `__consumer_offsets` (no consumer group semantics). Changing `group.id` loses all committed offsets and triggers a full replay from `earliest`.
 
+**Monitoring caveat**: because we use `assign()` instead of `subscribe()`, standard consumer group monitoring tools (`kafka-consumer-groups.sh`, Burrow, etc.) show empty output or stale data. Use Millpond's own `millpond_consumer_lag` metric for lag monitoring, and `millpond_last_committed_offset` for offset tracking.
+
 ### Flush Triggers
 
 Both time-based and size-based:

--- a/AGENT.md
+++ b/AGENT.md
@@ -300,10 +300,11 @@ Downtime = time to drain + time to start new pods. With `terminationGracePeriodS
 
 ## HTTP Server
 
-Both Prometheus metrics (`/metrics`) and health checks (`/healthz`) run on port 8000. `prometheus_client.start_http_server()` does not support custom routes, so Millpond uses a custom `http.server.HTTPServer` that serves both:
+Prometheus metrics and health checks on port 8000 via a custom `http.server.HTTPServer` (`prometheus_client.start_http_server()` doesn't support custom routes):
 
 - `GET /metrics` → Prometheus exposition format (via `prometheus_client.generate_latest()`)
-- `GET /healthz` → 200 if last poll and last flush are within thresholds, 503 otherwise
+- `GET /healthz` → liveness: 200 if started and last poll within `max_poll_age_s` (300s), 503 otherwise
+- `GET /readyz` → readiness: 200 if alive and last flush within `max_flush_age_s` (600s), 503 otherwise. Idle topics (no flush yet) pass readiness.
 
 ## Toolchain
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -98,9 +98,9 @@ Ported from ducklake-kafka-connect's `SinkRecordToArrowConverter`:
 
 1. Parse JSON via `orjson` (Rust, ~1GB/s)
 2. `pa.Table.from_pylist()` builds the columnar batch — PyArrow infers the superset schema across all dicts
-3. v1 types: all numbers → DOUBLE, all strings → VARCHAR, nested objects → JSON. No timestamp detection, no type promotion (see Deferred Complexity)
+3. v1 types: integers → INT64, floats → FLOAT64, all strings → VARCHAR, nested objects → JSON. No timestamp detection (see Deferred Complexity)
 
-**Important**: `orjson` parses JSON integers as Python `int`, so `pa.Table.from_pylist()` infers INT64 for integer-only columns. A column that's INT64 in batch N and DOUBLE in batch N+1 (because one value was `1.5`) causes type wobble. v1 must cast all numeric columns to DOUBLE after `from_pylist()` to avoid this.
+**Important**: `orjson` parses JSON integers as Python `int`, so `pa.Table.from_pylist()` infers INT64 for integer-only columns. A column that's INT64 in batch N and FLOAT64 in batch N+1 (because one value was `1.5`) causes type wobble. `_normalize_numeric_types()` casts all integers to INT64 and all floats to FLOAT64 after `from_pylist()` to prevent this.
 
 **Caveat**: `pa.Table.from_pylist()` infers the schema from the first record's keys only. `arrow_converter.py` works around this by pre-scanning all records to build the full key union and passing an explicit schema to `from_pylist()`. The pre-scan is effectively free (pointer iteration over dict keys).
 
@@ -266,7 +266,7 @@ Even [Confluent's own docs](https://www.confluent.io/learn/kafka-dead-letter-que
 
 | Feature | Status |
 |---------|--------|
-| Type promotion (int8→int16→int32→int64→float) | v1: all numbers are DOUBLE, all strings are VARCHAR, nested objects are JSON. Add promotion later if storage costs justify it. |
+| Type promotion (int8→int16→int32→int64→float) | v1: integers normalized to INT64, floats to FLOAT64, all strings VARCHAR, nested objects JSON. Add finer promotion later if storage costs justify it. |
 | Timestamp detection heuristic | v1: store as VARCHAR. Let query engine cast. The ISO8601 regex will misfire on non-timestamp strings that happen to match the pattern. Add opt-in timestamp columns later. When adding this, port the ID field heuristic from ducklake-kafka-connect's `SinkRecordToArrowConverter`: fields ending in `_uuid`, `uuid`, `_id`, `id`, `_key`, `key` must be forced to VARCHAR to prevent UUID strings like `"2024-02-28T23:59:59Z"` from being mis-inferred as timestamps. |
 
 ## DuckDB Logging
@@ -340,7 +340,7 @@ millpond/
 │   ├── __init__.py
 │   ├── main.py               # Entry point, main loop, signal handling
 │   ├── config.py             # Env var → dataclass
-│   ├── arrow_converter.py    # JSON → PyArrow Table (orjson + from_pylist + DOUBLE cast)
+│   ├── arrow_converter.py    # JSON → PyArrow Table (orjson + from_pylist + numeric normalization)
 │   ├── ducklake.py           # DuckDB/DuckLake connection, table mgmt, writes
 │   ├── metrics.py            # Prometheus metric definitions
 │   └── server.py             # HTTP server for /metrics and /healthz

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -126,6 +126,10 @@ services:
         condition: service_healthy
       minio-init:
         condition: service_completed_successfully
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     environment: &millpond-env
       KAFKA_BOOTSTRAP_SERVERS: kafka:9094
       KAFKA_TOPIC: test-events
@@ -158,6 +162,10 @@ services:
         condition: service_healthy
       minio-init:
         condition: service_completed_successfully
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     environment:
       <<: *millpond-env
       POD_NAME: millpond-test-1

--- a/justfile
+++ b/justfile
@@ -41,17 +41,17 @@ lint-fix:
 # Run unit tests
 [group('test')]
 test:
-    uv run pytest tests/unit
+    uv run python -m pytest tests/unit
 
 # Run integration tests
 [group('test')]
 test-integration:
-    uv run pytest tests/integration
+    uv run python -m pytest tests/integration
 
 # Run E2E test (brings up docker-compose stack automatically)
 [group('test')]
 test-e2e:
-    uv run pytest tests/e2e -v -s
+    uv run python -m pytest tests/e2e -v -s
 
 # Full CI check
 [group('test')]

--- a/millpond/arrow_converter.py
+++ b/millpond/arrow_converter.py
@@ -158,8 +158,11 @@ def convert(messages: list[bytes]) -> pa.Table | None:
         return None
 
     records = _flatten_nested_to_json(records)
-    records = _stringify_mixed_type_values(records, _build_schema(records))
     schema = _build_schema(records)
-    table = pa.Table.from_pylist(records, schema=schema)
+    patched = _stringify_mixed_type_values(records, schema)
+    if patched is not records:
+        # Mixed types were found and coerced — re-infer schema with string types
+        schema = _build_schema(patched)
+    table = pa.Table.from_pylist(patched, schema=schema)
     table = _normalize_numeric_types(table)
     return table

--- a/millpond/config.py
+++ b/millpond/config.py
@@ -41,6 +41,9 @@ class Config:
     consume_batch_size: int
     stats_interval_ms: int
 
+    # Extra librdkafka config (from KAFKA_CONSUMER_* env vars)
+    kafka_config_overrides: tuple[tuple[str, str], ...]
+
     @property
     def flush_interval_s(self) -> float:
         return self.flush_interval_ms / 1000.0
@@ -84,6 +87,15 @@ def load() -> Config:
             f"DUCKLAKE_PARTITION_BY {partition_by!r} contains unsafe characters (must match [a-zA-Z0-9_(),\\s]+)"
         )
 
+    # Collect KAFKA_CONSUMER_* env vars as librdkafka config overrides.
+    # e.g. KAFKA_CONSUMER_SECURITY_PROTOCOL=SASL_SSL -> security.protocol=SASL_SSL
+    _KAFKA_CONSUMER_PREFIX = "KAFKA_CONSUMER_"
+    kafka_overrides = tuple(
+        (k[len(_KAFKA_CONSUMER_PREFIX):].lower().replace("_", "."), v)
+        for k, v in os.environ.items()
+        if k.startswith(_KAFKA_CONSUMER_PREFIX)
+    )
+
     cfg = Config(
         bootstrap_servers=_require("KAFKA_BOOTSTRAP_SERVERS"),
         topic=topic,
@@ -101,6 +113,7 @@ def load() -> Config:
         fetch_max_wait_ms=int(os.environ.get("FETCH_MAX_WAIT_MS", "500")),
         consume_batch_size=int(os.environ.get("CONSUME_BATCH_SIZE", "1000")),
         stats_interval_ms=int(os.environ.get("STATS_INTERVAL_MS", "5000")),
+        kafka_config_overrides=kafka_overrides,
     )
 
     log.info(

--- a/millpond/config.py
+++ b/millpond/config.py
@@ -91,7 +91,7 @@ def load() -> Config:
     # e.g. KAFKA_CONSUMER_SECURITY_PROTOCOL=SASL_SSL -> security.protocol=SASL_SSL
     _KAFKA_CONSUMER_PREFIX = "KAFKA_CONSUMER_"
     kafka_overrides = tuple(
-        (k[len(_KAFKA_CONSUMER_PREFIX):].lower().replace("_", "."), v)
+        (k[len(_KAFKA_CONSUMER_PREFIX) :].lower().replace("_", "."), v)
         for k, v in os.environ.items()
         if k.startswith(_KAFKA_CONSUMER_PREFIX)
     )

--- a/millpond/consumer.py
+++ b/millpond/consumer.py
@@ -65,19 +65,22 @@ def create(cfg: Config) -> Consumer:
 
     log.info("Assigned partitions: %s", my_partitions)
 
-    consumer = Consumer(
-        {
-            "bootstrap.servers": cfg.bootstrap_servers,
-            "group.id": cfg.group_id,
-            "auto.offset.reset": "earliest",
-            "enable.auto.commit": False,
-            "enable.auto.offset.store": False,
-            "fetch.min.bytes": cfg.fetch_min_bytes,
-            "fetch.wait.max.ms": cfg.fetch_max_wait_ms,
-            "statistics.interval.ms": cfg.stats_interval_ms,
-            "stats_cb": _on_stats,
-        }
-    )
+    consumer_config = {
+        "bootstrap.servers": cfg.bootstrap_servers,
+        "group.id": cfg.group_id,
+        "auto.offset.reset": "earliest",
+        "enable.auto.commit": False,
+        "enable.auto.offset.store": False,
+        "fetch.min.bytes": cfg.fetch_min_bytes,
+        "fetch.wait.max.ms": cfg.fetch_max_wait_ms,
+        "statistics.interval.ms": cfg.stats_interval_ms,
+        "stats_cb": _on_stats,
+    }
+    # Merge KAFKA_CONSUMER_* overrides (e.g. security.protocol, sasl.mechanism)
+    for key, val in cfg.kafka_config_overrides:
+        consumer_config[key] = val
+
+    consumer = Consumer(consumer_config)
 
     consumer.assign([TopicPartition(cfg.topic, p) for p in my_partitions])
     return consumer

--- a/millpond/consumer.py
+++ b/millpond/consumer.py
@@ -73,6 +73,7 @@ def create(cfg: Config) -> Consumer:
         "enable.auto.offset.store": False,
         "fetch.min.bytes": cfg.fetch_min_bytes,
         "fetch.wait.max.ms": cfg.fetch_max_wait_ms,
+        "max.poll.interval.ms": 600000,  # 10 min — accommodates long S3 flushes
         "statistics.interval.ms": cfg.stats_interval_ms,
         "stats_cb": _on_stats,
     }

--- a/millpond/consumer.py
+++ b/millpond/consumer.py
@@ -11,7 +11,11 @@ log = logging.getLogger(__name__)
 
 
 def _on_stats(stats_json: str) -> None:
-    """Parse librdkafka stats JSON and update Prometheus gauges."""
+    """Parse librdkafka stats JSON and update Prometheus gauges.
+
+    Called on the librdkafka background thread, not the main thread.
+    prometheus_client Gauge.set() is thread-safe (atomic double write).
+    """
     try:
         stats = orjson.loads(stats_json)
     except (orjson.JSONDecodeError, TypeError):

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -91,6 +91,11 @@ def _validate_partition_expr(expr: str) -> str:
 _tables_ensured: set[str] = set()
 
 
+def reset_table_cache() -> None:
+    """Clear the table creation cache. Call when the DuckDB connection is recycled."""
+    _tables_ensured.clear()
+
+
 def _ensure_table(
     conn: duckdb.DuckDBPyConnection,
     table_name: str,

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -117,6 +117,7 @@ def _ensure_table(
         _validate_partition_expr(partition_by)
         conn.execute(f"ALTER TABLE lake.main.{table_name} SET PARTITIONED BY ({partition_by})")
         log.info("Table %s partitioned by: %s", table_name, partition_by)
+    # Cache AFTER both CREATE and ALTER succeed — if either fails, retry on next write.
     _tables_ensured.add(table_name)
 
 

--- a/millpond/main.py
+++ b/millpond/main.py
@@ -125,6 +125,9 @@ def main():
     metrics.init(f"{cfg.topic}-{cfg.ducklake_table}")
     http = server.start()
 
+    # No connection recovery logic — if DuckLake/Postgres fails, the pod crashes
+    # and K8s restarts it. Reconnection adds complexity for no benefit when the
+    # restart path already handles offset replay correctly.
     db = ducklake.connect(cfg)
     schema_mgr = schema.SchemaManager(db, cfg.ducklake_table)
     kafka = consumer.create(cfg)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -114,3 +114,17 @@ class TestLoad:
         monkeypatch.setenv("DUCKLAKE_PARTITION_BY", "")
         cfg = load()
         assert cfg.partition_by is None
+
+    def test_kafka_consumer_overrides(self, monkeypatch):
+        monkeypatch.setenv("KAFKA_CONSUMER_SECURITY_PROTOCOL", "SASL_SSL")
+        monkeypatch.setenv("KAFKA_CONSUMER_SASL_MECHANISM", "PLAIN")
+        monkeypatch.setenv("KAFKA_CONSUMER_SASL_USERNAME", "user1")
+        cfg = load()
+        overrides = dict(cfg.kafka_config_overrides)
+        assert overrides["security.protocol"] == "SASL_SSL"
+        assert overrides["sasl.mechanism"] == "PLAIN"
+        assert overrides["sasl.username"] == "user1"
+
+    def test_kafka_consumer_overrides_default_empty(self):
+        cfg = load()
+        assert cfg.kafka_config_overrides == ()

--- a/tests/unit/test_ducklake.py
+++ b/tests/unit/test_ducklake.py
@@ -1,6 +1,6 @@
 import pytest
 
-from millpond.ducklake import _escape_libpq, _sanitize_setting_value, _validate_partition_expr
+from millpond.ducklake import _escape_libpq, _sanitize_setting_value, _tables_ensured, _validate_partition_expr, reset_table_cache
 
 
 class TestSanitizeSettingValue:
@@ -76,3 +76,11 @@ class TestEscapeLibpq:
 
     def test_none(self):
         assert _escape_libpq(None) == "''"
+
+
+class TestResetTableCache:
+    def test_reset_clears_ensured_tables(self):
+        _tables_ensured.add("test_table")
+        assert "test_table" in _tables_ensured
+        reset_table_cache()
+        assert len(_tables_ensured) == 0


### PR DESCRIPTION
## Summary

- Add Kafka SASL/SSL config passthrough via `KAFKA_CONSUMER_*` env vars
- Add `reset_table_cache()` for connection recycling safety
- Document crash-restart design (no reconnection logic needed)
- Clarify `_ensure_table` cache ordering (cache after both CREATE and ALTER)
- Fix AGENT.md type documentation (int64/float64, not DOUBLE)
- Set `max.poll.interval.ms` to 10 min for long S3 flushes
- Clarify `_version.py` purpose in release tarball
- Avoid redundant `_build_schema()` call when no mixed types found
- Add memory limits to docker-compose millpond containers
- Document `/readyz` endpoint, `assign()` monitoring caveat, `_on_stats` threading
- Fix justfile pytest invocation

## Test plan

- [x] 107 unit tests pass
- [x] 15 integration tests pass
- [x] 4 E2E tests pass
- [x] `just ci` (format, lint, unit) passes