### PR TITLE
Add workflow_dispatch to Pages workflow

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths: [tools/**]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Fixes broken GitHub Pages deployment by adding `workflow_dispatch` trigger
- The original deploy failed due to a bad SHA pin that was fixed in #9, but the workflow hasn't re-run since

## Test plan

- [x] Merge, then manually trigger the workflow