### PR TITLE
Add flush trigger label (size/time) to batches_flushed_total

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -197,7 +197,7 @@ Prometheus via `prometheus_client`, HTTP on port 8000.
 |--------|------|-------------|
 | `millpond_records_consumed_total` | Counter | Records polled (by partition) |
 | `millpond_records_written_total` | Counter | Records written to DuckLake |
-| `millpond_batches_flushed_total` | Counter | Flush cycles completed |
+| `millpond_batches_flushed_total` | Counter | Flush cycles completed (by trigger: `size` or `time`) |
 | `millpond_records_skipped_total` | Counter | Records skipped (by reason: json_parse, schema) |
 | `millpond_errors_total` | Counter | Errors by type (kafka/duckdb/arrow/json) |
 | `millpond_arrow_conversion_seconds` | Histogram | Time to convert JSON to Arrow table |

--- a/grafana/dashboards/millpond.json
+++ b/grafana/dashboards/millpond.json
@@ -110,7 +110,7 @@
       ]
     },
     {
-      "title": "Flushes/s",
+      "title": "Flushes/s by Trigger",
       "type": "stat",
       "gridPos": {
         "h": 4,
@@ -145,8 +145,8 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(millpond_batches_flushed_total[1m]))",
-          "legendFormat": "flushes/s"
+          "expr": "sum(rate(millpond_batches_flushed_total[1m])) by (trigger)",
+          "legendFormat": "{{trigger}}"
         }
       ]
     },

--- a/millpond/main.py
+++ b/millpond/main.py
@@ -196,7 +196,18 @@ def main():
             if should_flush:
                 trigger = "size" if size_triggered else "time"
                 consolidated = pa.concat_tables(pending, promote_options="default")
-                _flush(db, cfg, kafka, consolidated, pending_bytes, pending_records, offsets, elapsed, schema_mgr, trigger)
+                _flush(
+                    db,
+                    cfg,
+                    kafka,
+                    consolidated,
+                    pending_bytes,
+                    pending_records,
+                    offsets,
+                    elapsed,
+                    schema_mgr,
+                    trigger,
+                )
 
                 # Sample lag metrics periodically, not on every flush
                 now = time.monotonic()

--- a/millpond/main.py
+++ b/millpond/main.py
@@ -52,7 +52,7 @@ def _write_with_retry(db, table_name, consolidated, schema_mgr, partition_by=Non
             time.sleep(delay)
 
 
-def _flush(db, cfg, kafka, consolidated, pending_bytes, pending_records, offsets, elapsed, schema_mgr):
+def _flush(db, cfg, kafka, consolidated, pending_bytes, pending_records, offsets, elapsed, schema_mgr, trigger="time"):
     """Write to DuckLake, commit offsets, update metrics."""
     t0 = time.monotonic()
     _write_with_retry(db, cfg.ducklake_table, consolidated, schema_mgr, cfg.partition_by)
@@ -99,7 +99,7 @@ def _flush(db, cfg, kafka, consolidated, pending_bytes, pending_records, offsets
     metrics.flush_size_bytes.observe(pending_bytes)
     metrics.flush_size_records.observe(pending_records)
     metrics.records_written_total.inc(pending_records)
-    metrics.batches_flushed_total.inc()
+    metrics.batches_flushed_total.labels(trigger=trigger).inc()
     server.health.record_flush()
 
     # Always update committed offset metrics (cheap, local)
@@ -189,11 +189,14 @@ def main():
 
             # Check flush triggers
             elapsed = time.monotonic() - last_flush
-            should_flush = pending_records > 0 and (pending_bytes >= cfg.flush_size or elapsed >= cfg.flush_interval_s)
+            size_triggered = pending_bytes >= cfg.flush_size
+            time_triggered = elapsed >= cfg.flush_interval_s
+            should_flush = pending_records > 0 and (size_triggered or time_triggered)
 
             if should_flush:
+                trigger = "size" if size_triggered else "time"
                 consolidated = pa.concat_tables(pending, promote_options="default")
-                _flush(db, cfg, kafka, consolidated, pending_bytes, pending_records, offsets, elapsed, schema_mgr)
+                _flush(db, cfg, kafka, consolidated, pending_bytes, pending_records, offsets, elapsed, schema_mgr, trigger)
 
                 # Sample lag metrics periodically, not on every flush
                 now = time.monotonic()

--- a/millpond/metrics.py
+++ b/millpond/metrics.py
@@ -27,7 +27,7 @@ _records_written_total = Counter(
 _batches_flushed_total = Counter(
     "millpond_batches_flushed_total",
     "Flush cycles completed",
-    ["pipeline"],
+    ["pipeline", "trigger"],
 )
 _records_skipped_total = Counter(
     "millpond_records_skipped_total",
@@ -153,6 +153,7 @@ def init(pipeline: str):
 
     # Metrics with additional labels — wrap so .labels() auto-injects pipeline
     records_consumed_total = _AutoPipelineLabels(_records_consumed_total, pipeline)
+    batches_flushed_total = _AutoPipelineLabels(_batches_flushed_total, pipeline)
     records_skipped_total = _AutoPipelineLabels(_records_skipped_total, pipeline)
     errors_total = _AutoPipelineLabels(_errors_total, pipeline)
     consumer_lag = _AutoPipelineLabels(_consumer_lag, pipeline)
@@ -162,7 +163,6 @@ def init(pipeline: str):
 
     # Metrics with no other labels — pre-label to get direct .inc()/.set()/.observe()
     records_written_total = _records_written_total.labels(pipeline=pipeline)
-    batches_flushed_total = _batches_flushed_total.labels(pipeline=pipeline)
     flush_duration_seconds = _flush_duration_seconds.labels(pipeline=pipeline)
     arrow_conversion_seconds = _arrow_conversion_seconds.labels(pipeline=pipeline)
     flush_size_bytes = _flush_size_bytes.labels(pipeline=pipeline)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -137,10 +137,11 @@ class TestFlushErrorDistinction:
     def test_successful_flush_records_write_metrics(self, mock_dl, mock_metrics, mock_server):
         db, cfg, kafka, table, offsets, schema_mgr = self._make_flush_args()
 
-        _flush(db, cfg, kafka, table, 100, 2, offsets, 1.0, schema_mgr)
+        _flush(db, cfg, kafka, table, 100, 2, offsets, 1.0, schema_mgr, trigger="size")
 
         mock_metrics.records_written_total.inc.assert_called_once_with(2)
-        mock_metrics.batches_flushed_total.inc.assert_called_once()
+        mock_metrics.batches_flushed_total.labels.assert_called_once_with(trigger="size")
+        mock_metrics.batches_flushed_total.labels.return_value.inc.assert_called_once()
 
 
 class TestArrowConversionTiming:


### PR DESCRIPTION
## Summary

- Adds `trigger` label (`size` or `time`) to `millpond_batches_flushed_total` counter
- Size-triggered = keeping up or catching up; time-triggered = idle/low volume
- Updates Grafana dashboard "Flushes/s" panel to show breakdown by trigger
- Updates AGENT.md metric documentation

## Test plan

- [x] 107 unit tests pass