### PR TITLE
Remove production S3 bucket name before going public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 .ruff_cache/
 .pytest_cache/
 .claude/settings.local.json
+session-*.md

--- a/k8s/statefulset.yaml
+++ b/k8s/statefulset.yaml
@@ -48,7 +48,7 @@ spec:
         - name: DUCKLAKE_TABLE
           value: "events"
         - name: DUCKLAKE_DATA_PATH
-          value: "s3://posthog-ducklake-prod-us/data"
+          value: "s3://your-bucket/data"
         - name: DUCKLAKE_METADATA_URL
           value: "postgresql://rds-host/ducklake"
         - name: FLUSH_SIZE

--- a/problemstatement.md
+++ b/problemstatement.md
@@ -198,7 +198,7 @@ spec:
         - name: DUCKLAKE_TABLE
           value: "events"
         - name: DUCKLAKE_DATA_PATH
-          value: "s3://posthog-ducklake-prod-us/data"
+          value: "s3://your-bucket/data"
         - name: DUCKLAKE_METADATA_URL
           value: "jdbc:postgresql://rds-host/ducklake"
         - name: FLUSH_SIZE


### PR DESCRIPTION
## Summary

- Replace `s3://posthog-ducklake-prod-us/data` with `s3://your-bucket/data` in k8s manifest and problem statement
- Add `session-*.md` to `.gitignore` (personal working notes)

## Test plan

- [x] CI passes (107 unit tests)
- [x] No other secrets found (full repo + git history scan)