### PR TITLE
Build multi-arch Docker images (amd64 + arm64)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,6 +79,9 @@ jobs:
 
     # Build and push Docker image before creating the release —
     # if the image fails, we don't end up with an orphaned release/tag.
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
@@ -94,6 +97,7 @@ jobs:
       with:
         context: .
         push: true
+        platforms: linux/amd64,linux/arm64
         build-args: |
           MILLPOND_VERSION=${{ steps.next_tag.outputs.version }}
         tags: |


### PR DESCRIPTION
## Summary
- Add QEMU setup step for cross-platform emulation
- Add `platforms: linux/amd64,linux/arm64` to Docker build-push action
- Required for deployment to arm64 Karpenter node pools

## Test plan
- [ ] Verify release workflow completes successfully
- [ ] Verify `docker manifest inspect ghcr.io/posthog/millpond:v0.0.6` shows both architectures