### PR TITLE
Pass RDS credentials as individual env vars

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,5 +1,17 @@
 # Millpond — Dead Simple Kafka to DuckLake
 
+## Pre-push Checklist
+
+Always run before pushing:
+
+```bash
+just lint       # ruff check
+just fmt-check  # ruff format --check
+just test       # unit tests
+```
+
+All three must pass. Do not push with lint or test failures.
+
 ## What This Is
 
 A standalone Python app that replaces Kafka Connect for writing Kafka topic data to DuckLake. Single thread, single loop, no framework.
@@ -114,7 +126,8 @@ At startup, `ducklake.py` must:
 conn = duckdb.connect(config.ducklake_connection)
 conn.execute("LOAD httpfs")       # must load before ducklake — race condition with S3 access
 conn.execute("LOAD ducklake")
-conn.execute(f"ATTACH 'ducklake:{config.ducklake_metadata_url}' AS lake (DATA_PATH '{config.ducklake_data_path}')")
+pg_connstr = f"host={config.rds_host} port={config.rds_port} dbname='{config.rds_database}' user='{config.rds_username}' password='{config.rds_password}'"
+conn.execute(f"ATTACH 'ducklake:postgres:{pg_connstr}' AS lake (DATA_PATH '{config.ducklake_data_path}')")
 ```
 
 Extensions are pre-installed in the Docker image at build time (no runtime network dependency). `httpfs` must be loaded before `ducklake` to avoid a race condition where ducklake tries to access S3 before httpfs is available.

--- a/AGENT.md
+++ b/AGENT.md
@@ -12,6 +12,8 @@ just test       # unit tests
 
 All three must pass. Do not push with lint or test failures.
 
+Prefer fixup commits over amending and force-pushing.
+
 ## What This Is
 
 A standalone Python app that replaces Kafka Connect for writing Kafka topic data to DuckLake. Single thread, single loop, no framework.

--- a/README.md
+++ b/README.md
@@ -82,8 +82,12 @@ All configuration via environment variables:
 | `REPLICA_COUNT` | yes | | Number of StatefulSet replicas (must match `spec.replicas`) |
 | `DUCKLAKE_TABLE` | yes | | Target DuckLake table name |
 | `DUCKLAKE_DATA_PATH` | yes | | S3 path for DuckLake data files |
-| `DUCKLAKE_METADATA_URL` | yes | | Postgres URL for DuckLake metadata (`postgresql://user:pass@host:5432/db`) |
 | `DUCKLAKE_CONNECTION` | yes | | DuckDB connection string |
+| `DUCKLAKE_RDS_HOST` | yes | | Postgres host for DuckLake metadata |
+| `DUCKLAKE_RDS_PORT` | no | `5432` | Postgres port |
+| `DUCKLAKE_RDS_DATABASE` | no | `ducklake` | Postgres database name |
+| `DUCKLAKE_RDS_USERNAME` | no | `ducklake` | Postgres username |
+| `DUCKLAKE_RDS_PASSWORD` | yes | | Postgres password |
 | `DUCKLAKE_PARTITION_BY` | no | | Hive-style partition expression (e.g. `year(_inserted_at),month(_inserted_at),day(_inserted_at),hour(_inserted_at)`). Applied via `ALTER TABLE SET PARTITIONED BY` on first write. |
 | `FLUSH_SIZE` | no | `104857600` | Flush after this many bytes of accumulated Arrow data (default 100MB) |
 | `FLUSH_INTERVAL_MS` | no | `60000` | Flush after this many ms |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -137,7 +137,11 @@ services:
       POD_NAME: millpond-test-0
       DUCKLAKE_TABLE: events
       DUCKLAKE_DATA_PATH: s3://ducklake/data
-      DUCKLAKE_METADATA_URL: postgresql://ducklake:ducklake@postgres:5432/ducklake
+      DUCKLAKE_RDS_HOST: postgres
+      DUCKLAKE_RDS_PORT: "5432"
+      DUCKLAKE_RDS_DATABASE: ducklake
+      DUCKLAKE_RDS_USERNAME: ducklake
+      DUCKLAKE_RDS_PASSWORD: ducklake
       DUCKLAKE_CONNECTION: ":memory:"
       FLUSH_SIZE: 5000
       FLUSH_INTERVAL_MS: 5000

--- a/k8s/statefulset.yaml
+++ b/k8s/statefulset.yaml
@@ -49,8 +49,10 @@ spec:
           value: "events"
         - name: DUCKLAKE_DATA_PATH
           value: "s3://your-bucket/data"
-        - name: DUCKLAKE_METADATA_URL
-          value: "postgresql://rds-host/ducklake"
+        - name: DUCKLAKE_RDS_HOST
+          value: "rds-host"
+        - name: DUCKLAKE_RDS_PASSWORD
+          value: "changeme"  # in production, use secretKeyRef
         - name: FLUSH_SIZE
           value: "104857600"  # 100MB
         - name: FLUSH_INTERVAL_MS

--- a/millpond/config.py
+++ b/millpond/config.py
@@ -25,8 +25,14 @@ class Config:
     # DuckLake
     ducklake_table: str
     ducklake_data_path: str
-    ducklake_metadata_url: str
     ducklake_connection: str
+
+    # RDS (DuckLake metadata store)
+    rds_host: str
+    rds_port: str
+    rds_database: str
+    rds_username: str
+    rds_password: str
 
     # Flush triggers
     flush_size: int  # bytes of accumulated Arrow data
@@ -104,8 +110,12 @@ def load() -> Config:
         ordinal=ordinal,
         ducklake_table=ducklake_table,
         ducklake_data_path=_require("DUCKLAKE_DATA_PATH"),
-        ducklake_metadata_url=_require("DUCKLAKE_METADATA_URL"),
         ducklake_connection=_require("DUCKLAKE_CONNECTION"),
+        rds_host=_require("DUCKLAKE_RDS_HOST"),
+        rds_port=os.environ.get("DUCKLAKE_RDS_PORT", "5432"),
+        rds_database=os.environ.get("DUCKLAKE_RDS_DATABASE", "ducklake"),
+        rds_username=os.environ.get("DUCKLAKE_RDS_USERNAME", "ducklake"),
+        rds_password=_require("DUCKLAKE_RDS_PASSWORD"),
         partition_by=partition_by,
         flush_size=int(os.environ.get("FLUSH_SIZE", "104857600")),
         flush_interval_ms=int(os.environ.get("FLUSH_INTERVAL_MS", "60000")),

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import re
-from urllib.parse import urlparse
 
 import duckdb
 import pyarrow as pa
@@ -55,15 +54,14 @@ def connect(cfg: Config) -> duckdb.DuckDBPyConnection:
     conn.execute("LOAD ducklake")
     conn.execute("LOAD postgres")
 
-    # Parse the PG URL into a libpq connection string for DuckLake.
+    # Build a libpq connection string for DuckLake.
     # The 'postgres:' prefix tells DuckLake to use the Postgres extension
     # for metadata storage rather than a local DuckDB file.
     # See: https://ducklake.select/docs/stable/duckdb/usage/connecting
-    parsed = urlparse(cfg.ducklake_metadata_url)
     pg_connstr = (
-        f"host={parsed.hostname} port={parsed.port or 5432} "
-        f"dbname={_escape_libpq(parsed.path.lstrip('/'))} user={_escape_libpq(parsed.username)} "
-        f"password={_escape_libpq(parsed.password)}"
+        f"host={cfg.rds_host} port={cfg.rds_port} "
+        f"dbname={_escape_libpq(cfg.rds_database)} user={_escape_libpq(cfg.rds_username)} "
+        f"password={_escape_libpq(cfg.rds_password)}"
     )
     # Double single quotes for DuckDB SQL string literal — the libpq layer
     # inside DuckLake sees the unescaped quotes after DuckDB parses the string.
@@ -74,7 +72,13 @@ def connect(cfg: Config) -> duckdb.DuckDBPyConnection:
         )
     """)
 
-    log.info("DuckLake connected: metadata=%s data=%s", cfg.ducklake_metadata_url, cfg.ducklake_data_path)
+    log.info(
+        "DuckLake connected: metadata=%s:%s/%s data=%s",
+        cfg.rds_host,
+        cfg.rds_port,
+        cfg.rds_database,
+        cfg.ducklake_data_path,
+    )
     return conn
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -34,7 +34,8 @@ class TestLoad:
         monkeypatch.setenv("POD_NAME", "millpond-events-2")
         monkeypatch.setenv("DUCKLAKE_TABLE", "events")
         monkeypatch.setenv("DUCKLAKE_DATA_PATH", "s3://bucket/data")
-        monkeypatch.setenv("DUCKLAKE_METADATA_URL", "postgresql://user:pass@host:5432/db")
+        monkeypatch.setenv("DUCKLAKE_RDS_HOST", "host")
+        monkeypatch.setenv("DUCKLAKE_RDS_PASSWORD", "pass")
         monkeypatch.setenv("DUCKLAKE_CONNECTION", ":memory:")
 
     def test_loads(self):


### PR DESCRIPTION
## Summary
- Replaces `DUCKLAKE_METADATA_URL` (a `postgresql://` connection URL) with individual env vars: `DUCKLAKE_RDS_HOST`, `DUCKLAKE_RDS_PORT`, `DUCKLAKE_RDS_DATABASE`, `DUCKLAKE_RDS_USERNAME`, `DUCKLAKE_RDS_PASSWORD`
- Builds the libpq connection string directly in `ducklake.py` from individual components, removing `urlparse`
- Avoids URL parsing issues when the RDS password contains URL-reserved characters (`@`, `/`, `#`, `?`, `%`)

## Test plan
- [x] Unit tests pass (107/107)
- [x] Verify docker-compose stack starts with new env vars
- [ ] Corresponding charts change needed before deploying (statefulset.yaml updated in charts repo)