### PR TITLE
Add DuckLake maintenance tooling to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,16 @@ ARG MILLPOND_VERSION=0.0.0.dev0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$MILLPOND_VERSION
 RUN uv sync --frozen --no-dev
 
+# Install DuckDB CLI (pinned to match the Python package version)
+RUN uv tool install "duckdb-cli>=1.4,<1.5"
+
 FROM python:3.12-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends just && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/.venv /app/.venv
 COPY --from=builder /app/millpond /app/millpond
+COPY --from=builder /root/.local/bin/duckdb /usr/local/bin/duckdb
 COPY tools/justfile /justfile
 
 ENV PATH="/app/.venv/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,11 @@ RUN uv sync --frozen --no-dev
 
 FROM python:3.12-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends just && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /app/.venv /app/.venv
 COPY --from=builder /app/millpond /app/millpond
+COPY tools/justfile /justfile
 
 ENV PATH="/app/.venv/bin:$PATH"
 

--- a/tools/justfile
+++ b/tools/justfile
@@ -1,0 +1,69 @@
+# DuckLake maintenance tasks
+# Requires: DUCKLAKE_RDS_PASSWORD, DUCKDB_S3_ACCESS_KEY_ID, DUCKDB_S3_SECRET_ACCESS_KEY
+
+duckdb := env("DUCKDB", "duckdb")
+
+rds_host := env("DUCKLAKE_RDS_HOST", "")
+rds_port := env("DUCKLAKE_RDS_PORT", "5432")
+rds_db := env("DUCKLAKE_RDS_DATABASE", "ducklake")
+rds_user := env("DUCKLAKE_RDS_USERNAME", "ducklake")
+rds_password := env("DUCKLAKE_RDS_PASSWORD", "")
+s3_region := env("DUCKDB_S3_REGION", "us-east-1")
+s3_key := env("DUCKDB_S3_ACCESS_KEY_ID", "")
+s3_secret := env("DUCKDB_S3_SECRET_ACCESS_KEY", "")
+data_path := env("DUCKLAKE_DATA_PATH", "")
+
+_setup := "LOAD httpfs; LOAD ducklake; LOAD postgres; SET s3_region = '" + s3_region + "'; SET s3_endpoint = 's3." + s3_region + ".amazonaws.com'; SET s3_access_key_id = '" + s3_key + "'; SET s3_secret_access_key = '" + s3_secret + "'; SET s3_use_ssl = true; SET s3_url_style = 'vhost'; ATTACH 'postgres:host=" + rds_host + " port=" + rds_port + " dbname=" + rds_db + " user=" + rds_user + " password=" + rds_password + "' AS lake (TYPE ducklake, DATA_PATH '" + data_path + "'); USE lake;"
+
+default:
+    @just --list
+
+# Open an interactive DuckDB shell connected to the DuckLake
+shell:
+    {{ duckdb }} -cmd "{{ _setup }}"
+
+# Drop a table
+drop table:
+    {{ duckdb }} -c "{{ _setup }} DROP TABLE lake.{{ table }};"
+
+# Expire snapshots (dry run)
+expire-dry-run days="7":
+    {{ duckdb }} -c "{{ _setup }} CALL ducklake_expire_snapshots('lake', older_than => now() - INTERVAL '{{ days }} days', dry_run => true);"
+
+# Expire snapshots
+expire days="7":
+    {{ duckdb }} -c "{{ _setup }} CALL ducklake_expire_snapshots('lake', older_than => now() - INTERVAL '{{ days }} days');"
+
+# Preview files scheduled for deletion
+cleanup-dry-run days="1":
+    {{ duckdb }} -c "{{ _setup }} CALL ducklake_cleanup_old_files('lake', older_than => now() - INTERVAL '{{ days }} days', dry_run => true);"
+
+# Delete files scheduled for deletion
+cleanup days="1":
+    {{ duckdb }} -c "{{ _setup }} CALL ducklake_cleanup_old_files('lake', older_than => now() - INTERVAL '{{ days }} days');"
+
+# Delete all files scheduled for deletion regardless of age
+cleanup-all:
+    {{ duckdb }} -c "{{ _setup }} CALL ducklake_cleanup_old_files('lake', cleanup_all => true);"
+
+# Preview orphaned files
+orphans-dry-run:
+    {{ duckdb }} -c "{{ _setup }} CALL ducklake_delete_orphaned_files('lake', dry_run => true);"
+
+# Delete orphaned files
+orphans:
+    {{ duckdb }} -c "{{ _setup }} CALL ducklake_delete_orphaned_files('lake');"
+
+# Full maintenance: expire snapshots + cleanup files
+maintain days="7":
+    just expire {{ days }}
+    just cleanup {{ days }}
+
+# Full maintenance dry run
+maintain-dry-run days="7":
+    just expire-dry-run {{ days }}
+    just cleanup-dry-run {{ days }}
+
+# Run CHECKPOINT (integrated merge + expire + cleanup)
+checkpoint:
+    {{ duckdb }} -c "{{ _setup }} CHECKPOINT lake;"


### PR DESCRIPTION
## Summary
- Installs `just` in the Docker image
- Adds `tools/justfile` with DuckLake maintenance recipes (copied to `/justfile` in the image)
- Recipes: expire snapshots, cleanup files, delete orphans, compaction, interactive shell
- All recipes configurable via env vars (`DUCKLAKE_RDS_HOST`, `DUCKDB_S3_*`, etc.)

## Usage from inside a pod
```bash
just --list              # see available recipes
just maintain-dry-run 3  # preview: expire >3 day snapshots + cleanup
just maintain 3          # execute it
just shell               # interactive DuckDB shell
```

## Test plan
- [x] Unit tests pass (107/107)
- [x] Docker image builds successfully
- [x] `just --list` works inside the container
- [x] docker-compose integration stack runs with new image