### PR TITLE
Fix AdminClient SSL config, add client.id, SSL testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .pytest_cache/
 .claude/settings.local.json
 session-*.md
+test/ssl/

--- a/docker-compose.ssl.yaml
+++ b/docker-compose.ssl.yaml
@@ -1,0 +1,45 @@
+# Overlay: docker-compose -f docker-compose.yaml -f docker-compose.ssl.yaml up
+# Requires: ./test/generate-ssl-certs.sh run first
+services:
+  kafka:
+    volumes:
+      - ./test/kafka-server-ssl.properties:/opt/kafka/config/kraft/server.properties:ro
+      - ./test/ssl:/opt/kafka/config/ssl:ro
+    healthcheck:
+      test: /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server kafka:9094 --command-config /opt/kafka/config/ssl/client.properties
+      interval: 5s
+      timeout: 10s
+      retries: 10
+
+  kafka-init:
+    volumes:
+      - ./test/ssl:/opt/kafka/config/ssl:ro
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9094 --command-config /opt/kafka/config/ssl/client.properties --create --if-not-exists --topic test-events --partitions 8 --replication-factor 1 &&
+        echo "Waiting for consumer group coordinator..." &&
+        sleep 2 &&
+        echo "Topic ready."
+
+  millpond-0:
+    environment:
+      KAFKA_CONSUMER_SECURITY_PROTOCOL: SSL
+      KAFKA_CONSUMER_SSL_CA_LOCATION: /opt/kafka/config/ssl/ca-cert.pem
+    volumes:
+      - ./test/ssl:/opt/kafka/config/ssl:ro
+
+  millpond-1:
+    environment:
+      KAFKA_CONSUMER_SECURITY_PROTOCOL: SSL
+      KAFKA_CONSUMER_SSL_CA_LOCATION: /opt/kafka/config/ssl/ca-cert.pem
+    volumes:
+      - ./test/ssl:/opt/kafka/config/ssl:ro
+
+  producer:
+    environment:
+      KAFKA_PRODUCER_SECURITY_PROTOCOL: SSL
+      KAFKA_PRODUCER_SSL_CA_LOCATION: /opt/kafka/config/ssl/ca-cert.pem
+    volumes:
+      - ./test/ssl:/opt/kafka/config/ssl:ro

--- a/justfile
+++ b/justfile
@@ -59,16 +59,32 @@ ci: fmt-check lint test
 
 # === Docker ===
 
+# Generate SSL certs for local Kafka (one-time setup)
+[group('docker')]
+ssl-certs:
+    ./test/generate-ssl-certs.sh
+
 # Start the docker-compose dev environment (Kafka, Postgres, MinIO, producer, 2 millpond pods)
 [group('docker')]
 up:
     docker compose build
     docker compose up -d
 
+# Start the docker-compose dev environment with SSL Kafka
+[group('docker')]
+up-ssl: ssl-certs
+    docker compose -f docker-compose.yaml -f docker-compose.ssl.yaml build
+    docker compose -f docker-compose.yaml -f docker-compose.ssl.yaml up -d
+
 # Stop the docker-compose dev environment
 [group('docker')]
 down:
     docker compose down -v
+
+# Stop the SSL docker-compose dev environment
+[group('docker')]
+down-ssl:
+    docker compose -f docker-compose.yaml -f docker-compose.ssl.yaml down -v
 
 # Open a DuckDB shell attached to the local DuckLake (requires `just up` first)
 [group('docker')]

--- a/millpond/consumer.py
+++ b/millpond/consumer.py
@@ -10,6 +10,17 @@ from millpond.config import Config
 log = logging.getLogger(__name__)
 
 
+def _base_kafka_config(cfg: Config) -> dict:
+    """Base config shared by all Kafka clients (AdminClient, Consumer)."""
+    base = {
+        "bootstrap.servers": cfg.bootstrap_servers,
+        "client.id": f"millpond-{cfg.topic}-{cfg.ducklake_table}-{cfg.ordinal}",
+    }
+    for key, val in cfg.kafka_config_overrides:
+        base[key] = val
+    return base
+
+
 def _on_stats(stats_json: str) -> None:
     """Parse librdkafka stats JSON and update Prometheus gauges.
 
@@ -39,7 +50,7 @@ def _on_stats(stats_json: str) -> None:
 
 def discover_partition_count(cfg: Config) -> int:
     """Discover partition count for the topic via broker metadata."""
-    admin = AdminClient({"bootstrap.servers": cfg.bootstrap_servers})
+    admin = AdminClient(_base_kafka_config(cfg))
     metadata = admin.list_topics(topic=cfg.topic, timeout=30)
     topic_meta = metadata.topics.get(cfg.topic)
     if topic_meta is None:
@@ -70,7 +81,7 @@ def create(cfg: Config) -> Consumer:
     log.info("Assigned partitions: %s", my_partitions)
 
     consumer_config = {
-        "bootstrap.servers": cfg.bootstrap_servers,
+        **_base_kafka_config(cfg),
         "group.id": cfg.group_id,
         "auto.offset.reset": "earliest",
         "enable.auto.commit": False,
@@ -81,9 +92,6 @@ def create(cfg: Config) -> Consumer:
         "statistics.interval.ms": cfg.stats_interval_ms,
         "stats_cb": _on_stats,
     }
-    # Merge KAFKA_CONSUMER_* overrides (e.g. security.protocol, sasl.mechanism)
-    for key, val in cfg.kafka_config_overrides:
-        consumer_config[key] = val
 
     consumer = Consumer(consumer_config)
 

--- a/test/generate-ssl-certs.sh
+++ b/test/generate-ssl-certs.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Generate self-signed CA + broker certs for local SSL Kafka testing.
+# Uses only openssl (no keytool). Output: test/ssl/
+set -euo pipefail
+
+SSL_DIR="$(dirname "$0")/ssl"
+rm -rf "$SSL_DIR"
+mkdir -p "$SSL_DIR"
+cd "$SSL_DIR"
+
+PASSWORD="testpassword"
+
+# CA key + cert
+openssl req -new -x509 -keyout ca-key.pem -out ca-cert.pem -days 365 \
+    -subj "/CN=MillpondTestCA" -passout "pass:$PASSWORD" -nodes 2>/dev/null
+
+# Broker key + CSR
+openssl req -newkey rsa:2048 -keyout kafka-key.pem -out kafka.csr \
+    -subj "/CN=kafka" -nodes 2>/dev/null
+
+# Sign broker cert with CA (with SAN)
+openssl x509 -req -CA ca-cert.pem -CAkey ca-key.pem -in kafka.csr \
+    -out kafka-cert.pem -days 365 -CAcreateserial \
+    -extfile <(echo "subjectAltName=DNS:kafka") 2>/dev/null
+
+# Create PKCS12 keystore for Kafka broker (combines key + cert + CA)
+openssl pkcs12 -export -in kafka-cert.pem -inkey kafka-key.pem \
+    -chain -CAfile ca-cert.pem -name kafka \
+    -out kafka.keystore.p12 -password "pass:$PASSWORD" 2>/dev/null
+
+# Create PKCS12 truststore with CA cert via keytool (from Kafka image)
+docker run --rm -v "$PWD:/ssl" -w /ssl --entrypoint keytool apache/kafka:3.9.0 \
+    -importcert -alias ca -file ca-cert.pem -keystore kafka.truststore.p12 \
+    -storetype PKCS12 -storepass "$PASSWORD" -noprompt 2>/dev/null
+
+# Kafka CLI client properties (for kafka-topics.sh etc.)
+cat > client.properties <<EOF
+security.protocol=SSL
+ssl.truststore.location=/opt/kafka/config/ssl/kafka.truststore.p12
+ssl.truststore.password=$PASSWORD
+ssl.truststore.type=PKCS12
+EOF
+
+echo "SSL certs generated in $SSL_DIR"

--- a/test/kafka-server-ssl.properties
+++ b/test/kafka-server-ssl.properties
@@ -1,0 +1,20 @@
+node.id=1
+process.roles=broker,controller
+controller.quorum.voters=1@kafka:9093
+listeners=SSL://kafka:9094,CONTROLLER://kafka:9093
+advertised.listeners=SSL://kafka:9094
+listener.security.protocol.map=SSL:SSL,CONTROLLER:PLAINTEXT
+controller.listener.names=CONTROLLER
+inter.broker.listener.name=SSL
+offsets.topic.replication.factor=1
+log.dirs=/tmp/kraft-combined-logs
+
+# SSL
+ssl.keystore.location=/opt/kafka/config/ssl/kafka.keystore.p12
+ssl.keystore.password=testpassword
+ssl.keystore.type=PKCS12
+ssl.key.password=testpassword
+ssl.truststore.location=/opt/kafka/config/ssl/kafka.truststore.p12
+ssl.truststore.password=testpassword
+ssl.truststore.type=PKCS12
+ssl.client.auth=none

--- a/test/producer.py
+++ b/test/producer.py
@@ -731,13 +731,19 @@ def make_event(i: int) -> dict:
 def main():
     from confluent_kafka import Producer
 
-    producer = Producer({
+    producer_config = {
         "bootstrap.servers": BOOTSTRAP_SERVERS,
         "linger.ms": 50,
         "batch.num.messages": 10000,
         "queue.buffering.max.messages": 100000,
         "compression.type": "lz4",
-    })
+    }
+    # Merge KAFKA_PRODUCER_* env vars (e.g. KAFKA_PRODUCER_SECURITY_PROTOCOL=SSL)
+    prefix = "KAFKA_PRODUCER_"
+    for k, v in os.environ.items():
+        if k.startswith(prefix):
+            producer_config[k[len(prefix):].lower().replace("_", ".")] = v
+    producer = Producer(producer_config)
 
     infinite = TOTAL_RECORDS == -1
     if infinite:

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -1,7 +1,10 @@
 import json
 from unittest.mock import MagicMock, patch
 
-from millpond.consumer import _on_stats, compute_assignment
+import pytest
+
+from millpond.consumer import _base_kafka_config, _on_stats, compute_assignment, create, discover_partition_count
+from millpond.config import Config
 
 
 class TestComputeAssignment:
@@ -115,3 +118,145 @@ class TestOnStats:
         _on_stats("not json")
         # Should not raise, gauges should not be called
         mock_metrics.rdkafka_replyq.set.assert_not_called()
+
+
+def _make_cfg(**overrides) -> Config:
+    defaults = dict(
+        bootstrap_servers="localhost:9092",
+        topic="test-topic",
+        group_id="test-group",
+        replica_count=4,
+        ordinal=1,
+        ducklake_table="events",
+        ducklake_data_path="s3://bucket/data",
+        ducklake_connection=":memory:",
+        rds_host="localhost",
+        rds_port="5432",
+        rds_database="ducklake",
+        rds_username="ducklake",
+        rds_password="pass",
+        flush_size=100,
+        flush_interval_ms=1000,
+        partition_by=None,
+        fetch_min_bytes=1,
+        fetch_max_wait_ms=500,
+        consume_batch_size=1000,
+        stats_interval_ms=5000,
+        kafka_config_overrides=(("security.protocol", "SSL"),),
+    )
+    defaults.update(overrides)
+    return Config(**defaults)
+
+
+class TestBaseKafkaConfig:
+    def test_includes_bootstrap_servers(self):
+        cfg = _make_cfg()
+        base = _base_kafka_config(cfg)
+        assert base["bootstrap.servers"] == "localhost:9092"
+
+    def test_includes_client_id(self):
+        cfg = _make_cfg(ordinal=3)
+        base = _base_kafka_config(cfg)
+        assert base["client.id"] == "millpond-test-topic-events-3"
+
+    def test_includes_overrides(self):
+        cfg = _make_cfg(kafka_config_overrides=(("security.protocol", "SSL"), ("sasl.mechanism", "PLAIN")))
+        base = _base_kafka_config(cfg)
+        assert base["security.protocol"] == "SSL"
+        assert base["sasl.mechanism"] == "PLAIN"
+
+    def test_empty_overrides(self):
+        cfg = _make_cfg(kafka_config_overrides=())
+        base = _base_kafka_config(cfg)
+        assert "security.protocol" not in base
+
+
+class TestDiscoverPartitionCount:
+    @patch("millpond.consumer.AdminClient")
+    def test_returns_partition_count(self, mock_admin_cls):
+        mock_admin = MagicMock()
+        mock_admin_cls.return_value = mock_admin
+        mock_topic = MagicMock()
+        mock_topic.error = None
+        mock_topic.partitions = {0: None, 1: None, 2: None}
+        mock_admin.list_topics.return_value.topics = {"test-topic": mock_topic}
+
+        cfg = _make_cfg()
+        count = discover_partition_count(cfg)
+        assert count == 3
+
+    @patch("millpond.consumer.AdminClient")
+    def test_passes_overrides_to_admin_client(self, mock_admin_cls):
+        mock_admin = MagicMock()
+        mock_admin_cls.return_value = mock_admin
+        mock_topic = MagicMock()
+        mock_topic.error = None
+        mock_topic.partitions = {0: None}
+        mock_admin.list_topics.return_value.topics = {"test-topic": mock_topic}
+
+        cfg = _make_cfg(kafka_config_overrides=(("security.protocol", "SSL"),))
+        discover_partition_count(cfg)
+
+        admin_config = mock_admin_cls.call_args[0][0]
+        assert admin_config["security.protocol"] == "SSL"
+        assert admin_config["bootstrap.servers"] == "localhost:9092"
+
+    @patch("millpond.consumer.AdminClient")
+    def test_topic_not_found(self, mock_admin_cls):
+        mock_admin = MagicMock()
+        mock_admin_cls.return_value = mock_admin
+        mock_admin.list_topics.return_value.topics = {}
+
+        cfg = _make_cfg()
+        with pytest.raises(RuntimeError, match="not found"):
+            discover_partition_count(cfg)
+
+    @patch("millpond.consumer.AdminClient")
+    def test_topic_error(self, mock_admin_cls):
+        mock_admin = MagicMock()
+        mock_admin_cls.return_value = mock_admin
+        mock_topic = MagicMock()
+        mock_topic.error = "LEADER_NOT_AVAILABLE"
+        mock_admin.list_topics.return_value.topics = {"test-topic": mock_topic}
+
+        cfg = _make_cfg()
+        with pytest.raises(RuntimeError, match="error"):
+            discover_partition_count(cfg)
+
+
+class TestCreate:
+    @patch("millpond.consumer.Consumer")
+    @patch("millpond.consumer.discover_partition_count", return_value=8)
+    def test_assigns_correct_partitions(self, mock_discover, mock_consumer_cls):
+        cfg = _make_cfg(ordinal=1, replica_count=4)
+        create(cfg)
+
+        assign_call = mock_consumer_cls.return_value.assign
+        assign_call.assert_called_once()
+        partitions = assign_call.call_args[0][0]
+        assert [tp.partition for tp in partitions] == [1, 5]
+
+    @patch("millpond.consumer.Consumer")
+    @patch("millpond.consumer.discover_partition_count", return_value=8)
+    def test_passes_overrides_to_consumer(self, mock_discover, mock_consumer_cls):
+        cfg = _make_cfg(kafka_config_overrides=(("security.protocol", "SSL"),))
+        create(cfg)
+
+        consumer_config = mock_consumer_cls.call_args[0][0]
+        assert consumer_config["security.protocol"] == "SSL"
+
+    @patch("millpond.consumer.Consumer")
+    @patch("millpond.consumer.discover_partition_count", return_value=8)
+    def test_sets_client_id(self, mock_discover, mock_consumer_cls):
+        cfg = _make_cfg(ordinal=2, replica_count=4)
+        create(cfg)
+
+        consumer_config = mock_consumer_cls.call_args[0][0]
+        assert consumer_config["client.id"] == "millpond-test-topic-events-2"
+
+    @patch("millpond.consumer.Consumer")
+    @patch("millpond.consumer.discover_partition_count", return_value=2)
+    def test_no_partitions_raises(self, mock_discover, mock_consumer_cls):
+        cfg = _make_cfg(ordinal=3, replica_count=4)
+        with pytest.raises(RuntimeError, match="No partitions assigned"):
+            create(cfg)


### PR DESCRIPTION
## Summary
- **Bug fix**: `discover_partition_count()` created AdminClient without SSL config, causing connection failure on MSK. Extracted `_base_kafka_config()` shared by AdminClient and Consumer to prevent this class of bug.
- **Improvement**: Added `client.id=millpond-{topic}-{table}-{ordinal}` for MSK CloudWatch log correlation
- **Testing**: 12 new unit tests covering `discover_partition_count`, `create`, and config propagation
- **SSL docker-compose**: `docker-compose.ssl.yaml` overlay + cert generation script for local SSL Kafka testing (`just up-ssl`)

## Test plan
- [x] 119 unit tests pass
- [x] SSL docker-compose stack verified end-to-end (producer → SSL Kafka → millpond → DuckLake)
- [ ] Deploy to dev and verify MSK connection