### PR TITLE
Handle concurrent table creation, update docs

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -12,7 +12,19 @@ just test       # unit tests
 
 All three must pass. Do not push with lint or test failures.
 
+For changes to Kafka client code or config handling, also verify with SSL Kafka:
+
+```bash
+just up-ssl     # start docker-compose with SSL Kafka
+# verify pods connect and flush
+just down-ssl
+```
+
 Prefer fixup commits over amending and force-pushing.
+
+## Maintenance Tooling
+
+`tools/justfile` contains DuckLake maintenance recipes (expire snapshots, cleanup files, delete orphans, compaction). It is copied to `/justfile` in the Docker image and uses the pod's existing env vars. The `DUCKDB` env var can override the duckdb binary path.
 
 ## What This Is
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,32 @@ just test              # run unit tests
 just test-integration  # run integration tests (local DuckDB)
 just test-e2e          # run E2E tests (docker-compose, builds stack automatically)
 just ci                # format check + lint + unit tests
+just up                # start docker-compose stack (plaintext Kafka)
+just up-ssl            # start docker-compose stack with SSL Kafka (closer to prod)
+just down              # stop docker-compose stack
+just down-ssl          # stop SSL docker-compose stack
 ```
+
+### SSL Kafka Testing
+
+The `just up-ssl` recipe generates self-signed certs and runs Kafka with SSL listeners, matching the production MSK configuration. This exercises the `KAFKA_CONSUMER_*` env var override path that isn't tested with plaintext Kafka.
+
+Requires Docker (uses `keytool` from the Kafka container image for cert generation).
+
+### DuckLake Maintenance
+
+`tools/justfile` contains DuckLake maintenance recipes and is baked into the Docker image at `/justfile`. From inside a running pod:
+
+```bash
+just --list              # see available recipes
+just maintain-dry-run 3  # preview: expire >3 day snapshots + cleanup
+just maintain 3          # execute it
+just shell               # interactive DuckDB shell connected to DuckLake
+just drop events         # drop a table (data files remain until cleanup)
+just orphans-dry-run     # preview orphaned S3 files
+```
+
+All recipes use the pod's existing env vars (`DUCKLAKE_RDS_*`, `DUCKDB_S3_*`, `DUCKLAKE_DATA_PATH`).
 
 ## Configuration
 

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -100,28 +100,63 @@ def reset_table_cache() -> None:
     _tables_ensured.clear()
 
 
+def _table_exists(conn: duckdb.DuckDBPyConnection, table_name: str) -> bool:
+    """Check if a table exists in the DuckLake catalog."""
+    result = conn.execute(
+        "SELECT 1 FROM information_schema.tables "
+        "WHERE table_catalog = 'lake' AND table_schema = 'main' AND table_name = ?",
+        [table_name],
+    ).fetchone()
+    return result is not None
+
+
 def _ensure_table(
     conn: duckdb.DuckDBPyConnection,
     table_name: str,
     batch: pa.Table,
     partition_by: str | None = None,
 ) -> None:
-    """Create the DuckLake table from Arrow schema if it doesn't exist. Cached after first call."""
+    """Create the DuckLake table if it doesn't exist. Cached after first call.
+
+    Handles concurrent creation by multiple pods: if CREATE or ALTER fails
+    with a serialization/catalog error, we check if the table now exists
+    and treat that as success.
+    """
     if table_name in _tables_ensured:
         return
+
+    if _table_exists(conn, table_name):
+        log.info("Table %s already exists", table_name)
+        _tables_ensured.add(table_name)
+        return
+
     conn.register("_schema_batch", batch.slice(0, 0))  # empty batch, just schema
     try:
         conn.execute(
             f"CREATE TABLE IF NOT EXISTS lake.main.{table_name} AS "
             "SELECT *, NOW() AS _inserted_at FROM _schema_batch WHERE false"
         )
+    except duckdb.Error as e:
+        # Another pod may have created the table concurrently
+        if _table_exists(conn, table_name):
+            log.info("Table %s created by another pod, continuing", table_name)
+        else:
+            raise RuntimeError(f"Failed to create table {table_name}: {e}") from e
     finally:
         conn.unregister("_schema_batch")
+
     if partition_by is not None:
         _validate_partition_expr(partition_by)
-        conn.execute(f"ALTER TABLE lake.main.{table_name} SET PARTITIONED BY ({partition_by})")
-        log.info("Table %s partitioned by: %s", table_name, partition_by)
-    # Cache AFTER both CREATE and ALTER succeed — if either fails, retry on next write.
+        try:
+            conn.execute(f"ALTER TABLE lake.main.{table_name} SET PARTITIONED BY ({partition_by})")
+            log.info("Table %s partitioned by: %s", table_name, partition_by)
+        except duckdb.Error as e:
+            # Another pod may have already set partitioning — verify table exists and continue
+            if _table_exists(conn, table_name):
+                log.info("Table %s partition may have been set by another pod, continuing: %s", table_name, e)
+            else:
+                raise RuntimeError(f"Failed to partition table {table_name}: {e}") from e
+
     _tables_ensured.add(table_name)
 
 

--- a/millpond/main.py
+++ b/millpond/main.py
@@ -45,8 +45,9 @@ def _write_with_retry(db, table_name, consolidated, schema_mgr, partition_by=Non
                 delay,
                 exc_info=True,
             )
-            # Invalidate cached schema so retry re-runs evolve() — another pod
-            # may have changed the table schema since our last attempt.
+            # Invalidate caches so retry re-checks table existence and schema —
+            # another pod may have created the table or changed columns.
+            ducklake.reset_table_cache()
             if schema_mgr is not None:
                 schema_mgr.invalidate()
             time.sleep(delay)

--- a/tests/unit/test_ducklake.py
+++ b/tests/unit/test_ducklake.py
@@ -1,6 +1,18 @@
+from unittest.mock import MagicMock, patch
+
+import duckdb
+import pyarrow as pa
 import pytest
 
-from millpond.ducklake import _escape_libpq, _sanitize_setting_value, _tables_ensured, _validate_partition_expr, reset_table_cache
+from millpond.ducklake import (
+    _ensure_table,
+    _escape_libpq,
+    _sanitize_setting_value,
+    _table_exists,
+    _tables_ensured,
+    _validate_partition_expr,
+    reset_table_cache,
+)
 
 
 class TestSanitizeSettingValue:
@@ -84,3 +96,102 @@ class TestResetTableCache:
         assert "test_table" in _tables_ensured
         reset_table_cache()
         assert len(_tables_ensured) == 0
+
+
+@pytest.fixture(autouse=True)
+def _clear_table_cache():
+    """Ensure table cache is clean before and after each test."""
+    reset_table_cache()
+    yield
+    reset_table_cache()
+
+
+def _sample_batch() -> pa.Table:
+    return pa.table({"col_a": [1], "col_b": ["x"]})
+
+
+class TestTableExists:
+    def test_returns_true_when_table_found(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (1,)
+        assert _table_exists(conn, "events") is True
+
+    def test_returns_false_when_no_table(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+        assert _table_exists(conn, "events") is False
+
+
+class TestEnsureTable:
+    def test_skips_if_cached(self):
+        conn = MagicMock()
+        _tables_ensured.add("events")
+        _ensure_table(conn, "events", _sample_batch())
+        conn.execute.assert_not_called()
+
+    @patch("millpond.ducklake._table_exists", return_value=True)
+    def test_skips_create_if_table_exists(self, mock_exists):
+        conn = MagicMock()
+        _ensure_table(conn, "events", _sample_batch())
+        conn.execute.assert_not_called()
+        assert "events" in _tables_ensured
+
+    @patch("millpond.ducklake._table_exists", return_value=False)
+    def test_creates_table_and_caches(self, mock_exists):
+        conn = MagicMock()
+        _ensure_table(conn, "events", _sample_batch())
+        # Should have called register, execute (CREATE), unregister
+        assert conn.execute.call_count >= 1
+        create_sql = conn.execute.call_args_list[0][0][0]
+        assert "CREATE TABLE IF NOT EXISTS" in create_sql
+        assert "events" in _tables_ensured
+
+    @patch("millpond.ducklake._table_exists", return_value=False)
+    def test_creates_table_with_partitioning(self, mock_exists):
+        conn = MagicMock()
+        _ensure_table(conn, "events", _sample_batch(), partition_by="team_id,year(ts)")
+        # Find the ALTER PARTITIONED BY call
+        alter_calls = [
+            call for call in conn.execute.call_args_list if "PARTITIONED BY" in str(call)
+        ]
+        assert len(alter_calls) == 1
+        assert "team_id,year(ts)" in str(alter_calls[0])
+
+    @patch("millpond.ducklake._table_exists")
+    def test_concurrent_create_recovers(self, mock_exists):
+        """If CREATE fails but another pod created the table, continue."""
+        # First call: table doesn't exist. Second call (after error): table exists.
+        mock_exists.side_effect = [False, True]
+        conn = MagicMock()
+        conn.register = MagicMock()
+        conn.unregister = MagicMock()
+        conn.execute.side_effect = duckdb.Error("serialization conflict")
+        _ensure_table(conn, "events", _sample_batch())
+        assert "events" in _tables_ensured
+
+    @patch("millpond.ducklake._table_exists")
+    def test_create_fails_and_table_still_missing_raises(self, mock_exists):
+        """If CREATE fails and table doesn't exist, raise."""
+        mock_exists.return_value = False
+        conn = MagicMock()
+        conn.register = MagicMock()
+        conn.unregister = MagicMock()
+        conn.execute.side_effect = duckdb.Error("connection lost")
+        with pytest.raises(RuntimeError, match="Failed to create table"):
+            _ensure_table(conn, "events", _sample_batch())
+
+    @patch("millpond.ducklake._table_exists")
+    def test_concurrent_partition_alter_recovers(self, mock_exists):
+        """If ALTER PARTITIONED BY fails but table exists, continue."""
+        mock_exists.side_effect = [False, True]
+        conn = MagicMock()
+        conn.register = MagicMock()
+        conn.unregister = MagicMock()
+
+        def execute_side_effect(sql, *args):
+            if "PARTITIONED BY" in sql:
+                raise duckdb.Error("serialization conflict")
+
+        conn.execute.side_effect = execute_side_effect
+        _ensure_table(conn, "events", _sample_batch(), partition_by="team_id")
+        assert "events" in _tables_ensured


### PR DESCRIPTION
## Summary
- `_ensure_table()` now tolerates concurrent table creation from multiple pods — catches serialization/catalog errors and verifies table exists as fallback
- Write retry path calls `reset_table_cache()` so retries re-check table existence
- 9 new unit tests for `_ensure_table` and `_table_exists` (concurrent create, concurrent partition alter, failure when table genuinely missing)
- README: added SSL testing and DuckLake maintenance tooling sections
- AGENT.md: added SSL verification to pre-push checklist, documented maintenance tooling

## Test plan
- [x] 128 unit tests pass
- [ ] Deploy to dev with 2 pods starting simultaneously — verify no serialization crash