### PR TITLE
Add MSK IAM authentication via SASL/OAUTHBEARER

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -80,6 +80,17 @@ while not shutdown:
 
 ## Key Design Decisions
 
+### Credential Isolation
+
+Millpond has two independent credential paths that must not interfere:
+
+- **Kafka (MSK)**: SASL/OAUTHBEARER via IRSA. The `aws-msk-iam-sasl-signer-python` library uses the standard AWS credential chain (IRSA projected token → STS → temporary creds).
+- **S3 (DuckLake data)**: Static IAM credentials via `DUCKDB_S3_ACCESS_KEY_ID` / `DUCKDB_S3_SECRET_ACCESS_KEY`. DuckDB's aws extension does not support IRSA ([duckdb/duckdb-aws#31](https://github.com/duckdb/duckdb-aws/issues/31)).
+
+The S3 credentials use DuckDB-specific env var names, **not** the standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`. This is intentional — standard AWS env vars would shadow IRSA in the credential chain and break MSK IAM auth. Do not change the S3 credential env var names to standard AWS names.
+
+`aws-msk-iam-sasl-signer-python` is an optional dependency (`pip install millpond[msk-iam]`) but the Dockerfile always installs it (`--extra msk-iam`). All production deployments use IAM auth. The optional dep is for local dev where boto3/botocore (~15MB) may not be wanted.
+
 ### Language: Python
 
 The hot path is all C/C++ (librdkafka, orjson, PyArrow, DuckDB). Python is glue — it touches each record once to pass a parsed dict into a list. Performance bottleneck is S3 write latency, not Python.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ COPY --from=uv /uv /usr/local/bin/uv
 
 WORKDIR /app
 COPY pyproject.toml uv.lock LICENSE ./
-RUN uv sync --frozen --no-dev --no-install-project
+RUN uv sync --frozen --no-dev --no-install-project --extra msk-iam
 
 COPY millpond/ millpond/
 ARG MILLPOND_VERSION=0.0.0.dev0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$MILLPOND_VERSION
-RUN uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev --extra msk-iam
 
 # Install DuckDB CLI (pinned to match the Python package version)
 RUN uv tool install "duckdb-cli>=1.4,<1.5"

--- a/README.md
+++ b/README.md
@@ -263,6 +263,19 @@ pipelines:
 
 One `range` over `pipelines` in the StatefulSet template produces N independent StatefulSets. Adding a pipeline is adding a block to `values.yaml` and running `helm upgrade`.
 
+## AWS Credential Isolation
+
+Millpond uses two separate AWS credential paths that must not interfere with each other:
+
+| Component | Auth | Credential source |
+|---|---|---|
+| Kafka (MSK) | SASL/OAUTHBEARER | IRSA (standard AWS credential chain) |
+| S3 (DuckLake data files) | Static IAM keys | `DUCKDB_S3_ACCESS_KEY_ID` / `DUCKDB_S3_SECRET_ACCESS_KEY` |
+
+DuckDB's [aws extension does not support IRSA](https://github.com/duckdb/duckdb-aws/issues/31) — it cannot perform the `AssumeRoleWithWebIdentity` token exchange that IRSA requires. Until that is resolved, S3 access requires static credentials.
+
+These static credentials are passed via DuckDB-specific env var names, not the standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`. This is deliberate: standard AWS env vars take precedence in the credential chain and would shadow the IRSA role used for Kafka authentication.
+
 ## Note
 This project should absolutely be called TableFowl, but that would be an [SEO](https://www.confluent.io/product/tableflow/) and linguistic palaver.
 

--- a/millpond/consumer.py
+++ b/millpond/consumer.py
@@ -29,7 +29,11 @@ def _maybe_attach_oauth_cb(config: dict) -> dict:
             "Install with: pip install millpond[msk-iam]"
         ) from None
 
-    region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+    region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+    if not region:
+        raise RuntimeError(
+            "AWS_REGION or AWS_DEFAULT_REGION must be set when using OAUTHBEARER auth"
+        )
     log.info("MSK IAM auth enabled (region=%s)", region)
 
     def oauth_cb(config_str):

--- a/millpond/consumer.py
+++ b/millpond/consumer.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import orjson
 from confluent_kafka import Consumer, TopicPartition
@@ -10,6 +11,39 @@ from millpond.config import Config
 log = logging.getLogger(__name__)
 
 
+def _maybe_attach_oauth_cb(config: dict) -> dict:
+    """If SASL OAUTHBEARER is configured, attach the MSK IAM token callback."""
+    if "sasl.mechanism" in config and "sasl.mechanisms" not in config:
+        log.warning(
+            "sasl.mechanism (singular) is set but librdkafka uses sasl.mechanisms (plural). "
+            "Use KAFKA_CONSUMER_SASL_MECHANISMS instead of KAFKA_CONSUMER_SASL_MECHANISM."
+        )
+    sasl_mechanism = config.get("sasl.mechanisms")
+    if sasl_mechanism != "OAUTHBEARER":
+        return config
+    try:
+        from aws_msk_iam_auth import MSKAuthTokenProvider
+    except ImportError:
+        raise RuntimeError(
+            "aws-msk-iam-sasl-signer-python is required for OAUTHBEARER auth. "
+            "Install with: pip install millpond[msk-iam]"
+        ) from None
+
+    region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+    log.info("MSK IAM auth enabled (region=%s)", region)
+
+    def oauth_cb(config_str):
+        try:
+            token, expiry_ms = MSKAuthTokenProvider.generate_auth_token(region)
+            return token, expiry_ms / 1000
+        except Exception:
+            log.exception("MSK IAM token generation failed")
+            raise
+
+    config["oauth_cb"] = oauth_cb
+    return config
+
+
 def _base_kafka_config(cfg: Config) -> dict:
     """Base config shared by all Kafka clients (AdminClient, Consumer)."""
     base = {
@@ -18,7 +52,7 @@ def _base_kafka_config(cfg: Config) -> dict:
     }
     for key, val in cfg.kafka_config_overrides:
         base[key] = val
-    return base
+    return _maybe_attach_oauth_cb(base)
 
 
 def _on_stats(stats_json: str) -> None:

--- a/millpond/consumer.py
+++ b/millpond/consumer.py
@@ -31,9 +31,7 @@ def _maybe_attach_oauth_cb(config: dict) -> dict:
 
     region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
     if not region:
-        raise RuntimeError(
-            "AWS_REGION or AWS_DEFAULT_REGION must be set when using OAUTHBEARER auth"
-        )
+        raise RuntimeError("AWS_REGION or AWS_DEFAULT_REGION must be set when using OAUTHBEARER auth")
     log.info("MSK IAM auth enabled (region=%s)", region)
 
     def oauth_cb(config_str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
     "prometheus-client>=0.21",
 ]
 
+[project.optional-dependencies]
+msk-iam = ["aws-msk-iam-sasl-signer-python>=1.0.0"]
+
 [project.scripts]
 millpond = "millpond.main:main"
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -118,12 +118,12 @@ class TestLoad:
 
     def test_kafka_consumer_overrides(self, monkeypatch):
         monkeypatch.setenv("KAFKA_CONSUMER_SECURITY_PROTOCOL", "SASL_SSL")
-        monkeypatch.setenv("KAFKA_CONSUMER_SASL_MECHANISM", "PLAIN")
+        monkeypatch.setenv("KAFKA_CONSUMER_SASL_MECHANISMS", "PLAIN")
         monkeypatch.setenv("KAFKA_CONSUMER_SASL_USERNAME", "user1")
         cfg = load()
         overrides = dict(cfg.kafka_config_overrides)
         assert overrides["security.protocol"] == "SASL_SSL"
-        assert overrides["sasl.mechanism"] == "PLAIN"
+        assert overrides["sasl.mechanisms"] == "PLAIN"
         assert overrides["sasl.username"] == "user1"
 
     def test_kafka_consumer_overrides_default_empty(self):

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -3,7 +3,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from millpond.consumer import _base_kafka_config, _on_stats, compute_assignment, create, discover_partition_count
+from millpond.consumer import (
+    _base_kafka_config,
+    _maybe_attach_oauth_cb,
+    _on_stats,
+    compute_assignment,
+    create,
+    discover_partition_count,
+)
 from millpond.config import Config
 
 
@@ -160,15 +167,61 @@ class TestBaseKafkaConfig:
         assert base["client.id"] == "millpond-test-topic-events-3"
 
     def test_includes_overrides(self):
-        cfg = _make_cfg(kafka_config_overrides=(("security.protocol", "SSL"), ("sasl.mechanism", "PLAIN")))
+        cfg = _make_cfg(kafka_config_overrides=(("security.protocol", "SSL"), ("sasl.mechanisms", "PLAIN")))
         base = _base_kafka_config(cfg)
         assert base["security.protocol"] == "SSL"
-        assert base["sasl.mechanism"] == "PLAIN"
+        assert base["sasl.mechanisms"] == "PLAIN"
 
     def test_empty_overrides(self):
         cfg = _make_cfg(kafka_config_overrides=())
         base = _base_kafka_config(cfg)
         assert "security.protocol" not in base
+
+
+class TestMaybeAttachOauthCb:
+    def test_noop_for_ssl_config(self):
+        config = {"bootstrap.servers": "localhost:9092", "security.protocol": "SSL"}
+        result = _maybe_attach_oauth_cb(config)
+        assert "oauth_cb" not in result
+
+    def test_noop_when_no_sasl(self):
+        config = {"bootstrap.servers": "localhost:9092"}
+        result = _maybe_attach_oauth_cb(config)
+        assert "oauth_cb" not in result
+
+    @patch.dict("os.environ", {"AWS_REGION": "us-east-1"})
+    def test_attaches_callback_for_oauthbearer(self):
+        mock_provider = MagicMock()
+        mock_provider.generate_auth_token.return_value = ("fake-token", 1700000000000)
+        with patch.dict("sys.modules", {"aws_msk_iam_auth": MagicMock(MSKAuthTokenProvider=mock_provider)}):
+            config = {"bootstrap.servers": "localhost:9092", "sasl.mechanisms": "OAUTHBEARER"}
+            result = _maybe_attach_oauth_cb(config)
+            assert "oauth_cb" in result
+            token, expiry = result["oauth_cb"]("")
+            assert token == "fake-token"
+            assert expiry == 1700000000.0
+
+    def test_singular_mechanism_ignored_with_warning(self, caplog):
+        config = {"bootstrap.servers": "localhost:9092", "sasl.mechanism": "OAUTHBEARER"}
+        result = _maybe_attach_oauth_cb(config)
+        assert "oauth_cb" not in result
+        assert "sasl.mechanisms (plural)" in caplog.text
+
+    def test_raises_when_signer_not_installed(self):
+        with patch.dict("sys.modules", {"aws_msk_iam_auth": None}):
+            config = {"bootstrap.servers": "localhost:9092", "sasl.mechanisms": "OAUTHBEARER"}
+            with pytest.raises(RuntimeError, match="aws-msk-iam-sasl-signer-python is required"):
+                _maybe_attach_oauth_cb(config)
+
+    @patch.dict("os.environ", {"AWS_REGION": "eu-central-1"})
+    def test_uses_aws_region_env(self):
+        mock_provider = MagicMock()
+        mock_provider.generate_auth_token.return_value = ("token", 1000)
+        with patch.dict("sys.modules", {"aws_msk_iam_auth": MagicMock(MSKAuthTokenProvider=mock_provider)}):
+            config = {"sasl.mechanisms": "OAUTHBEARER"}
+            result = _maybe_attach_oauth_cb(config)
+            result["oauth_cb"]("")
+            mock_provider.generate_auth_token.assert_called_with("eu-central-1")
 
 
 class TestDiscoverPartitionCount:

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -223,6 +223,13 @@ class TestMaybeAttachOauthCb:
             result["oauth_cb"]("")
             mock_provider.generate_auth_token.assert_called_with("eu-central-1")
 
+    @patch.dict("os.environ", {}, clear=True)
+    def test_raises_when_region_not_set(self):
+        with patch.dict("sys.modules", {"aws_msk_iam_auth": MagicMock()}):
+            config = {"sasl.mechanisms": "OAUTHBEARER"}
+            with pytest.raises(RuntimeError, match="AWS_REGION or AWS_DEFAULT_REGION must be set"):
+                _maybe_attach_oauth_cb(config)
+
 
 class TestDiscoverPartitionCount:
     @patch("millpond.consumer.AdminClient")

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,48 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "aws-msk-iam-sasl-signer-python"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/8b/9af0a7def4ba357afadc89c06019d3735944cb3d6065a455f41580ba7fd6/aws_msk_iam_sasl_signer_python-1.0.2.tar.gz", hash = "sha256:3432d88a7c6db4887ceb1130ebaed0113bfda48b79ea811537add5f1d25fa13f", size = 24034, upload-time = "2025-03-05T20:49:48.582Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/43/f3ffd79fc4941b8d610530d81e1f600cfa1b8651affc25cb929fd0f2f2c9/aws_msk_iam_sasl_signer_python-1.0.2-py2.py3-none-any.whl", hash = "sha256:310eb2db9ca0ff55ed06a24212739b87533e7f1cf6f34e43aabbd97a3b21290e", size = 13279, upload-time = "2025-03-05T20:49:46.611Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.42.78"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/2b/ebdad075934cf6bb78bf81fe31d83339bcd804ad6c856f7341376cbc88b6/boto3-1.42.78.tar.gz", hash = "sha256:cef2ebdb9be5c0e96822f8d3941ac4b816c90a5737a7ffb901d664c808964b63", size = 112789, upload-time = "2026-03-27T19:28:07.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/bb/1f6dade1f1e86858bef7bd332bc8106c445f2dbabec7b32ab5d7d118c9b6/boto3-1.42.78-py3-none-any.whl", hash = "sha256:480a34a077484a5ca60124dfd150ba3ea6517fc89963a679e45b30c6db614d26", size = 140556, upload-time = "2026-03-27T19:28:06.125Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.78"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/8e/cdb34c8ca71216d214e049ada2148ee08bcda12b1ac72af3a720dea300ff/botocore-1.42.78.tar.gz", hash = "sha256:61cbd49728e23f68cfd945406ab40044d49abed143362f7ffa4a4f4bd4311791", size = 15023592, upload-time = "2026-03-27T19:27:57.122Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/72/94bba1a375d45c685b00e051b56142359547837086a83861d76f6aec26f4/botocore-1.42.78-py3-none-any.whl", hash = "sha256:038ab63c7f898e8b5db58cb6a45e4da56c31dd984e7e995839a3540c735564ea", size = 14701729, upload-time = "2026-03-27T19:27:54.05Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -82,6 +124,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/7a/d269d834cb3a76291651256f3b9a5945e81d0a49ab9f4a498964e83c0416/charset_normalizer-3.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:cd5e2801c89992ed8c0a3f0293ae83c159a60d9a5d685005383ef4caca77f2c4", size = 169043, upload-time = "2026-03-15T18:52:28.502Z" },
     { url = "https://files.pythonhosted.org/packages/23/06/28b29fba521a37a8932c6a84192175c34d49f84a6d4773fa63d05f9aff22/charset_normalizer-3.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:47955475ac79cc504ef2704b192364e51d0d473ad452caedd0002605f780101c", size = 148523, upload-time = "2026-03-15T18:52:29.956Z" },
     { url = "https://files.pythonhosted.org/packages/2a/68/687187c7e26cb24ccbd88e5069f5ef00eba804d36dde11d99aad0838ab45/charset_normalizer-3.4.6-py3-none-any.whl", hash = "sha256:947cf925bc916d90adba35a64c82aace04fa39b46b52d4630ece166655905a69", size = 61455, upload-time = "2026-03-15T18:53:23.833Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
@@ -178,6 +232,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "millpond"
 source = { editable = "." }
 dependencies = [
@@ -186,6 +249,11 @@ dependencies = [
     { name = "orjson" },
     { name = "prometheus-client" },
     { name = "pyarrow" },
+]
+
+[package.optional-dependencies]
+msk-iam = [
+    { name = "aws-msk-iam-sasl-signer-python" },
 ]
 
 [package.dev-dependencies]
@@ -197,12 +265,14 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aws-msk-iam-sasl-signer-python", marker = "extra == 'msk-iam'", specifier = ">=1.0.0" },
     { name = "confluent-kafka", specifier = ">=2.6" },
     { name = "duckdb", specifier = ">=1.4,<1.5" },
     { name = "orjson", specifier = ">=3.10" },
     { name = "prometheus-client", specifier = ">=0.21" },
     { name = "pyarrow", specifier = ">=18.0" },
 ]
+provides-extras = ["msk-iam"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -360,6 +430,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -422,6 +504,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/26/6b/8786ba5736562220d588a2f6653e6c17e90c59ced34a2d7b512ef8956103/ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de", size = 10582538, upload-time = "2026-03-19T16:26:15.992Z" },
     { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
     { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Registers `oauth_cb` for MSK IAM token generation when `KAFKA_CONSUMER_SASL_MECHANISMS=OAUTHBEARER`
- Uses `aws-msk-iam-sasl-signer-python` (optional dep, always installed in Docker image)
- Both AdminClient and Consumer get the callback via `_base_kafka_config`
- Warns if `sasl.mechanism` (singular) is used — librdkafka only reads `sasl.mechanisms` (plural)
- Documents credential isolation: IRSA for Kafka, static keys for DuckDB S3 (duckdb/duckdb-aws#31)

## Test plan

- [x] 134 unit tests pass (6 new for OAUTHBEARER callback wiring)
- [x] 15 integration tests pass (no regressions)
- [x] Lint + format clean
- [ ] Deploy to dev with `KAFKA_CONSUMER_SASL_MECHANISMS=OAUTHBEARER` and `KAFKA_CONSUMER_SECURITY_PROTOCOL=SASL_SSL`