### PR TITLE
Add pre-commit hook for lint and format checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running ruff check..."
+uv run ruff check millpond/
+
+echo "Running ruff format check..."
+uv run ruff format --check millpond/
+
+echo "Pre-commit checks passed."

--- a/justfile
+++ b/justfile
@@ -11,6 +11,11 @@ default:
 sync:
     uv sync
 
+# Install git hooks
+[group('dev')]
+install-hooks:
+    git config core.hooksPath .githooks
+
 # Run the application
 [group('dev')]
 run:


### PR DESCRIPTION
## Summary

- `.githooks/pre-commit` runs `ruff check` + `ruff format --check` before each commit
- `just install-hooks` configures git to use `.githooks/` as the hooks directory

## Setup

```bash
just install-hooks
```