### PR TITLE
fix: use git tag --sort for latest tag lookup in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,8 @@ jobs:
     - name: Get latest tag
       id: latest_tag
       run: |
-        tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+        tag=$(git tag --sort=-v:refname | head -1 || echo "v0.0.0")
+        [ -z "$tag" ] && tag="v0.0.0"
         echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
     - name: Bump patch version


### PR DESCRIPTION
git describe --tags --abbrev=0 only finds tags reachable from HEAD. When a tag exists on a different commit (e.g. v0.0.16 was created before the fix was merged), git describe returns the older v0.0.15, bumps to v0.0.16, and fails because it already exists.

Switch to `git tag --sort=-v:refname | head -1` which finds the highest tag globally.