### PR TITLE
Add pod ordinal to log prefix

### DIFF
--- a/millpond/logging_config.py
+++ b/millpond/logging_config.py
@@ -5,9 +5,13 @@ import sys
 
 def setup() -> None:
     level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    pod_name = os.environ.get("POD_NAME") or os.environ.get("HOSTNAME", "")
+    # Extract ordinal from pod name (e.g. "millpond-events-2" -> "2")
+    ordinal = pod_name.rsplit("-", 1)[-1] if "-" in pod_name else pod_name
+    prefix = f"[{ordinal}]" if ordinal else ""
     logging.basicConfig(
         level=level,
-        format="%(asctime)s %(levelname)-5s [%(name)s] %(message)s",
+        format=f"%(asctime)s %(levelname)-5s {prefix}[%(name)s] %(message)s",
         datefmt="%Y-%m-%dT%H:%M:%S",
         stream=sys.stderr,
     )


### PR DESCRIPTION
## Summary

Extracts the ordinal from `POD_NAME` (e.g. `millpond-events-2` → `2`) and prepends it to every log line. Makes aggregated StatefulSet logs attributable to individual pods.

Before: `2026-03-31T18:19:25 INFO  [millpond.main] Flush: 16994 records...`
After:  `2026-03-31T18:19:25 INFO  [2][millpond.main] Flush: 16994 records...`

## Test plan

- [x] 135 unit tests pass
- [x] Lint + format clean