### PR TITLE
Pin AWS_ROLE_SESSION_NAME for stable MSK IAM re-authentication

### DIFF
--- a/millpond/consumer.py
+++ b/millpond/consumer.py
@@ -32,6 +32,11 @@ def _maybe_attach_oauth_cb(config: dict) -> dict:
     region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
     if not region:
         raise RuntimeError("AWS_REGION or AWS_DEFAULT_REGION must be set when using OAUTHBEARER auth")
+
+    # MSK rejects token refreshes if the session name changes between re-authentications.
+    # Each call to generate_auth_token() creates a new botocore session with a random name.
+    # Pin it so the principal stays stable across refreshes on the same connection.
+    os.environ.setdefault("AWS_ROLE_SESSION_NAME", "millpond")
     log.info("MSK IAM auth enabled (region=%s)", region)
 
     def oauth_cb(config_str):


### PR DESCRIPTION
## Summary

MSK rejects OAUTHBEARER token refreshes when the botocore session name changes between re-authentications on the same connection:

```
SASL authentication error: Cannot change principals during re-authentication
from IAM...botocore-session-1774984046: IAM...botocore-session-1774986927
```

Each call to `generate_auth_token()` creates a new botocore session with a random name. This pins `AWS_ROLE_SESSION_NAME=millpond` so the principal stays stable across `oauth_cb` refreshes.

All pods share the same session name — MSK only requires stability within a single TCP connection, not uniqueness across pods.

## Test plan

- [x] 135 unit tests pass
- [x] Lint + format clean
- [ ] Deploy to dev, verify no more re-authentication errors after token refresh (~15 min cycle)