### PR TITLE
Explicitly use OFFSET_STORED in assign(), add tests for offset resume

### DIFF
--- a/millpond/consumer.py
+++ b/millpond/consumer.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 import orjson
-from confluent_kafka import Consumer, TopicPartition
+from confluent_kafka import OFFSET_STORED, Consumer, TopicPartition
 from confluent_kafka.admin import AdminClient
 
 from millpond import metrics
@@ -136,5 +136,9 @@ def create(cfg: Config) -> Consumer:
 
     consumer = Consumer(consumer_config)
 
-    consumer.assign([TopicPartition(cfg.topic, p) for p in my_partitions])
+    # OFFSET_STORED: resume from committed offset in __consumer_offsets.
+    # Falls back to auto.offset.reset (earliest) if no offset committed.
+    # Critical for replica count changes — new pods must resume from offsets
+    # committed by whichever pod previously owned each partition.
+    consumer.assign([TopicPartition(cfg.topic, p, OFFSET_STORED) for p in my_partitions])
     return consumer

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -3,6 +3,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from confluent_kafka import OFFSET_STORED
+
 from millpond.consumer import (
     _base_kafka_config,
     _maybe_attach_oauth_cb,
@@ -313,6 +315,37 @@ class TestCreate:
 
         consumer_config = mock_consumer_cls.call_args[0][0]
         assert consumer_config["client.id"] == "millpond-test-topic-events-2"
+
+    @patch("millpond.consumer.Consumer")
+    @patch("millpond.consumer.discover_partition_count", return_value=8)
+    def test_assign_uses_stored_offsets(self, mock_discover, mock_consumer_cls):
+        """Verify assign() does not set explicit offsets — librdkafka defaults to STORED.
+
+        STORED means: use committed offset from __consumer_offsets if available,
+        otherwise fall back to auto.offset.reset (earliest). This is critical for
+        replica count changes — a new pod must resume from the offset committed
+        by whichever pod previously owned that partition.
+        """
+        cfg = _make_cfg(ordinal=0, replica_count=2)
+        create(cfg)
+
+        assign_call = mock_consumer_cls.return_value.assign
+        partitions = assign_call.call_args[0][0]
+        for tp in partitions:
+            assert tp.offset == OFFSET_STORED, (
+                f"Partition {tp.partition} has offset {tp.offset}, expected OFFSET_STORED ({OFFSET_STORED}). "
+                "assign() must use OFFSET_STORED to resume from committed offsets."
+            )
+
+    @patch("millpond.consumer.Consumer")
+    @patch("millpond.consumer.discover_partition_count", return_value=8)
+    def test_auto_offset_reset_is_earliest(self, mock_discover, mock_consumer_cls):
+        """Verify auto.offset.reset=earliest for partitions with no committed offset."""
+        cfg = _make_cfg()
+        create(cfg)
+
+        consumer_config = mock_consumer_cls.call_args[0][0]
+        assert consumer_config["auto.offset.reset"] == "earliest"
 
     @patch("millpond.consumer.Consumer")
     @patch("millpond.consumer.discover_partition_count", return_value=2)

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -319,12 +319,12 @@ class TestCreate:
     @patch("millpond.consumer.Consumer")
     @patch("millpond.consumer.discover_partition_count", return_value=8)
     def test_assign_uses_stored_offsets(self, mock_discover, mock_consumer_cls):
-        """Verify assign() does not set explicit offsets — librdkafka defaults to STORED.
+        """Verify assign() explicitly uses OFFSET_STORED for all partitions.
 
-        STORED means: use committed offset from __consumer_offsets if available,
-        otherwise fall back to auto.offset.reset (earliest). This is critical for
-        replica count changes — a new pod must resume from the offset committed
-        by whichever pod previously owned that partition.
+        STORED means: resume from the committed offset in __consumer_offsets,
+        falling back to auto.offset.reset (earliest) if none exists. This is
+        critical for replica count changes — a new pod must resume from the
+        offset committed by whichever pod previously owned that partition.
         """
         cfg = _make_cfg(ordinal=0, replica_count=2)
         create(cfg)


### PR DESCRIPTION
## Summary

Makes the committed-offset resume behavior explicit in `consumer.assign()`. Previously relied on librdkafka's implicit default (`OFFSET_INVALID` → same as `OFFSET_STORED`). Now explicitly passes `OFFSET_STORED` so the intent is clear in code.

**Why this matters:** When replica count changes (e.g. 4 → 2 pods), partitions get reassigned to different pods. Each pod must resume from the offset committed by whichever pod previously owned that partition — not replay from earliest. `OFFSET_STORED` fetches the committed offset from `__consumer_offsets`, falling back to `auto.offset.reset=earliest` only if no offset has ever been committed.

No functional change — just making the invariant explicit and tested.

## Test plan

- [x] 137 unit tests pass (2 new)
- [x] `test_assign_uses_stored_offsets` — verifies every partition uses `OFFSET_STORED`
- [x] `test_auto_offset_reset_is_earliest` — verifies fallback for new partitions