### PR TITLE
SET preserve_insertion_order=false to reduce memory during partitioned writes

### DIFF
--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -54,6 +54,11 @@ def connect(cfg: Config) -> duckdb.DuckDBPyConnection:
     conn.execute("LOAD ducklake")
     conn.execute("LOAD postgres")
 
+    # Partitioned INSERTs hold concurrent write buffers per partition value.
+    # With high-cardinality partition keys this can exhaust memory.
+    # Disabling insertion order allows DuckDB to process partitions sequentially.
+    conn.execute("SET preserve_insertion_order = false")
+
     # Build a libpq connection string for DuckLake.
     # The 'postgres:' prefix tells DuckLake to use the Postgres extension
     # for metadata storage rather than a local DuckDB file.


### PR DESCRIPTION
## Summary

DuckDB's partitioned INSERT holds concurrent write buffers per partition value. With high-cardinality partition keys (e.g. 1,300 distinct values), the internal memory for these buffers plus the Arrow batch exceeds the pod's memory limit during large flushes.

`SET preserve_insertion_order = false` allows DuckDB to process partitions sequentially instead of concurrently, dramatically reducing peak memory. Insertion order is irrelevant for append-only event ingestion.

## Context

At 1GB flush size with 4Gi pod memory, DuckDB OOMs at 3.1Gi — the 1GB Arrow data plus ~2GB of concurrent partition write buffers. This setting should allow the 1GB flush to fit within 4Gi.

## Test plan

- [x] 153 unit tests pass
- [ ] Deploy to prod-us, verify 1GB flushes complete without OOM