### PR TITLE
Add promote-to-prod workflow

### DIFF
--- a/.github/workflows/promote-to-prod.yaml
+++ b/.github/workflows/promote-to-prod.yaml
@@ -22,12 +22,21 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Validate version
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+          echo "::error::Invalid version format: '$VERSION'. Expected: v0.0.0"
+          exit 1
+        fi
+
     - name: Retag as prod
       env:
         VERSION: ${{ inputs.version }}
       run: |
         echo "Promoting ghcr.io/posthog/millpond:${VERSION} → prod"
         docker buildx imagetools create \
-          --tag ghcr.io/posthog/millpond:prod \
-          ghcr.io/posthog/millpond:${VERSION}
+          --tag "ghcr.io/posthog/millpond:prod" \
+          "ghcr.io/posthog/millpond:${VERSION}"
         echo "Done. ghcr.io/posthog/millpond:prod now points to ${VERSION}"

--- a/.github/workflows/promote-to-prod.yaml
+++ b/.github/workflows/promote-to-prod.yaml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: promote-to-prod
+  cancel-in-progress: false
+
 permissions:
   packages: write
 

--- a/.github/workflows/promote-to-prod.yaml
+++ b/.github/workflows/promote-to-prod.yaml
@@ -1,0 +1,33 @@
+name: Promote to prod
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to promote (e.g. v0.0.23)'
+        required: true
+        type: string
+
+permissions:
+  packages: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Log in to GHCR
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Retag as prod
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        echo "Promoting ghcr.io/posthog/millpond:${VERSION} → prod"
+        docker buildx imagetools create \
+          --tag ghcr.io/posthog/millpond:prod \
+          ghcr.io/posthog/millpond:${VERSION}
+        echo "Done. ghcr.io/posthog/millpond:prod now points to ${VERSION}"


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` workflow to retag an existing image version as `prod`. Run from the Actions tab — enter a version like `v0.0.23` and it promotes that image to `ghcr.io/posthog/millpond:prod`.

Uses `docker buildx imagetools create` to retag without pulling/pushing the full image — just a manifest update.

Once the charts prod-us values file is updated to `tag: "prod"`, promoting a new version to production is a one-click action with no charts PR required.

## Usage

Actions → "Promote to prod" → Run workflow → enter version → Run