### PR TITLE
Auto-resolve latest release in promote-to-prod workflow

### DIFF
--- a/.github/workflows/promote-to-prod.yaml
+++ b/.github/workflows/promote-to-prod.yaml
@@ -4,21 +4,25 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag to promote (e.g. v0.0.23)'
-        required: true
+        description: 'Version tag to promote (leave empty for latest release)'
+        required: false
         type: string
+        default: ''
 
 concurrency:
   group: promote-to-prod
   cancel-in-progress: false
 
 permissions:
+  contents: read
   packages: write
 
 jobs:
   promote:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
     - name: Log in to GHCR
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
       with:
@@ -26,18 +30,25 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Validate version
+    - name: Resolve version
+      id: resolve
       env:
         VERSION: ${{ inputs.version }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        if [ -z "$VERSION" ]; then
+          VERSION=$(gh release view --json tagName -q .tagName)
+          echo "Auto-resolved to latest release: $VERSION"
+        fi
         if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
           echo "::error::Invalid version format: '$VERSION'. Expected: v0.0.0"
           exit 1
         fi
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Retag as prod
       env:
-        VERSION: ${{ inputs.version }}
+        VERSION: ${{ steps.resolve.outputs.version }}
       run: |
         echo "Promoting ghcr.io/posthog/millpond:${VERSION} → prod"
         docker buildx imagetools create \


### PR DESCRIPTION
## Summary

Leave the version field empty → workflow auto-resolves to the latest GitHub release via `gh release view`. Enter a specific version to override.

Also adds `actions/checkout` (needed for `gh` CLI) and `contents: read` permission.