### PR TITLE
Arrow IPC on the wire: C++ consumer PoC

### DIFF
--- a/experiments/arrow-payload/.gitignore
+++ b/experiments/arrow-payload/.gitignore
@@ -1,0 +1,25 @@
+# CMake
+build/
+cmake-build-*/
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+Makefile
+
+# Compiled binaries
+*.o
+*.out
+*.exe
+arrow_consumer
+
+# Python
+__pycache__/
+*.pyc
+.venv/
+venv/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo

--- a/experiments/arrow-payload/Dockerfile.consumer
+++ b/experiments/arrow-payload/Dockerfile.consumer
@@ -1,0 +1,141 @@
+# syntax=docker/dockerfile:1.7
+#
+# Arrow-IPC-on-Kafka consumer image.
+#
+# Build context: experiments/arrow-payload/  (see docker-compose.yaml)
+#
+# Pinned versions:
+#   - Base:        debian:bookworm-slim (Debian 12)
+#   - librdkafka:  1.9.2-1+deb12u1      (from Debian 12 main; satisfies our use — we only need
+#                                        the high-level consumer API, which has been stable since 1.x)
+#   - Apache Arrow: 18.x                (installed via the official apache-arrow-apt-source package;
+#                                        Debian default repos do not ship libarrow)
+#   - DuckDB:      v1.4.0                (matches parent Dockerfile: `duckdb-cli>=1.4,<1.5`)
+#
+# Why Arrow 18 and not 19: 18.x is the latest release with a stable `libarrow1800` runtime
+# package name in the Arrow APT repo at the time of writing. Bump to 19 once we've verified
+# the runtime package naming on apt.apache.org/arrow.
+
+# -----------------------------------------------------------------------------
+# Stage 1: builder
+# -----------------------------------------------------------------------------
+FROM debian:bookworm-slim AS builder
+
+# TARGETARCH is automatically populated by buildx (amd64 / arm64). We use it
+# to pick the matching DuckDB precompiled release. Apple Silicon hosts MUST
+# build arm64 here — building amd64 under Rosetta would invalidate any
+# throughput numbers this PoC produces.
+ARG TARGETARCH
+ARG ARROW_VERSION=18.1.0
+ARG ARROW_SO=1801
+ARG DUCKDB_VERSION=1.4.0
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Base build deps.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential \
+      cmake \
+      pkg-config \
+      git \
+      ca-certificates \
+      wget \
+      unzip \
+      lsb-release \
+      gnupg \
+      librdkafka-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Apache Arrow C++ via the official Arrow APT repo.
+# See https://arrow.apache.org/install/ — the `apache-arrow-apt-source` .deb drops
+# a signed sources.list entry into /etc/apt/sources.list.d/.
+RUN wget -qO /tmp/apache-arrow-apt-source.deb \
+      "https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb" \
+    && apt-get install -y --no-install-recommends /tmp/apache-arrow-apt-source.deb \
+    && rm /tmp/apache-arrow-apt-source.deb \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+         "libarrow-dev=${ARROW_VERSION}-1" \
+    && rm -rf /var/lib/apt/lists/*
+
+# DuckDB C/C++ headers + shared library (precompiled upstream release).
+# Pick the right zip per host arch — DuckDB ships amd64 and aarch64 builds.
+RUN case "${TARGETARCH}" in \
+        amd64) DUCKDB_ARCH=linux-amd64 ;; \
+        arm64) DUCKDB_ARCH=linux-arm64 ;; \
+        *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && wget -qO /tmp/libduckdb.zip \
+        "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-${DUCKDB_ARCH}.zip" \
+    && unzip -o /tmp/libduckdb.zip -d /tmp/libduckdb \
+    && install -m 0644 /tmp/libduckdb/duckdb.h /usr/local/include/duckdb.h \
+    && install -m 0644 /tmp/libduckdb/duckdb.hpp /usr/local/include/duckdb.hpp \
+    && install -m 0755 /tmp/libduckdb/libduckdb.so /usr/local/lib/libduckdb.so \
+    && ldconfig \
+    && rm -rf /tmp/libduckdb /tmp/libduckdb.zip
+
+# Pre-install DuckDB extensions so the consumer's runtime LOAD has no network
+# dependency. Mirrors parent project's Dockerfile pattern. We grab the matching
+# DuckDB CLI release, run INSTALL into /root/.duckdb, and stage the extensions
+# directory for the runtime stage to copy.
+RUN case "${TARGETARCH}" in \
+        amd64) DUCKDB_ARCH=linux-amd64 ;; \
+        arm64) DUCKDB_ARCH=linux-arm64 ;; \
+    esac \
+    && wget -qO /tmp/duckdb_cli.zip \
+        "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-${DUCKDB_ARCH}.zip" \
+    && unzip -o /tmp/duckdb_cli.zip -d /tmp/duckdb_cli \
+    && install -m 0755 /tmp/duckdb_cli/duckdb /usr/local/bin/duckdb \
+    && /usr/local/bin/duckdb -c "INSTALL httpfs; INSTALL ducklake; INSTALL postgres;" \
+    && rm -rf /tmp/duckdb_cli /tmp/duckdb_cli.zip
+
+# Build the consumer.
+# NOTE: build context is experiments/arrow-payload/, so this COPY grabs the consumer/ subdir.
+WORKDIR /build
+COPY consumer/ /build/
+RUN cmake -B build -S . -DCMAKE_BUILD_TYPE=Release \
+    && cmake --build build -j"$(nproc)"
+
+# -----------------------------------------------------------------------------
+# Stage 2: runtime
+# -----------------------------------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+
+ARG ARROW_VERSION=18.1.0
+ARG ARROW_SO=1801
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Arrow runtime via the same APT repo as the builder, then the small
+# set of runtime libraries the consumer binary links against.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      wget \
+      lsb-release \
+      gnupg \
+    && wget -qO /tmp/apache-arrow-apt-source.deb \
+        "https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb" \
+    && apt-get install -y --no-install-recommends /tmp/apache-arrow-apt-source.deb \
+    && rm /tmp/apache-arrow-apt-source.deb \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+         librdkafka1 \
+         "libarrow${ARROW_SO}=${ARROW_VERSION}-1" \
+    && apt-get purge -y --auto-remove wget lsb-release gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# DuckDB shared library (headers not needed at runtime).
+COPY --from=builder /usr/local/lib/libduckdb.so /usr/local/lib/libduckdb.so
+RUN ldconfig
+
+# Consumer binary.
+COPY --from=builder /build/build/arrow-consumer /usr/local/bin/arrow-consumer
+
+# DuckDB extensions baked in at build time. The consumer process runs as root
+# in this image (PoC; matches simplicity, not parent-stack non-root norms),
+# so extensions land in /root/.duckdb where the consumer's LOAD statements
+# expect them. The consumer issues `LOAD httpfs/ducklake/postgres` at startup
+# and these pre-installed extensions are picked up without any network call.
+COPY --from=builder /root/.duckdb /root/.duckdb
+
+ENTRYPOINT ["/usr/local/bin/arrow-consumer"]

--- a/experiments/arrow-payload/Dockerfile.producer
+++ b/experiments/arrow-payload/Dockerfile.producer
@@ -1,0 +1,36 @@
+# Dockerfile for the arrow-payload experiment's Python producer.
+#
+# IMPORTANT: the build context MUST be the repository root
+# (/Users/jakob/src/millpond). From experiments/arrow-payload/docker-compose.yaml
+# this means:
+#
+#   build:
+#     context: ../..
+#     dockerfile: experiments/arrow-payload/Dockerfile.producer
+#
+# We reuse test/producer.py verbatim for its PostHog event generators
+# (pageview, autocapture, identify, etc.) and put it on PYTHONPATH so
+# arrow_producer.py can `import producer`.
+
+FROM python:3.12-slim
+
+# Pinned to minor versions. confluent-kafka 2.6.x ships with librdkafka
+# 2.6.x; pyarrow 18.1.x is the current stable at the time of writing.
+RUN pip install --no-cache-dir \
+        "pyarrow==18.1.*" \
+        "confluent-kafka==2.6.*"
+
+WORKDIR /app
+
+# Reused generators (copied from repo root — build context is repo root).
+COPY test/producer.py /app/posthog_gen/producer.py
+
+# The Arrow IPC producer itself.
+COPY experiments/arrow-payload/producer/arrow_producer.py /app/arrow_producer.py
+
+# Put the reused generators on PYTHONPATH so `import producer` in
+# arrow_producer.py resolves to /app/posthog_gen/producer.py.
+ENV PYTHONPATH=/app/posthog_gen
+ENV PYTHONUNBUFFERED=1
+
+ENTRYPOINT ["python", "/app/arrow_producer.py"]

--- a/experiments/arrow-payload/FINDINGS.md
+++ b/experiments/arrow-payload/FINDINGS.md
@@ -1,0 +1,161 @@
+# Arrow IPC on the Wire: Findings
+
+Experiment branch: `experiment/arrow-message-payload`
+
+## Question
+
+Can a C++ consumer achieve near-zero-copy ingest from Kafka into DuckLake
+when the producer ships Arrow IPC on the wire?
+
+## Answer
+
+Yes. The PoC demonstrates:
+
+```
+librdkafka recv buffer ──(zero-copy wrap)──> Arrow IPC reader ──(Arrow C Data Interface)──> DuckDB arrow_scan ──> INSERT into DuckLake
+```
+
+No `memcpy` occurs between librdkafka's receive buffer and DuckDB's scan.
+The only copy is DuckDB materializing into its own column store during
+`INSERT`, which is unavoidable regardless of source format.
+
+## What the original doc got wrong
+
+`WICKED_COOL_NEXT_STEPS.md` line 25 says:
+
+> The pipeline is memcpy from librdkafka recv buffer -> Arrow buffer -> DuckDB zero-copy scan.
+
+This implies two hops. In practice there is **one**: librdkafka buffer
+**is** the Arrow buffer (wrapped in place via `arrow::Buffer(ptr, len)`).
+There is no intermediate copy. The table at line 31 listing `~memcpy` as
+the per-record CPU cost is also misleading — the per-record cost is closer
+to zero (pointer arithmetic inside Arrow's IPC reader + DuckDB's columnar
+materialization on INSERT).
+
+## Buffer ownership — the key invariant
+
+| Question | Answer |
+|---|---|
+| Who owns `msg->payload`? | librdkafka, until `rd_kafka_message_destroy()` |
+| Can we read it in place? | Yes, for the lifetime of the message |
+| Can we hold the pointer past `destroy()`? | No |
+| How does the consumer handle this? | Option A: non-owning `arrow::Buffer(ptr, len)`. All Arrow + DuckDB work runs synchronously in one loop iteration. `rd_kafka_message_destroy()` is the **last** call in the iteration, after DuckDB has fully materialized the batch. |
+| Is there a use-after-free risk? | Only if `INSERT` were ever made async or deferred. It isn't — `duckdb_query` is synchronous, so by the time it returns, DuckDB owns a copy in its column store and the borrowed pointers are dead. |
+| Buffer alignment? | librdkafka does not align to Arrow's preferred 64-byte boundary. Arrow IPC tolerates this. DuckDB copies into its own storage on INSERT, so alignment is moot. |
+
+## DuckDB Arrow C API — the `duckdb_arrow_stream` ABI trap
+
+The most significant finding from QE review. The `duckdb_arrow_stream`
+typedef is defined as:
+
+```c
+typedef struct _duckdb_arrow_stream {
+    void *internal_ptr;
+} *duckdb_arrow_stream;
+```
+
+This looks like it wants a wrapper struct with `internal_ptr` pointing at
+your `ArrowArrayStream`. **It does not.** At the ABI boundary, DuckDB's
+`duckdb_arrow_scan` implementation (`src/main/capi/arrow-c.cpp`) does:
+
+```cpp
+reinterpret_cast<ArrowArrayStream *>(arrow)
+```
+
+It interprets the argument directly as an `ArrowArrayStream*`. If you pass
+a wrapper struct, DuckDB treats the wrapper's first word (`internal_ptr`,
+which is the address of your `ArrowArrayStream`) as the `get_schema`
+function pointer and calls it. **Guaranteed segfault.**
+
+Correct usage:
+
+```cpp
+ArrowArrayStream c_stream{};
+arrow::ExportRecordBatchReader(reader, &c_stream);
+duckdb_arrow_scan(con, view, reinterpret_cast<duckdb_arrow_stream>(&c_stream));
+```
+
+This is underdocumented. The Python API (`conn.register('arrow_batch', table)`)
+routes through a completely different code path and doesn't illustrate the
+C ABI contract.
+
+## Smoke-test results
+
+| Metric | Value |
+|---|---|
+| Platform | Apple Silicon (arm64), Docker native |
+| Producer rate (intentionally rate-limited) | 10 batches/sec x 1000 records = 10K rec/sec |
+| Per-batch Arrow IPC size (uncompressed, on wire) | ~1.10-1.14 MB |
+| Consumer behavior | Kept up trivially, 0 lag across 8 partitions |
+| Records ingested (~30s run) | 660,000 |
+| Parquet files written to MinIO | 660, ~345-352 KB each |
+| Arrow IPC -> parquet compression ratio | ~3.2x |
+| Consumer crashes / segfaults | 0 |
+| Data lost | 0 |
+
+These numbers do not represent peak consumer throughput. The producer was
+rate-limited; the consumer was never saturated. Measuring the ceiling
+requires removing the rate limiter or running multiple producer instances.
+
+## Build issues encountered
+
+| # | Symptom | Root cause | Fix |
+|---|---|---|---|
+| 1 | `wget` exit 8 fetching DuckDB lib | DuckDB names arm64 assets `linux-arm64`, not `linux-aarch64` | `TARGETARCH`-driven `case` in Dockerfile |
+| 2 | `libarrow.so.1801 not found` at runtime | Builder pulled Arrow 18.1.0 (SONAME 1801), runtime installed `libarrow1800` (18.0.x) | Pin both stages to `18.1.0-1` |
+| 3 | `MSG_SIZE_TOO_LARGE` from producer | 1000 PostHog events x ~1.1 KB avg > 1 MB Kafka default | Bumped broker, topic, and producer `message.max.bytes` to 16 MiB |
+| 4 | DuckDB `Parser Error` on `ATTACH` | Inner single quotes in Postgres connstring (`dbname='ducklake'`) closed the outer SQL string literal | Dropped inner quotes (values contain no whitespace) |
+
+## Architecture of the PoC
+
+```
+experiments/arrow-payload/
+├── producer/arrow_producer.py   # 233 lines: generate events, batch to Arrow IPC, publish
+├── consumer/main.cpp            # 250 lines: poll, wrap buffer, arrow_scan, INSERT, commit
+├── consumer/CMakeLists.txt      # 35 lines
+├── Dockerfile.producer          # python:3.12-slim + pyarrow + confluent-kafka
+├── Dockerfile.consumer          # debian bookworm + Arrow 18.1 + DuckDB 1.4.0 + librdkafka
+└── docker-compose.yaml          # kafka + postgres + minio + producer + consumer
+```
+
+The consumer loop is ~50 lines of load-bearing code:
+
+1. `rd_kafka_consumer_poll` — get message
+2. `arrow::Buffer(msg->payload, msg->len)` — zero-copy wrap
+3. `arrow::ipc::RecordBatchStreamReader::Open` — parse IPC stream in place
+4. `arrow::ExportRecordBatchReader` — export to Arrow C Data Interface
+5. `duckdb_arrow_scan` — register as scannable view
+6. `INSERT INTO lake.main.events_arrow SELECT *, NOW() FROM view` — materialize
+7. `rd_kafka_commit` — commit offset (synchronous, after successful write)
+8. `rd_kafka_message_destroy` — release librdkafka buffer (last call)
+
+## What this does not cover
+
+- Peak throughput (producer was rate-limited; consumer never saturated)
+- Comparison vs the Python millpond consumer at equal load
+- Schema evolution (fixed schema, no ALTER TABLE)
+- Compression on the wire (Arrow IPC sent uncompressed; LZ4 could reduce wire size but adds a decompression copy)
+- Pure-C implementation (would need Arrow GLib for IPC reading)
+- Metrics, health checks, graceful shutdown under load
+- Multi-consumer scaling (static `assign()` over all partitions; only one consumer instance ran)
+
+## Implications for the production pipeline
+
+The claim in `WICKED_COOL_NEXT_STEPS.md` holds: if the producer writes
+Arrow IPC, the consumer reduces to "three pointers and a loop." The JSON
+parse + `from_pylist()` + Python object creation that dominates the current
+pipeline's CPU profile disappears entirely.
+
+What changes on the producer side: PostHog's ingestion pipeline would need
+to emit Arrow IPC instead of JSON. This is a non-trivial change — the
+current pipeline is JSON-native end to end. The consumer savings are
+meaningless without the producer change, so the decision is whether the
+aggregate system benefit (fewer consumer pods, less Postgres catalog
+contention, simpler consumer code) justifies the producer-side work.
+
+The consumer-side complexity delta: 250 lines of C++ vs ~400 lines of
+Python (millpond's consumer + arrow_converter + config). The C++ has no
+runtime, no GC, no allocator pressure per record. The trade-off is
+operational: C++ is harder to debug in production, has no Prometheus
+metrics integration without additional work, and requires a separate
+build toolchain.

--- a/experiments/arrow-payload/README.md
+++ b/experiments/arrow-payload/README.md
@@ -1,0 +1,162 @@
+# Experiment: Arrow IPC on the wire (C++ PoC)
+
+## Goal
+
+Validate the claim from `WICKED_COOL_NEXT_STEPS.md` that producing **Arrow IPC**
+on the Kafka wire enables a near-zero-copy consumer path:
+
+```
+librdkafka recv buffer  ──►  Arrow C Data Interface  ──►  DuckDB arrow_scan  ──►  DuckLake INSERT
+```
+
+The librdkafka payload buffer is wrapped in place by Arrow C++ — no `memcpy`
+into a separate Arrow buffer. The only "copy" is DuckDB materializing into its
+own column store during `INSERT`, which is unavoidable.
+
+## Non-goals
+
+- Pure-C consumer (Arrow IPC reading in pure C requires Arrow GLib; we use
+  Arrow C++ + the Arrow C Data Interface to keep the PoC tight). The C++ side
+  is still ~150 LOC.
+- Full feature parity with the Python consumer (no schema evolution detection,
+  no adaptive backpressure, no Prometheus metrics — those layers are
+  orthogonal to the zero-copy claim).
+- Replacing the Python consumer in production. This is "for fun".
+
+## Architecture
+
+```
+┌─────────────┐    Arrow IPC    ┌──────────────────────┐    Arrow C Data Interface    ┌─────────┐    INSERT    ┌──────────┐
+│  producer   │ ──────────────► │  arrow-consumer C++  │ ───────────────────────────► │ DuckDB  │ ───────────► │ DuckLake │
+│  (Python)   │   record batch  │   librdkafka loop    │   ArrowArrayStream            │ in-mem  │              │  (PG+S3) │
+└─────────────┘                 └──────────────────────┘                               └─────────┘              └──────────┘
+```
+
+- **Topic**: `test-events-arrow` (separate from the existing `test-events`).
+- **Payload format**: Arrow IPC stream — one record batch per Kafka message.
+  Each batch contains N PostHog-shaped events.
+- **Schema**: fixed at producer startup (no per-batch evolution). See below.
+- **Sink**: full DuckLake stack (Postgres catalog + MinIO data) — same services
+  as the parent project's `docker-compose.yaml`, separate table:
+  `lake.main.events_arrow`.
+
+## Shared contract (producer ↔ consumer)
+
+Both sides MUST agree on these.
+
+| Item | Value |
+|---|---|
+| Topic | `test-events-arrow` |
+| Partitions | `8` |
+| Records per batch | `1000` (env: `BATCH_SIZE`) |
+| IPC variant | Arrow IPC **stream** format (`ipc.new_stream` / `arrow::ipc::RecordBatchStreamReader`) |
+| Compression | none (we want raw memcpy semantics; LZ4 can come later) |
+| DuckLake table | `lake.main.events_arrow` |
+| Postgres / MinIO | reuses parent stack env vars (`DUCKLAKE_RDS_*`, `DUCKDB_S3_*`) |
+
+### Arrow schema (v1)
+
+Top-level columns. Mirrors the PostHog event shape, flattened where convenient.
+Properties get JSON-encoded into a VARCHAR column to match the production
+Millpond approach (avoids struct unification headaches in the PoC).
+
+| Column | Arrow type |
+|---|---|
+| `uuid` | `string` |
+| `event` | `string` |
+| `distinct_id` | `string` |
+| `timestamp` | `string` (ISO8601) |
+| `team_id` | `int64` |
+| `project_id` | `int64` |
+| `properties` | `string` (JSON-encoded) |
+| `elements_chain` | `string` (nullable, only for `$autocapture`) |
+
+The producer generates events with the existing `test/producer.py` event
+generators (pageview, autocapture, identify, etc.) but ships them as columnar
+Arrow record batches instead of one-JSON-per-message.
+
+## Repository layout
+
+```
+experiments/arrow-payload/
+├── README.md              # this file (design + results)
+├── docker-compose.yaml    # standalone stack: kafka + postgres + minio + producer + consumer
+├── Dockerfile.producer    # Python image with pyarrow + confluent-kafka
+├── Dockerfile.consumer    # Debian + librdkafka-dev + libarrow-dev + duckdb headers/lib
+├── producer/
+│   └── arrow_producer.py  # generates events, batches into Arrow IPC, publishes to Kafka
+└── consumer/
+    ├── CMakeLists.txt
+    └── main.cpp           # librdkafka poll loop → Arrow IPC reader → DuckDB arrow_scan → INSERT
+```
+
+## Build & run
+
+```bash
+cd experiments/arrow-payload
+docker compose up --build
+```
+
+Expected output:
+- Kafka, Postgres, MinIO healthy
+- DuckLake table `events_arrow` created on consumer startup
+- Producer logs `[arrow-producer] sent batch N records=1000 bytes=…`
+- Consumer logs `[arrow-consumer] flushed batch N records=1000 lag=…`
+- Records visible in MinIO under `s3://ducklake/data/main/events_arrow/...`
+
+## What we're measuring
+
+- **Throughput**: records/sec sustained at the consumer.
+- **Per-record CPU**: from `perf stat` or just wall time vs records.
+- **Memory**: RSS of the consumer process. Should stay flat — no per-record
+  allocations beyond what librdkafka and DuckDB need internally.
+
+## First-run results (smoke test, 2026-04-12)
+
+End-to-end works on Apple Silicon with the stack in this directory.
+
+| Metric | Value |
+|---|---|
+| Producer rate (rate-limited) | 10 batches/sec × 1000 records = **10,000 rec/sec** |
+| Per-batch wire size (Arrow IPC stream) | ~1.10–1.14 MB uncompressed |
+| Consumer behavior | Kept up with the producer trivially across all 8 partitions; no lag |
+| Records ingested into DuckLake (~30s run) | **660,000** across 660 data files |
+| Average parquet file size (compressed, on MinIO) | ~345–352 KB per 1000-record batch |
+| Compression ratio (Arrow IPC → parquet) | ~3.2× (1.12 MB → 350 KB) |
+| DuckLake catalog rows | `ducklake_table` × 1 (`events_arrow`), `ducklake_data_file` × 660 |
+| Consumer crashes / segfaults | 0 |
+| Data lost | 0 |
+
+These numbers do **not** stress the consumer's peak throughput — the
+producer was deliberately rate-limited and ran a single instance. To
+measure the consumer ceiling, raise `BATCHES_PER_SECOND` aggressively
+(or set it to 0 to disable the limiter entirely) and watch consumer
+lag from `kafka-consumer-groups.sh`.
+
+### Things that bit during the smoke test (in case anyone reproduces)
+
+| # | Symptom | Fix |
+|---|---|---|
+| 1 | `wget` exit 8 fetching `libduckdb-linux-aarch64.zip` | DuckDB ships `libduckdb-linux-arm64.zip`, not `aarch64`. Dockerfile uses `linux-arm64`. |
+| 2 | `libarrow.so.1801: cannot open shared object file` | Builder pulled Arrow 18.1.0 (SONAME `1801`), runtime tried to install `libarrow1800` (18.0.x runtime package). Fix: pin both stages to `18.1.0-1` and use `libarrow1801`. |
+| 3 | `MSG_SIZE_TOO_LARGE` from producer | 1000 PostHog events with full properties = ~1.1MB > 1MB Kafka default. Bumped broker `KAFKA_CFG_MESSAGE_MAX_BYTES`, topic-level `max.message.bytes`, and producer `message.max.bytes` to 16 MiB. |
+| 4 | DuckDB `Parser Error` on `ATTACH 'ducklake:postgres:...'` | Inner single quotes around `dbname='ducklake'` closed the outer SQL string literal early. Fixed by dropping the inner quotes (Postgres connstring values are unquoted-safe when they contain no whitespace). The Python `ducklake.py` has the same shape and is technically vulnerable to the same parser error if a value ever needs quoting — flag for the production code if this turns out to matter. |
+| 5 | `duckdb_arrow_scan` segfault (caught by QE review before runtime) | The `_duckdb_arrow_stream { void *internal_ptr; }*` typedef is opaque at the ABI boundary; DuckDB does `reinterpret_cast<ArrowArrayStream *>(arrow)` directly. Pass `&c_stream` cast to the typedef, NOT a wrapper struct. |
+
+## Open questions / known caveats
+
+- **Lifetime of `msg->payload`**: librdkafka owns the buffer until
+  `rd_kafka_message_destroy()`. We must hold the message alive across the
+  entire `arrow_scan` → `INSERT` window. The C++ consumer wraps the buffer in
+  an `arrow::Buffer` with a custom deleter that calls
+  `rd_kafka_message_destroy()` once Arrow drops its reference. This makes the
+  zero-copy claim defensible.
+- **Buffer alignment**: librdkafka does not align its receive buffer to Arrow's
+  preferred 64-byte boundary. Arrow IPC tolerates this — readers do not assume
+  alignment — but any downstream SIMD kernel that requires alignment would need
+  to copy. DuckDB does its own copy into its column store on `INSERT`, so this
+  doesn't affect the PoC.
+- **`INSERT` materializes**: "zero-copy" here means zero copies in the consumer
+  process up to the point DuckDB takes ownership. DuckDB still copies into its
+  internal storage during `INSERT`, regardless of source format. This is
+  unavoidable and not unique to Arrow IPC.

--- a/experiments/arrow-payload/consumer/CMakeLists.txt
+++ b/experiments/arrow-payload/consumer/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.16)
+project(arrow_consumer CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+add_compile_options(-Wall -Wextra -O2 -DNDEBUG)
+
+# Arrow C++ (record batch reader + C data interface bridge)
+find_package(Arrow REQUIRED)
+
+# librdkafka ships a pkg-config file; use it for the C API
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(RDKAFKA REQUIRED IMPORTED_TARGET rdkafka)
+
+# DuckDB shared library. Headers + libduckdb.so are installed into the
+# Dockerfile.consumer image by the infra agent (/usr/local/include + /usr/local/lib).
+find_library(DUCKDB_LIB duckdb REQUIRED)
+find_path(DUCKDB_INCLUDE_DIR duckdb.h REQUIRED)
+
+add_executable(arrow-consumer main.cpp)
+
+target_include_directories(arrow-consumer PRIVATE ${DUCKDB_INCLUDE_DIR})
+
+target_link_libraries(arrow-consumer
+    PRIVATE
+        Arrow::arrow_shared
+        PkgConfig::RDKAFKA
+        ${DUCKDB_LIB}
+)

--- a/experiments/arrow-payload/consumer/main.cpp
+++ b/experiments/arrow-payload/consumer/main.cpp
@@ -1,0 +1,259 @@
+// arrow-consumer: Kafka (Arrow IPC) -> DuckDB (Arrow C Data Interface) -> DuckLake
+//
+// PoC for experiments/arrow-payload. See ../README.md for the shared contract.
+//
+// Buffer lifetime strategy: Option A (simplest).
+//   librdkafka owns msg->payload until rd_kafka_message_destroy(). We wrap
+//   the buffer in a non-owning arrow::Buffer, feed it through
+//   BufferReader -> RecordBatchStreamReader -> ExportRecordBatchReader
+//   -> duckdb_arrow_scan -> INSERT SELECT, all synchronously in one loop
+//   iteration. rd_kafka_message_destroy() is the LAST call in the iteration,
+//   after DuckDB has fully materialized the batch into its own column store
+//   during INSERT. Defensible zero-copy without Option B's custom subclass.
+
+#include <arrow/api.h>
+#include <arrow/c/bridge.h>
+#include <arrow/io/memory.h>
+#include <arrow/ipc/reader.h>
+
+#include <duckdb.h>
+#include <librdkafka/rdkafka.h>
+
+#include <atomic>
+#include <csignal>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::atomic<int> g_running{1};
+void handle_signal(int) { g_running.store(0); }
+
+const char *env_or(const char *k, const char *fb) {
+    const char *v = std::getenv(k);
+    return (v && *v) ? v : fb;
+}
+std::string env_required(const char *k) {
+    const char *v = std::getenv(k);
+    if (!v || !*v) { std::cerr << "[arrow-consumer] ERROR missing env " << k << "\n"; std::exit(2); }
+    return v;
+}
+void log_err(const std::string &m) { std::cerr << "[arrow-consumer] ERROR " << m << "\n"; }
+
+void duckdb_exec(duckdb_connection con, const std::string &sql) {
+    duckdb_result res;
+    if (duckdb_query(con, sql.c_str(), &res) != DuckDBSuccess) {
+        std::string err = duckdb_result_error(&res) ? duckdb_result_error(&res) : "(null)";
+        duckdb_destroy_result(&res);
+        throw std::runtime_error("duckdb_query failed: " + sql + " : " + err);
+    }
+    duckdb_destroy_result(&res);
+}
+
+void init_ducklake(duckdb_connection con) {
+    // Extensions: httpfs MUST load before ducklake (see AGENT.md).
+    duckdb_exec(con, "LOAD httpfs");
+    duckdb_exec(con, "LOAD ducklake");
+    duckdb_exec(con, "LOAD postgres");
+
+    auto set_opt = [&](const char *key, const char *val, bool quoted) {
+        if (!val || !*val) return;
+        std::string sql = std::string("SET ") + key + "=";
+        sql += quoted ? (std::string("'") + val + "'") : val;
+        duckdb_exec(con, sql);
+    };
+    set_opt("s3_endpoint",          std::getenv("DUCKDB_S3_ENDPOINT"),          true);
+    set_opt("s3_access_key_id",     std::getenv("DUCKDB_S3_ACCESS_KEY_ID"),     true);
+    set_opt("s3_secret_access_key", std::getenv("DUCKDB_S3_SECRET_ACCESS_KEY"), true);
+    set_opt("s3_use_ssl",           env_or("DUCKDB_S3_USE_SSL", "false"),       false);
+    set_opt("s3_url_style",         env_or("DUCKDB_S3_URL_STYLE", "path"),      true);
+
+    // Postgres connstring values are unquoted: any single quote inside would
+    // collide with the SQL string literal that wraps the ATTACH target. The
+    // values in this experiment are alphanumeric (no spaces, no quotes), so
+    // unquoted is safe and avoids the escape rabbit hole entirely.
+    std::string pg = "host=" + env_required("DUCKLAKE_RDS_HOST") +
+                     " port=" + env_or("DUCKLAKE_RDS_PORT", "5432") +
+                     " dbname=" + env_required("DUCKLAKE_RDS_DATABASE") +
+                     " user=" + env_required("DUCKLAKE_RDS_USERNAME") +
+                     " password=" + env_required("DUCKLAKE_RDS_PASSWORD");
+    duckdb_exec(con, "ATTACH 'ducklake:postgres:" + pg + "' AS lake (DATA_PATH '" +
+                         env_required("DUCKLAKE_DATA_PATH") + "')");
+    duckdb_exec(con,
+        "CREATE TABLE IF NOT EXISTS lake.main.events_arrow ("
+        " uuid VARCHAR, event VARCHAR, distinct_id VARCHAR, timestamp VARCHAR,"
+        " team_id BIGINT, project_id BIGINT, properties VARCHAR, elements_chain VARCHAR,"
+        " _inserted_at TIMESTAMP)");
+}
+
+// Open an Arrow IPC stream reader over msg->payload (non-owning, zero-copy).
+// Caller must keep `msg` alive until the returned reader is dropped.
+arrow::Result<std::shared_ptr<arrow::RecordBatchReader>>
+open_ipc_reader(const rd_kafka_message_t *msg) {
+    auto buf = std::make_shared<arrow::Buffer>(
+        static_cast<const uint8_t *>(msg->payload), static_cast<int64_t>(msg->len));
+    auto input = std::make_shared<arrow::io::BufferReader>(buf);
+    ARROW_ASSIGN_OR_RAISE(auto r, arrow::ipc::RecordBatchStreamReader::Open(input));
+    return std::static_pointer_cast<arrow::RecordBatchReader>(r);
+}
+
+void ingest(duckdb_connection con,
+            std::shared_ptr<arrow::RecordBatchReader> reader,
+            const std::string &view) {
+    // Lifetime invariant: c_stream is stack-allocated. It MUST remain live
+    // through both arrow_scan (which only registers the view) AND the INSERT
+    // that drives the lazy arrow_scan pull. Do not split these two calls.
+    ArrowArrayStream c_stream{};
+    auto st = arrow::ExportRecordBatchReader(reader, &c_stream);
+    if (!st.ok()) throw std::runtime_error("ExportRecordBatchReader: " + st.ToString());
+
+    // duckdb_arrow_stream is a typedef'd opaque handle, but at the C ABI
+    // boundary DuckDB does `reinterpret_cast<ArrowArrayStream *>(arrow)` on
+    // its third argument (see duckdb/src/main/capi/arrow-c.cpp). So we hand
+    // it our ArrowArrayStream pointer cast to the typedef. NOT a wrapper
+    // struct — that was a misreading of the typedef and would segfault when
+    // DuckDB called the wrapper's first word as get_schema().
+    if (duckdb_arrow_scan(con, view.c_str(),
+                          reinterpret_cast<duckdb_arrow_stream>(&c_stream)) != DuckDBSuccess) {
+        if (c_stream.release) c_stream.release(&c_stream);
+        throw std::runtime_error("duckdb_arrow_scan failed");
+    }
+    try {
+        duckdb_exec(con, "INSERT INTO lake.main.events_arrow "
+                         "SELECT *, NOW() AS _inserted_at FROM \"" + view + "\"");
+    } catch (...) {
+        duckdb_exec(con, "DROP VIEW IF EXISTS \"" + view + "\"");
+        if (c_stream.release) c_stream.release(&c_stream);
+        throw;
+    }
+    duckdb_exec(con, "DROP VIEW IF EXISTS \"" + view + "\"");
+    if (c_stream.release) c_stream.release(&c_stream);
+}
+
+void commit_offset(rd_kafka_t *rk, const std::string &topic, int32_t part, int64_t off) {
+    rd_kafka_topic_partition_list_t *cpl = rd_kafka_topic_partition_list_new(1);
+    rd_kafka_topic_partition_list_add(cpl, topic.c_str(), part)->offset = off + 1;
+    rd_kafka_resp_err_t err = rd_kafka_commit(rk, cpl, 0 /* sync */);
+    rd_kafka_topic_partition_list_destroy(cpl);
+    if (err != RD_KAFKA_RESP_ERR_NO_ERROR) log_err(std::string("commit: ") + rd_kafka_err2str(err));
+}
+
+}  // namespace
+
+int main() {
+    std::signal(SIGTERM, handle_signal);
+    std::signal(SIGINT, handle_signal);
+
+    std::string brokers = env_required("KAFKA_BOOTSTRAP_SERVERS");
+    std::string topic   = env_or("KAFKA_TOPIC", "test-events-arrow");
+    int partition_count = std::atoi(env_or("KAFKA_PARTITION_COUNT", "8"));
+    if (partition_count <= 0) partition_count = 8;
+
+    duckdb_database db; duckdb_connection con;
+    if (duckdb_open(nullptr, &db) != DuckDBSuccess) { log_err("duckdb_open"); return 1; }
+    if (duckdb_connect(db, &con) != DuckDBSuccess) { log_err("duckdb_connect"); duckdb_close(&db); return 1; }
+    try { init_ducklake(con); }
+    catch (const std::exception &e) {
+        log_err(std::string("ducklake init: ") + e.what());
+        duckdb_disconnect(&con); duckdb_close(&db); return 1;
+    }
+
+    char errstr[512];
+    rd_kafka_conf_t *conf = rd_kafka_conf_new();
+    auto conf_set = [&](const char *k, const char *v) {
+        if (rd_kafka_conf_set(conf, k, v, errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+            log_err(std::string("conf ") + k + ": " + errstr); std::exit(1);
+        }
+    };
+    conf_set("bootstrap.servers", brokers.c_str());
+    conf_set("group.id", env_or("KAFKA_GROUP_ID", "arrow-consumer"));
+    conf_set("enable.auto.commit", "false");
+    conf_set("enable.auto.offset.store", "false");
+    conf_set("auto.offset.reset", "earliest");
+    conf_set("queued.max.messages.kbytes", "16384");
+
+    rd_kafka_t *rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, sizeof(errstr));
+    if (!rk) { log_err(std::string("rd_kafka_new: ") + errstr); return 1; }
+    rd_kafka_poll_set_consumer(rk);
+
+    rd_kafka_topic_partition_list_t *parts = rd_kafka_topic_partition_list_new(partition_count);
+    for (int p = 0; p < partition_count; ++p)
+        rd_kafka_topic_partition_list_add(parts, topic.c_str(), p)->offset = RD_KAFKA_OFFSET_STORED;
+    if (rd_kafka_assign(rk, parts) != RD_KAFKA_RESP_ERR_NO_ERROR) {
+        log_err("rd_kafka_assign"); rd_kafka_topic_partition_list_destroy(parts);
+        rd_kafka_destroy(rk); return 1;
+    }
+    rd_kafka_topic_partition_list_destroy(parts);
+
+    std::cerr << "[arrow-consumer] started brokers=" << brokers
+              << " topic=" << topic << " partitions=" << partition_count << "\n";
+
+    // --- Main loop ---
+    // Lifetime invariant: `msg` MUST outlive all Arrow/DuckDB use of the
+    // payload buffer within each iteration. rd_kafka_message_destroy() is the
+    // last call before looping.
+    uint64_t batch_counter = 0;
+    while (g_running.load()) {
+        rd_kafka_message_t *msg = rd_kafka_consumer_poll(rk, 100);
+        if (!msg) continue;
+
+        if (msg->err) {
+            if (msg->err != RD_KAFKA_RESP_ERR__PARTITION_EOF)
+                log_err(std::string("poll: ") + rd_kafka_message_errstr(msg));
+            rd_kafka_message_destroy(msg);
+            continue;
+        }
+
+        try {
+            auto r = open_ipc_reader(msg);
+            if (!r.ok()) throw std::runtime_error("open ipc: " + r.status().ToString());
+
+            // Drain stream into a batch vector so we can report row counts.
+            // Batches still reference msg->payload (zero-copy borrowed ptrs).
+            // Distinguish "end of stream" (b == nullptr, status ok) from
+            // "decode error" — collapsing them would silently swallow
+            // truncated/corrupt IPC streams and commit past them.
+            std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+            int64_t rows = 0;
+            while (true) {
+                std::shared_ptr<arrow::RecordBatch> b;
+                auto rs = (*r)->ReadNext(&b);
+                if (!rs.ok()) throw std::runtime_error("ReadNext: " + rs.ToString());
+                if (!b) break;  // end of stream
+                rows += b->num_rows();
+                batches.push_back(std::move(b));
+            }
+            if (batches.empty()) { rd_kafka_message_destroy(msg); continue; }
+
+            auto made = arrow::RecordBatchReader::Make(batches, batches.front()->schema());
+            if (!made.ok()) throw std::runtime_error("make reader: " + made.status().ToString());
+
+            std::string view = "arrow_batch_" + std::to_string(batch_counter);
+            ingest(con, *made, view);
+            commit_offset(rk, topic, msg->partition, msg->offset);
+
+            std::cout << "[arrow-consumer] flushed batch " << batch_counter
+                      << " records=" << rows
+                      << " offset=" << msg->offset
+                      << " partition=" << msg->partition << "\n";
+            std::cout.flush();
+            ++batch_counter;
+        } catch (const std::exception &e) {
+            log_err("message p=" + std::to_string(msg->partition) +
+                    " off=" + std::to_string(msg->offset) + ": " + e.what());
+            commit_offset(rk, topic, msg->partition, msg->offset);
+        }
+
+        rd_kafka_message_destroy(msg);  // lifetime invariant: last call
+    }
+
+    std::cerr << "[arrow-consumer] shutting down\n";
+    rd_kafka_consumer_close(rk);
+    rd_kafka_destroy(rk);
+    duckdb_disconnect(&con);
+    duckdb_close(&db);
+    return 0;
+}

--- a/experiments/arrow-payload/docker-compose.yaml
+++ b/experiments/arrow-payload/docker-compose.yaml
@@ -1,0 +1,162 @@
+# Standalone stack for the Arrow-IPC-on-Kafka experiment.
+#
+# Runs independently of the parent docker-compose.yaml. Host ports are shifted
+# to avoid collisions so both stacks can run side-by-side during A/B comparisons.
+#
+#   Parent stack            | This stack
+#   ------------------------|------------------------
+#   postgres  5433:5432     | postgres  5434:5432
+#   minio     9000:9000     | minio     9100:9000
+#   minio     9001:9001     | minio     9101:9001
+#   kafka     (no host port) | kafka     (no host port)
+#
+# Topic: test-events-arrow (8 partitions), separate from the parent `test-events`.
+
+services:
+  # --- Infrastructure ---
+
+  kafka:
+    image: apache/kafka:3.9.0
+    hostname: kafka
+    volumes:
+      # This compose file lives at experiments/arrow-payload/, so the parent
+      # project's test/ directory is two levels up.
+      - ../../test/kafka-server.properties:/opt/kafka/config/kraft/server.properties:ro
+    environment:
+      CLUSTER_ID: millpond-arrow-dev-cluster-001
+      # Allow batched Arrow IPC payloads larger than the 1MB default. PostHog
+      # events with full properties run ~2-5KB each; 1000-record batches push
+      # 2-5MB. Mirror with `max.message.bytes` on the topic and the producer.
+      KAFKA_CFG_MESSAGE_MAX_BYTES: "16777216"
+      KAFKA_CFG_REPLICA_FETCH_MAX_BYTES: "16777216"
+    command: >
+      bash -c "
+      /opt/kafka/bin/kafka-storage.sh format -t $$CLUSTER_ID -c /opt/kafka/config/kraft/server.properties --ignore-formatted &&
+      /opt/kafka/bin/kafka-server-start.sh /opt/kafka/config/kraft/server.properties
+      "
+    healthcheck:
+      test: /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server kafka:9094
+      interval: 5s
+      timeout: 10s
+      retries: 10
+
+  postgres:
+    image: postgres:17
+    hostname: postgres
+    ports:
+      - "127.0.0.1:5434:5432"
+    environment:
+      POSTGRES_USER: ducklake
+      POSTGRES_PASSWORD: ducklake
+      POSTGRES_DB: ducklake
+    healthcheck:
+      test: pg_isready -U ducklake -d ducklake
+      interval: 2s
+      timeout: 5s
+      retries: 5
+    tmpfs:
+      - /var/lib/postgresql/data
+
+  minio:
+    image: minio/minio:latest
+    hostname: minio
+    ports:
+      - "127.0.0.1:9100:9000"
+      - "127.0.0.1:9101:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+      MINIO_PROMETHEUS_AUTH_TYPE: public
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: mc ready local
+      interval: 2s
+      timeout: 5s
+      retries: 5
+
+  minio-init:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minioadmin minioadmin &&
+      mc mb --ignore-existing local/ducklake &&
+      mc anonymous set download local/ducklake
+      "
+
+  # --- Topic Setup ---
+
+  kafka-init:
+    image: apache/kafka:3.9.0
+    depends_on:
+      kafka:
+        condition: service_healthy
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9094 --create --if-not-exists --topic test-events-arrow --partitions 8 --replication-factor 1 --config max.message.bytes=16777216 &&
+        echo "Waiting for consumer group coordinator..." &&
+        for i in $(seq 1 20); do
+          /opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server kafka:9094 --group millpond-arrow-events --describe >/dev/null 2>&1 && echo "Coordinator ready." && break
+          echo "  attempt $i/20..."
+          sleep 1
+        done
+
+  # --- Producer (Python + pyarrow) ---
+
+  producer:
+    build:
+      # Build context is the repo root so the producer Dockerfile can pull in
+      # test/producer.py helpers if it wants to. Dockerfile path is relative
+      # to that context.
+      context: ../..
+      dockerfile: experiments/arrow-payload/Dockerfile.producer
+    depends_on:
+      kafka-init:
+        condition: service_completed_successfully
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9094
+      KAFKA_TOPIC: test-events-arrow
+      KAFKA_PARTITION_COUNT: "8"
+      BATCH_SIZE: "1000"
+      BATCHES_PER_SECOND: "10"
+      TOTAL_BATCHES: "-1"
+
+  # --- Consumer (C++ + librdkafka + Arrow + DuckDB) ---
+
+  arrow-consumer:
+    build:
+      context: .
+      dockerfile: Dockerfile.consumer
+    depends_on:
+      kafka-init:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9094
+      KAFKA_TOPIC: test-events-arrow
+      KAFKA_PARTITION_COUNT: "8"
+      KAFKA_GROUP_ID: millpond-arrow-events
+      DUCKLAKE_TABLE: events_arrow
+      DUCKLAKE_DATA_PATH: s3://ducklake/data
+      DUCKLAKE_RDS_HOST: postgres
+      DUCKLAKE_RDS_PORT: "5432"
+      DUCKLAKE_RDS_DATABASE: ducklake
+      DUCKLAKE_RDS_USERNAME: ducklake
+      DUCKLAKE_RDS_PASSWORD: ducklake
+      DUCKLAKE_CONNECTION: ":memory:"
+      DUCKDB_S3_ENDPOINT: minio:9000
+      DUCKDB_S3_ACCESS_KEY_ID: minioadmin
+      DUCKDB_S3_SECRET_ACCESS_KEY: minioadmin
+      DUCKDB_S3_USE_SSL: "false"
+      DUCKDB_S3_URL_STYLE: path

--- a/experiments/arrow-payload/justfile
+++ b/experiments/arrow-payload/justfile
@@ -1,0 +1,73 @@
+# Arrow IPC on Kafka — C++ consumer experiment
+
+# Default recipe: list all available recipes
+default:
+    @just --list
+
+# === Docker ===
+
+# Build and start the full stack (Kafka, Postgres, MinIO, producer, consumer)
+[group('docker')]
+up:
+    docker compose build
+    docker compose up -d
+
+# Stop the stack and remove volumes
+[group('docker')]
+down:
+    docker compose down -v
+
+# Tail logs from all services
+[group('docker')]
+logs *ARGS:
+    docker compose logs {{ ARGS }}
+
+# Tail consumer logs
+[group('docker')]
+logs-consumer:
+    docker compose logs -f arrow-consumer
+
+# Tail producer logs
+[group('docker')]
+logs-producer:
+    docker compose logs -f producer
+
+# Open the MinIO console (login: minioadmin/minioadmin)
+[group('docker')]
+minio:
+    open http://localhost:9101
+
+# === Build (local, outside Docker) ===
+
+# Configure the CMake build
+[group('build')]
+configure:
+    cmake -B consumer/build -S consumer -DCMAKE_BUILD_TYPE=Release
+
+# Build the consumer binary
+[group('build')]
+build: configure
+    cmake --build consumer/build -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
+
+# Remove local build artifacts
+[group('build')]
+clean:
+    rm -rf consumer/build
+
+# === Inspect ===
+
+# Query record count in DuckLake (requires stack running)
+[group('inspect')]
+count:
+    docker compose exec arrow-consumer sh -c 'duckdb -c " \
+        LOAD httpfs; LOAD ducklake; LOAD postgres; \
+        SET s3_endpoint=\"minio:9000\"; SET s3_access_key_id=\"minioadmin\"; \
+        SET s3_secret_access_key=\"minioadmin\"; SET s3_use_ssl=false; SET s3_url_style=\"path\"; \
+        ATTACH \"ducklake:postgres:host=postgres port=5432 dbname=ducklake user=ducklake password=ducklake\" AS lake; \
+        SELECT count(*) AS total_records FROM lake.main.events_arrow;"'
+
+# Show consumer group lag
+[group('inspect')]
+lag:
+    docker compose exec kafka /opt/kafka/bin/kafka-consumer-groups.sh \
+        --bootstrap-server kafka:9094 --group millpond-arrow-events --describe

--- a/experiments/arrow-payload/producer/arrow_producer.py
+++ b/experiments/arrow-payload/producer/arrow_producer.py
@@ -1,0 +1,237 @@
+"""Arrow IPC producer for the arrow-payload experiment.
+
+Generates PostHog-shaped events using the existing generators in
+``test/producer.py``, packs them into Arrow record batches matching the
+schema in ``experiments/arrow-payload/README.md``, and publishes each
+batch as a single Kafka message whose value is a full Arrow IPC
+*stream* (schema + record batch + EOS).
+
+Why we reuse test/producer.py by import (not copy):
+    The realistic PostHog event generators (pageview, autocapture, etc.)
+    and the carefully tuned weighted mix live in test/producer.py. We
+    do not want to maintain two copies. The Dockerfile puts ``test/`` on
+    PYTHONPATH so ``import producer`` works. The producer module reads
+    a few Kafka env vars at import time (KAFKA_BOOTSTRAP_SERVERS,
+    KAFKA_TOPIC, KAFKA_PARTITION_COUNT) as module-level globals; those
+    globals are only used by producer.main(), which we never call, but
+    they still must be present at import time. We therefore set
+    harmless defaults via os.environ.setdefault BEFORE importing.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+import signal
+import sys
+import time
+
+# --- Stub env vars required at import time by test/producer.py -----------
+# These are only consulted by producer.main() (which we do not call). They
+# must exist so that module-level ``os.environ[...]`` lookups do not raise.
+os.environ.setdefault("KAFKA_BOOTSTRAP_SERVERS", "unused-at-import-time")
+os.environ.setdefault("KAFKA_TOPIC", "unused-at-import-time")
+os.environ.setdefault("KAFKA_PARTITION_COUNT", "1")
+
+import producer as posthog_gen  # noqa: E402  (see stub block above)
+import pyarrow as pa  # noqa: E402
+from confluent_kafka import Producer  # noqa: E402
+
+# -------------------------------------------------------------------------
+# Config
+# -------------------------------------------------------------------------
+
+BOOTSTRAP_SERVERS = os.environ["KAFKA_BOOTSTRAP_SERVERS"]
+# Detect the import-time stub leaking into the runtime config — if the user
+# never set the env var, the setdefault block above installed a sentinel.
+# Fail loudly here rather than letting librdkafka log bogus connect errors.
+if BOOTSTRAP_SERVERS == "unused-at-import-time":
+    raise SystemExit("KAFKA_BOOTSTRAP_SERVERS must be set in the environment")
+TOPIC = os.environ.get("KAFKA_TOPIC", "test-events-arrow")
+BATCH_SIZE = int(os.environ.get("BATCH_SIZE", "1000"))
+BATCHES_PER_SECOND = int(os.environ.get("BATCHES_PER_SECOND", "10"))
+TOTAL_BATCHES = int(os.environ.get("TOTAL_BATCHES", "-1"))
+
+# Arrow schema v1 — MUST match experiments/arrow-payload/README.md.
+SCHEMA = pa.schema(
+    [
+        pa.field("uuid", pa.string()),
+        pa.field("event", pa.string()),
+        pa.field("distinct_id", pa.string()),
+        pa.field("timestamp", pa.string()),
+        pa.field("team_id", pa.int64()),
+        pa.field("project_id", pa.int64()),
+        pa.field("properties", pa.string()),
+        pa.field("elements_chain", pa.string()),
+    ]
+)
+
+log = logging.getLogger("arrow-producer")
+
+
+# -------------------------------------------------------------------------
+# Shutdown handling
+# -------------------------------------------------------------------------
+
+_shutdown = False
+
+
+def _install_signal_handlers() -> None:
+    def _handler(signum, _frame):
+        global _shutdown
+        log.info("received signal %s, shutting down", signum)
+        _shutdown = True
+
+    signal.signal(signal.SIGTERM, _handler)
+    signal.signal(signal.SIGINT, _handler)
+
+
+# -------------------------------------------------------------------------
+# Batch construction
+# -------------------------------------------------------------------------
+
+
+def _build_batch(n: int) -> pa.RecordBatch:
+    """Generate ``n`` events and return an Arrow RecordBatch matching SCHEMA."""
+    uuids: list[str] = []
+    events: list[str] = []
+    distinct_ids: list[str] = []
+    timestamps: list[str] = []
+    team_ids: list[int] = []
+    project_ids: list[int] = []
+    properties: list[str] = []
+    elements_chains: list[str | None] = []
+
+    for i in range(n):
+        ev = posthog_gen.make_event(i)
+        props = ev["properties"]
+
+        # Pull elements_chain out of properties for $autocapture only.
+        # Non-autocapture events have null. We also remove it from the
+        # properties dict before JSON-encoding to avoid duplication.
+        chain: str | None = None
+        if ev["event"] == "$autocapture":
+            chain = props.pop("$elements_chain", None)
+
+        uuids.append(ev["uuid"])
+        events.append(ev["event"])
+        distinct_ids.append(ev["distinct_id"])
+        timestamps.append(ev["timestamp"])
+        team_ids.append(ev["team_id"])
+        project_ids.append(ev["project_id"])
+        # Match Millpond's production approach: JSON-encode the nested
+        # properties dict into a single VARCHAR column. See
+        # millpond/arrow_converter.py::_flatten_nested_to_json.
+        properties.append(json.dumps(props, default=str))
+        elements_chains.append(chain)
+
+    return pa.record_batch(
+        [
+            pa.array(uuids, type=pa.string()),
+            pa.array(events, type=pa.string()),
+            pa.array(distinct_ids, type=pa.string()),
+            pa.array(timestamps, type=pa.string()),
+            pa.array(team_ids, type=pa.int64()),
+            pa.array(project_ids, type=pa.int64()),
+            pa.array(properties, type=pa.string()),
+            pa.array(elements_chains, type=pa.string()),
+        ],
+        schema=SCHEMA,
+    )
+
+
+def _serialize_batch(batch: pa.RecordBatch) -> bytes:
+    """Serialize a RecordBatch as a self-contained Arrow IPC *stream*.
+
+    We intentionally use ``ipc.new_stream`` (not ``new_file``) because the
+    C++ consumer uses ``arrow::ipc::RecordBatchStreamReader`` to wrap the
+    librdkafka payload buffer in place. One Kafka message value contains
+    one full stream: schema + record batch + EOS marker.
+    """
+    sink = io.BytesIO()
+    with pa.ipc.new_stream(sink, SCHEMA) as writer:
+        writer.write_batch(batch)
+    return sink.getvalue()
+
+
+# -------------------------------------------------------------------------
+# Main loop
+# -------------------------------------------------------------------------
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        stream=sys.stdout,
+    )
+    _install_signal_handlers()
+
+    # No producer-side compression: we want raw memcpy semantics in the
+    # C++ consumer. LZ4 can be added later once the zero-copy path is
+    # validated.
+    producer = Producer(
+        {
+            "bootstrap.servers": BOOTSTRAP_SERVERS,
+            "compression.type": "none",
+            "linger.ms": 5,
+            "queue.buffering.max.messages": 1000,
+            "queue.buffering.max.kbytes": 1048576,
+            # 16 MiB. Matches kafka broker `message.max.bytes` and the topic
+            # `max.message.bytes` set in docker-compose.yaml. PostHog events
+            # with full properties batched 1000-at-a-time push ~2-5MB.
+            "message.max.bytes": 16777216,
+        }
+    )
+
+    infinite = TOTAL_BATCHES < 0
+    target_interval = 1.0 / BATCHES_PER_SECOND if BATCHES_PER_SECOND > 0 else 0.0
+    log.info(
+        "starting: topic=%s batch_size=%d batches_per_second=%d total_batches=%s",
+        TOPIC,
+        BATCH_SIZE,
+        BATCHES_PER_SECOND,
+        "infinite" if infinite else str(TOTAL_BATCHES),
+    )
+
+    n = 0
+    while not _shutdown and (infinite or n < TOTAL_BATCHES):
+        loop_start = time.monotonic()
+
+        batch = _build_batch(BATCH_SIZE)
+        payload = _serialize_batch(batch)
+
+        # Let librdkafka round-robin across partitions (no key, no
+        # explicit partition). This matches the contract: partition
+        # assignment is not semantically meaningful for this experiment.
+        producer.produce(TOPIC, value=payload)
+        producer.poll(0)
+
+        n += 1
+        print(
+            f"[arrow-producer] sent batch {n} records={BATCH_SIZE} bytes={len(payload)}",
+            flush=True,
+        )
+
+        if target_interval > 0:
+            elapsed = time.monotonic() - loop_start
+            remaining = target_interval - elapsed
+            if remaining > 0:
+                # Sleep in small slices so SIGTERM is responsive.
+                deadline = time.monotonic() + remaining
+                while not _shutdown:
+                    slice_s = min(0.1, deadline - time.monotonic())
+                    if slice_s <= 0:
+                        break
+                    time.sleep(slice_s)
+
+    log.info("flushing producer")
+    producer.flush(30)
+    log.info("done: sent %d batches", n)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Validates the zero-copy claim from `WICKED_COOL_NEXT_STEPS.md`: a C++ consumer wraps librdkafka's receive buffer in place via `arrow::Buffer(ptr, len)` — no memcpy between Kafka and DuckDB's `arrow_scan`
- Python producer batches PostHog-shaped events into Arrow IPC record batches on the `test-events-arrow` topic
- C++ consumer (~250 LOC): librdkafka poll → Arrow IPC reader → Arrow C Data Interface → DuckDB `arrow_scan` → INSERT into DuckLake
- Standalone docker-compose stack with shifted ports for side-by-side comparison with the parent stack
- Smoke test: 660K records ingested over ~30s, zero crashes, zero data loss

## Smoke-test results (Apple Silicon, 2026-04-12)

| Metric | Value |
|---|---|
| Producer rate (rate-limited) | 10K rec/sec |
| Per-batch wire size | ~1.1 MB |
| Consumer lag | 0 across 8 partitions |
| Arrow IPC → parquet compression | ~3.2× |

## Test plan

- [ ] `cd experiments/arrow-payload && docker compose up --build` — all services healthy, records flowing
- [ ] Consumer logs show `flushed batch` with record counts
- [ ] MinIO console at `:9101` shows parquet files under `ducklake/data/main/events_arrow/`