### PR TITLE
Log millpond version at startup

### DIFF
--- a/millpond/main.py
+++ b/millpond/main.py
@@ -2,6 +2,7 @@ import logging
 import signal
 import sys
 import time
+from importlib.metadata import PackageNotFoundError, version
 
 import pyarrow as pa
 from confluent_kafka import TopicPartition
@@ -121,7 +122,11 @@ def _update_lag_metrics(kafka, tp_offsets):
 
 def main():
     logging_config.setup()
-    log.info("millpond starting")
+    try:
+        __version__ = version("millpond")
+    except PackageNotFoundError:
+        __version__ = "0.0.0+unknown"
+    log.info("millpond %s starting", __version__)
 
     cfg = config.load()
     metrics.init(f"{cfg.topic}-{cfg.ducklake_table}")


### PR DESCRIPTION
## Summary
- Log the package version on startup via `importlib.metadata.version()`
- Version is derived from git tags at build time by hatch-vcs
- Falls back to `0.0.0+unknown` if running from uninstalled source

## Test plan
- [ ] Verify startup log shows `millpond <version> starting` in a deployed pod
- [ ] Verify local `uv run millpond` logs the dev version