### PR TITLE
Fix readiness probe failing on idle topics

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -361,7 +361,7 @@ Prometheus metrics and health checks on port 8000 via a custom `http.server.HTTP
 
 - `GET /metrics` → Prometheus exposition format (via `prometheus_client.generate_latest()`)
 - `GET /healthz` → liveness: 200 if started and last poll within `max_poll_age_s` (300s), 503 otherwise
-- `GET /readyz` → readiness: same as liveness (started + polling). A consumer with no incoming data is still ready — it's sitting in its consume-write loop.
+- `GET /readyz` → readiness: 200 if started and last poll within `max_poll_age_s` (300s), 503 otherwise. A consumer with no incoming data is still ready — it's sitting in its consume-write loop.
 
 ## Toolchain
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -361,7 +361,7 @@ Prometheus metrics and health checks on port 8000 via a custom `http.server.HTTP
 
 - `GET /metrics` → Prometheus exposition format (via `prometheus_client.generate_latest()`)
 - `GET /healthz` → liveness: 200 if started and last poll within `max_poll_age_s` (300s), 503 otherwise
-- `GET /readyz` → readiness: 200 if alive and last flush within `max_flush_age_s` (600s), 503 otherwise. Idle topics (no flush yet) pass readiness.
+- `GET /readyz` → readiness: same as liveness (started + polling). A consumer with no incoming data is still ready — it's sitting in its consume-write loop.
 
 ## Toolchain
 

--- a/millpond/server.py
+++ b/millpond/server.py
@@ -11,9 +11,8 @@ log = logging.getLogger(__name__)
 class _HealthState:
     """Tracks recency of poll and flush for health checks."""
 
-    def __init__(self, max_poll_age_s: float = 300, max_flush_age_s: float = 600):
+    def __init__(self, max_poll_age_s: float = 300):
         self.max_poll_age_s = max_poll_age_s
-        self.max_flush_age_s = max_flush_age_s
         self._last_poll: float = 0
         self._last_flush: float = 0
         self._started: bool = False
@@ -39,15 +38,14 @@ class _HealthState:
         return (now - self._last_poll) < self.max_poll_age_s
 
     def is_ready(self) -> bool:
-        """Readiness: is the process healthy and keeping up?"""
-        if not self.is_alive():
-            return False
-        # Only check flush recency if at least one flush has occurred.
-        # Idle topics with no messages should not fail readiness for not flushing.
-        if self._has_flushed:
-            now = time.monotonic()
-            return (now - self._last_flush) < self.max_flush_age_s
-        return True
+        """Readiness: is the process started and actively polling?
+
+        A consumer with no incoming data is still ready — it's sitting in its
+        consume-write loop waiting for messages.  Flush recency is not checked
+        because topics can legitimately receive no data for extended periods
+        (e.g. during ingestion cutover).
+        """
+        return self.is_alive()
 
     def is_healthy(self) -> bool:
         """Backward-compatible: same as is_ready()."""

--- a/millpond/server.py
+++ b/millpond/server.py
@@ -41,7 +41,7 @@ class _HealthState:
         """Readiness: is the process started and actively polling?
 
         A consumer with no incoming data is still ready — it's sitting in its
-        consume-write loop waiting for messages.  Flush recency is not checked
+        consume-write loop waiting for messages. Flush recency is not checked
         because topics can legitimately receive no data for extended periods
         (e.g. during ingestion cutover).
         """

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -26,49 +26,42 @@ class TestLiveness:
         h.record_poll()
         assert h.is_alive()
 
-    def test_liveness_ignores_flush(self):
-        """Liveness doesn't care about flush recency."""
-        h = _HealthState(max_flush_age_s=0.01)
-        h.mark_started()
-        h.record_flush()
-        time.sleep(0.02)
-        h.record_poll()
-        assert h.is_alive()
-
 
 class TestReadiness:
+    """Readiness = liveness = started + actively polling.
+
+    Flush state is irrelevant — a consumer with no incoming data is still
+    ready as long as it's in its consume-write loop.
+    """
+
     def test_not_started(self):
         h = _HealthState()
         assert not h.is_ready()
 
-    def test_started_no_flush(self):
+    def test_started(self):
         h = _HealthState()
         h.mark_started()
         assert h.is_ready()
 
-    def test_idle_topic_stays_ready(self):
-        """Pod with no messages (no flush ever) stays ready as long as polling."""
-        h = _HealthState(max_flush_age_s=0.01)
+    def test_stale_poll_not_ready(self):
+        h = _HealthState(max_poll_age_s=0.01)
         h.mark_started()
         time.sleep(0.02)
+        assert not h.is_ready()
+
+    def test_ready_without_any_flush(self):
+        """Idle topic — no messages, no flush ever."""
+        h = _HealthState()
+        h.mark_started()
         h.record_poll()
         assert h.is_ready()
 
-    def test_stale_flush_after_first_flush(self):
-        """Once a flush has occurred, stale flush marks not ready."""
-        h = _HealthState(max_flush_age_s=0.01)
+    def test_ready_despite_past_flush(self):
+        """Consumer was active, data stopped. Still ready as long as polling."""
+        h = _HealthState()
         h.mark_started()
         h.record_flush()
-        time.sleep(0.02)
         h.record_poll()
-        assert not h.is_ready()
-
-    def test_flush_refreshes(self):
-        h = _HealthState(max_flush_age_s=0.05)
-        h.mark_started()
-        h.record_flush()
-        time.sleep(0.03)
-        h.record_flush()
         assert h.is_ready()
 
 


### PR DESCRIPTION
## Summary

Readiness probe returns 503 after 600s with no data, causing k8s to remove consumers from service during ingestion cutover. A consumer sitting in its consume-write loop polling for messages is ready regardless of flush recency.

## Changes

- `server.py`: `is_ready()` now delegates to `is_alive()` (started + polling within 300s). Removed dead `max_flush_age_s` parameter.
- `tests/unit/test_server.py`: Removed vestigial sleeps from readiness tests, added `test_stale_poll_not_ready` and `test_ready_despite_past_flush`.
- `AGENT.md`: Updated readiness probe documentation.

## Rollback

Revert this PR.