### PR TITLE
Add tiered compaction recipes

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -24,7 +24,9 @@ Prefer fixup commits over amending and force-pushing.
 
 ## Maintenance Tooling
 
-`tools/maintenance.py` is a self-contained Python script for DuckLake maintenance operations (snapshot expiry, file cleanup, orphan deletion, checkpoint). It connects to DuckLake using the same env vars as the main app (`DUCKLAKE_RDS_*`, `DUCKDB_S3_*`, `DUCKLAKE_DATA_PATH`) but does not import from the `millpond` package. Designed to run as a K8s CronJob reusing the same Docker image.
+`tools/maintenance.py` is a self-contained Python script for DuckLake maintenance operations (snapshot expiry, file cleanup, orphan deletion, checkpoint, tiered compaction). It connects to DuckLake using the same env vars as the main app (`DUCKLAKE_RDS_*`, `DUCKDB_S3_*`, `DUCKLAKE_DATA_PATH`) but does not import from the `millpond` package. Designed to run as a K8s CronJob reusing the same Docker image.
+
+The `compact` subcommand implements tiered compaction: each tier wraps `ducklake_merge_adjacent_files()` with a save/restore of the catalog's `target_file_size` option (which `ducklake_set_option` writes durably and cannot be unset). Tier specs and the steady-state default live in `TIERS` and `DEFAULT_TARGET_FILE_SIZE` at the top of the file. Bin semantics on DuckLake 1.4.x are `min_file_size` inclusive, `max_file_size` exclusive — so the tier ranges `[0, 1 MiB)`, `[1 MiB, 10 MiB)`, `[10 MiB, 64 MiB)` partition the file-size space without overlap.
 
 If `PUSHGATEWAY_URL` is set, the script pushes two metrics: `maintenance_start_time{operation}` (pushed immediately on start) and `maintenance_duration_seconds{operation, status}` (pushed on completion). This enables Grafana annotation queries for maintenance windows.
 

--- a/README.md
+++ b/README.md
@@ -225,11 +225,22 @@ At peak (9.5K/partition), the size trigger fires at ~35s producing ~320MB object
 
 ### When to add a merge job
 
-If your volume is low enough that time-triggered flushes produce <10MB objects, consider running `ducklake_merge_adjacent_files()` periodically to compact small files:
+If your volume is low enough that time-triggered flushes produce <10MB objects, run periodic compaction. The `compact` subcommand implements a tiered strategy: small files merge frequently into medium files, medium files merge less often into large files. Each tier saves and restores the catalog's `target_file_size` so running one tier doesn't permanently change file sizing for inserts or other compactions.
 
-```sql
-CALL ducklake_merge_adjacent_files('lake', 'events');
+```bash
+just compact-to-tier-1-dry-run        # preview: files <1 MiB → ~5 MiB
+just compact-to-tier-1                # execute (catalog-wide)
+just compact-to-tier-2 events         # tier 1->2, scoped to one table
+just compact-probe events 4           # diagnostic: merge up to 4 adjacent files in 'events'
 ```
+
+Tier ranges (verified semantics: `min_file_size` inclusive, `max_file_size` exclusive):
+
+| Recipe | Input range | Target |
+|---|---|---|
+| `compact-to-tier-1` | `[0, 1 MiB)` | ~5 MiB |
+| `compact-to-tier-2` | `[1 MiB, 10 MiB)` | ~32 MiB |
+| `compact-to-tier-3` | `[10 MiB, 64 MiB)` | ~128 MiB |
 
 This is an out-of-band maintenance operation, not part of the hot path.
 

--- a/tools/justfile
+++ b/tools/justfile
@@ -14,57 +14,113 @@ s3_key := env("DUCKDB_S3_ACCESS_KEY_ID", "")
 s3_secret := env("DUCKDB_S3_SECRET_ACCESS_KEY", "")
 data_path := env("DUCKLAKE_DATA_PATH", "")
 
-_setup := "INSTALL httpfs; INSTALL ducklake; INSTALL postgres; LOAD httpfs; LOAD ducklake; LOAD postgres; SET s3_region = '" + s3_region + "'; SET s3_endpoint = 's3." + s3_region + ".amazonaws.com'; SET s3_access_key_id = '" + s3_key + "'; SET s3_secret_access_key = '" + s3_secret + "'; SET s3_use_ssl = true; SET s3_url_style = 'vhost'; ATTACH 'postgres:host=" + rds_host + " port=" + rds_port + " dbname=" + rds_db + " user=" + rds_user + " password=" + rds_password + "' AS lake (TYPE ducklake, DATA_PATH '" + data_path + "'); USE lake;"
+_setup := "INSTALL httpfs; INSTALL ducklake; INSTALL postgres; LOAD httpfs; LOAD ducklake; LOAD postgres; SET pg_debug_show_queries = true; SET s3_region = '" + s3_region + "'; SET s3_endpoint = 's3." + s3_region + ".amazonaws.com'; SET s3_access_key_id = '" + s3_key + "'; SET s3_secret_access_key = '" + s3_secret + "'; SET s3_use_ssl = true; SET s3_url_style = 'vhost'; ATTACH 'postgres:host=" + rds_host + " port=" + rds_port + " dbname=" + rds_db + " user=" + rds_user + " password=" + rds_password + "' AS lake (TYPE ducklake, DATA_PATH '" + data_path + "'); USE lake;"
 
 maintenance := env("MAINTENANCE_SCRIPT", "/app/tools/maintenance.py")
 
 default:
     @just --list
 
+# ----------------------------------------------------------------------------
+# interactive
+# ----------------------------------------------------------------------------
+
 # Open an interactive DuckDB shell connected to the DuckLake
+[group('interactive')]
 shell:
     {{ duckdb }} -cmd "{{ _setup }}"
 
 # Drop a table
+[group('interactive')]
 drop table:
     {{ duckdb }} -c "{{ _setup }} DROP TABLE lake.{{ table }};"
 
+# ----------------------------------------------------------------------------
+# snapshot + file lifecycle
+# ----------------------------------------------------------------------------
+
 # Expire snapshots (dry run)
+[group('lifecycle')]
 expire-dry-run days="7":
     python {{ maintenance }} expire --days {{ days }} --dry-run
 
 # Expire snapshots
+[group('lifecycle')]
 expire days="7":
     python {{ maintenance }} expire --days {{ days }}
 
 # Preview files scheduled for deletion
+[group('lifecycle')]
 cleanup-dry-run days="1":
     python {{ maintenance }} cleanup --days {{ days }} --dry-run
 
 # Delete files scheduled for deletion
+[group('lifecycle')]
 cleanup days="1":
     python {{ maintenance }} cleanup --days {{ days }}
 
 # Delete all files scheduled for deletion regardless of age
+[group('lifecycle')]
 cleanup-all:
     python {{ maintenance }} cleanup-all
 
 # Preview orphaned files
+[group('lifecycle')]
 orphans-dry-run:
     python {{ maintenance }} orphans --dry-run
 
 # Delete orphaned files
+[group('lifecycle')]
 orphans:
     python {{ maintenance }} orphans
 
 # Full maintenance: expire snapshots + cleanup files
+[group('lifecycle')]
 maintain days="7":
     python {{ maintenance }} maintain --days {{ days }}
 
 # Full maintenance dry run
+[group('lifecycle')]
 maintain-dry-run days="7":
     python {{ maintenance }} maintain --days {{ days }} --dry-run
 
 # Run CHECKPOINT (integrated merge + expire + cleanup)
+[group('lifecycle')]
 checkpoint:
     python {{ maintenance }} checkpoint
+
+# ----------------------------------------------------------------------------
+# tiered compaction
+# ----------------------------------------------------------------------------
+
+# Probe: merge up to a few adjacent files in one table (no target_file_size change)
+[group('compaction')]
+compact-probe table="events" max_compacted_files="2":
+    {{ duckdb }} -c "{{ _setup }} CALL ducklake_merge_adjacent_files('lake', '{{ table }}', max_compacted_files => {{ max_compacted_files }});"
+
+# Tier 0 -> Tier 1: merge files < 1 MiB into ~5 MiB files
+[group('compaction')]
+compact-to-tier-1 table="":
+    python {{ maintenance }} compact --tier 1 --table "{{ table }}"
+
+[group('compaction')]
+compact-to-tier-1-dry-run table="":
+    python {{ maintenance }} compact --tier 1 --table "{{ table }}" --dry-run
+
+# Tier 1 -> Tier 2: merge files in [1 MiB, 10 MiB) into ~32 MiB files
+[group('compaction')]
+compact-to-tier-2 table="":
+    python {{ maintenance }} compact --tier 2 --table "{{ table }}"
+
+[group('compaction')]
+compact-to-tier-2-dry-run table="":
+    python {{ maintenance }} compact --tier 2 --table "{{ table }}" --dry-run
+
+# Tier 2 -> Tier 3: merge files in [10 MiB, 64 MiB) into ~128 MiB files
+[group('compaction')]
+compact-to-tier-3 table="":
+    python {{ maintenance }} compact --tier 3 --table "{{ table }}"
+
+[group('compaction')]
+compact-to-tier-3-dry-run table="":
+    python {{ maintenance }} compact --tier 3 --table "{{ table }}" --dry-run

--- a/tools/maintenance.py
+++ b/tools/maintenance.py
@@ -18,6 +18,7 @@ Optional:
 from __future__ import annotations
 
 import argparse
+import contextlib
 import logging
 import os
 import re
@@ -30,6 +31,23 @@ from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
 log = logging.getLogger("maintenance")
 
 _SETTING_VALUE_RE = re.compile(r"^[a-zA-Z0-9_.:/\-@+=]+$")
+
+# Tiered compaction spec.
+# Bin semantics on DuckLake 1.4.x: min_file_size is inclusive, max_file_size is
+# exclusive — verified empirically. Files at exactly the boundary fall into the
+# higher tier. Targets are MiB (binary) so they line up with the byte literals.
+_MIB = 1024 * 1024
+TIERS = {
+    1: {"min": None, "max": 1 * _MIB, "target": "5MiB"},  # < 1 MiB    -> ~5 MiB
+    2: {"min": 1 * _MIB, "max": 10 * _MIB, "target": "32MiB"},  # [1, 10) MiB -> ~32 MiB
+    3: {"min": 10 * _MIB, "max": 64 * _MIB, "target": "128MiB"},  # [10, 64) MiB -> ~128 MiB
+}
+
+# DuckLake's `ducklake_set_option('target_file_size', ...)` persists in the
+# catalog across sessions and cannot be unset (NULL is rejected). When the
+# option was unset before we touched it, restore to this documented default
+# rather than leaving the catalog at whatever the last tier set.
+DEFAULT_TARGET_FILE_SIZE = "128MiB"
 
 
 def _setup_logging(verbose: bool = False) -> None:
@@ -92,6 +110,7 @@ def connect() -> duckdb.DuckDBPyConnection:
     conn.execute("LOAD httpfs")
     conn.execute("LOAD ducklake")
     conn.execute("LOAD postgres")
+    conn.execute("SET pg_debug_show_queries = true")
 
     rds_host = _require("DUCKLAKE_RDS_HOST")
     rds_port = os.environ.get("DUCKLAKE_RDS_PORT", "5432")
@@ -152,9 +171,7 @@ def cleanup_all(conn: duckdb.DuckDBPyConnection, dry_run: bool) -> None:
         log.info("cleanup-all has no dry-run mode; skipping")
         return
     log.info("Cleaning up all files scheduled for deletion")
-    result = conn.execute(
-        "CALL ducklake_cleanup_old_files('lake', cleanup_all => true)"
-    ).fetchall()
+    result = conn.execute("CALL ducklake_cleanup_old_files('lake', cleanup_all => true)").fetchall()
     for row in result:
         log.info("cleanup-all: %s", row)
 
@@ -162,10 +179,7 @@ def cleanup_all(conn: duckdb.DuckDBPyConnection, dry_run: bool) -> None:
 def orphans(conn: duckdb.DuckDBPyConnection, dry_run: bool) -> None:
     """Find and delete orphaned S3 files."""
     log.info("Deleting orphaned files (dry_run=%s)", dry_run)
-    result = conn.execute(
-        f"CALL ducklake_delete_orphaned_files('lake', "
-        f"dry_run => {str(dry_run).lower()})"
-    ).fetchall()
+    result = conn.execute(f"CALL ducklake_delete_orphaned_files('lake', dry_run => {str(dry_run).lower()})").fetchall()
     for row in result:
         log.info("orphans: %s", row)
 
@@ -181,6 +195,81 @@ def maintain(conn: duckdb.DuckDBPyConnection, days: int, dry_run: bool) -> None:
     """Full maintenance: expire snapshots then cleanup files."""
     expire(conn, days, dry_run)
     cleanup(conn, days, dry_run)
+
+
+@contextlib.contextmanager
+def _scoped_target_file_size(conn: duckdb.DuckDBPyConnection, value: str):
+    """Set target_file_size for the body, restore prior value (or default) on exit."""
+    _sanitize_setting_value(value)
+    prior = conn.execute("SELECT value FROM ducklake_options('lake') WHERE option_name = 'target_file_size'").fetchone()
+    conn.execute(f"CALL ducklake_set_option('lake', 'target_file_size', '{value}')")
+    try:
+        yield
+    finally:
+        restore = prior[0] if prior else DEFAULT_TARGET_FILE_SIZE
+        _sanitize_setting_value(restore)
+        conn.execute(f"CALL ducklake_set_option('lake', 'target_file_size', '{restore}')")
+        log.info("target_file_size restored to %s", restore)
+
+
+def compact(
+    conn: duckdb.DuckDBPyConnection,
+    tier: int,
+    table: str | None,
+    dry_run: bool,
+) -> None:
+    """Compact files in tier N (1, 2, or 3) for the catalog or one table."""
+    spec = TIERS[tier]
+    min_b, max_b, target = spec["min"], spec["max"], spec["target"]
+    scope = f"table '{table}'" if table else "catalog-wide"
+    range_str = f"[{min_b or 0}, {max_b}) bytes"
+    log.info(
+        "Compact tier %d (%s): merge files %s into ~%s targets (dry_run=%s)",
+        tier,
+        scope,
+        range_str,
+        target,
+        dry_run,
+    )
+
+    where = ["end_snapshot IS NULL", f"file_size_bytes < {max_b}"]
+    if min_b is not None:
+        where.append(f"file_size_bytes >= {min_b}")
+    if table:
+        if not _SETTING_VALUE_RE.match(table):
+            raise ValueError(f"Illegal character in table name: {table!r}")
+        where.append(
+            f"table_id IN (SELECT table_id FROM __ducklake_metadata_lake.ducklake_table WHERE table_name = '{table}')"
+        )
+    candidate_count, candidate_bytes = conn.execute(
+        f"SELECT COUNT(*), COALESCE(SUM(file_size_bytes), 0) "
+        f"FROM __ducklake_metadata_lake.ducklake_data_file WHERE {' AND '.join(where)}"
+    ).fetchone()
+    log.info(
+        "compact tier-%d candidates: %d files, %d bytes total",
+        tier,
+        candidate_count,
+        candidate_bytes,
+    )
+
+    if dry_run:
+        return
+    if candidate_count == 0:
+        log.info("compact tier-%d: nothing to do, skipping merge", tier)
+        return
+
+    args = [f"max_file_size => {max_b}"]
+    if min_b is not None:
+        args.append(f"min_file_size => {min_b}")
+    if table:
+        sql = f"CALL ducklake_merge_adjacent_files('lake', '{table}', {', '.join(args)})"
+    else:
+        sql = f"CALL ducklake_merge_adjacent_files('lake', {', '.join(args)})"
+
+    with _scoped_target_file_size(conn, target):
+        result = conn.execute(sql).fetchall()
+    for row in result:
+        log.info("compact tier-%d: %s", tier, row)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -217,6 +306,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     # checkpoint
     sub.add_parser("checkpoint", help="CHECKPOINT (merge + expire + cleanup)")
+
+    # compact
+    p = sub.add_parser("compact", help="Tiered compaction (merge small files into larger ones)")
+    p.add_argument("--tier", type=int, choices=[1, 2, 3], required=True)
+    p.add_argument("--table", default="", help="Limit to one table; empty = catalog-wide")
+    p.add_argument("--dry-run", action="store_true")
 
     return parser
 
@@ -274,6 +369,8 @@ def main(argv: list[str] | None = None) -> None:
                 maintain(conn, args.days, args.dry_run)
             case "checkpoint":
                 checkpoint(conn)
+            case "compact":
+                compact(conn, args.tier, args.table or None, args.dry_run)
     except Exception:
         status = "error"
         log.exception("Maintenance operation %s failed", operation)


### PR DESCRIPTION
## Summary

Adds tiered compaction recipes following the DuckLake-recommended three-tier strategy, plus a per-table `compact-probe` diagnostic.

| Recipe | Input range | Target |
|---|---|---|
| `compact-to-tier-1` | files `< 1 MiB` | `~5 MiB` |
| `compact-to-tier-2` | files in `[1 MiB, 10 MiB)` | `~32 MiB` |
| `compact-to-tier-3` | files in `[10 MiB, 64 MiB)` | `~128 MiB` |
| `compact-probe` | up to `max_compacted_files` adjacent files in one table | (uses current catalog `target_file_size`) |

Each tier accepts an optional `table=` arg (empty = catalog-wide) and has a `*-dry-run` sibling.

## Why this isn't a one-liner

`ducklake_set_option('target_file_size', ...)` is **durable** in the catalog, applies to **both inserts and compactions**, and **cannot be unset** (NULL is rejected). The naive recipe — `set_option(...); merge_adjacent_files(...)` from the DuckLake docs — silently leaves the catalog at whatever the last tier set, permanently changing file sizing for subsequent inserts. The `compact` subcommand wraps each tier in a save/restore. If no prior value was set, restore falls back to a documented 128 MiB default.

DuckDB 1.4.x has no `dry_run` parameter on `ducklake_merge_adjacent_files` and no per-call `target_file_size`, so:
- Dry-run reports candidate count + total bytes via a metadata query against `__ducklake_metadata_lake.ducklake_data_file`.
- Save/restore is the only path to non-destructive tier compaction.

## Other changes

- `[group(...)]` attributes split the justfile into `interactive` / `lifecycle` / `compaction` sections.
- `SET pg_debug_show_queries = true` added to both the justfile `_setup` prelude and `maintenance.py`'s `connect()` for easier debugging.
- README + AGENT.md updated.

## Verification

Empirical (on duckdb 1.4.4 + ducklake extension):
- `min_file_size` is inclusive, `max_file_size` is exclusive — tier ranges partition the file-size space without overlap.
- E2E: 15 small files merged into 1 via `compact tier-1 --table events`; `target_file_size` restored to `128MiB` after the operation; subsequent tier-2 with 0 candidates correctly skips the merge call.

## Test plan

- [ ] `just compact-probe events 2` against a real cluster to confirm prelude SQL parses with the new `pg_debug_show_queries` line
- [ ] `just compact-to-tier-1-dry-run` against the dev cluster — confirm candidate counts look reasonable
- [ ] `just compact-to-tier-1` against the dev cluster — confirm `target_file_size` ends at the expected value (read via `SELECT value FROM ducklake_options('lake') WHERE option_name = 'target_file_size'`)
- [ ] `just --list` renders the three groups