### PR TITLE
ducklake-metrics: track catalog format version

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Built-in queries:
 | `ducklake_compaction_candidates` | `tier` (`tier1` / `tier2` / `tier3` / `large` / `total`) | `count` | `ducklake_data_file` |
 | `ducklake_snapshots` | — | `count`, `oldest_seconds_ago`, `newest_seconds_ago` | `ducklake_snapshot` |
 | `ducklake_files_per_partition_top20` | `partition` | `count` | `ducklake_data_file` ⨝ `ducklake_file_partition_value` |
+| `ducklake_catalog` | `suffix` | `format_version` | `ducklake_metadata` (key=`version`); numeric `major.minor` lands in the value, any trailing tag (e.g. `-dev1`, `-rc7`) lands in the `suffix` label so dev/pre-release builds stay distinguishable. Empty `suffix=""` for clean releases |
 
 Plus self-metrics: `ducklake_metrics_up`, `ducklake_metrics_query_duration_seconds{query}`, `ducklake_metrics_query_last_success_timestamp{query}`, `ducklake_metrics_query_errors_total{query}`.
 

--- a/tests/integration/test_ducklake_metrics_integration.py
+++ b/tests/integration/test_ducklake_metrics_integration.py
@@ -62,6 +62,10 @@ def _stub_full_catalog(c: duckdb.DuckDBPyConnection) -> None:
     c.execute(
         "CREATE TABLE __ducklake_metadata_lake.ducklake_files_scheduled_for_deletion (path TEXT)"
     )
+    c.execute(
+        "CREATE TABLE __ducklake_metadata_lake.ducklake_metadata ("
+        "key VARCHAR, value VARCHAR, scope VARCHAR, scope_id BIGINT)"
+    )
     # Seed: enough rows that every metric has a non-zero value.
     c.execute(
         "INSERT INTO __ducklake_metadata_lake.ducklake_data_file VALUES "
@@ -82,6 +86,10 @@ def _stub_full_catalog(c: duckdb.DuckDBPyConnection) -> None:
     c.execute(
         "INSERT INTO __ducklake_metadata_lake.ducklake_files_scheduled_for_deletion "
         "VALUES ('s3://b/x'), ('s3://b/x'), ('s3://b/y')"
+    )
+    c.execute(
+        "INSERT INTO __ducklake_metadata_lake.ducklake_metadata "
+        "VALUES ('version', '0.4', NULL, NULL)"
     )
 
 
@@ -175,6 +183,8 @@ class TestDaemonHTTP:
                     "ducklake_snapshots_newest_seconds_ago",
                     # b6
                     "ducklake_files_per_partition_top20_count",
+                    # catalog version
+                    "ducklake_catalog_format_version",
                     # self-metrics
                     "ducklake_metrics_up",
                     "ducklake_metrics_query_duration_seconds",

--- a/tests/unit/test_ducklake_metrics.py
+++ b/tests/unit/test_ducklake_metrics.py
@@ -307,6 +307,10 @@ def _stub_catalog(conn):
         "CREATE TABLE __ducklake_metadata_lake.ducklake_snapshot ("
         "snapshot_id BIGINT, snapshot_time VARCHAR, schema_version BIGINT)"
     )
+    conn.execute(
+        "CREATE TABLE __ducklake_metadata_lake.ducklake_metadata ("
+        "key VARCHAR, value VARCHAR, scope VARCHAR, scope_id BIGINT)"
+    )
 
 
 def _builtin(name):
@@ -467,6 +471,112 @@ class TestBuiltinFilesPerPartitionTop20:
         dm._run_query(conn, q, gauges[q.name], sm)
 
         assert _gauge_value(registry, "ducklake_files_per_partition_top20_count", {"partition": "2026/05-01"}) == 1
+
+
+class TestBuiltinCatalog:
+    """ducklake_metadata.value (VARCHAR) parses to a numeric format-version gauge."""
+
+    def _seed(self, conn, version: str):
+        conn.execute(
+            "INSERT INTO __ducklake_metadata_lake.ducklake_metadata VALUES "
+            f"('version', '{version}', NULL, NULL),"
+            "('created_by', 'DuckDB testfixture', NULL, NULL),"
+            "('encrypted', 'false', NULL, NULL)"
+        )
+
+    @pytest.mark.parametrize(
+        "version,expected_value,expected_suffix",
+        [
+            # Released versions seen in DuckLake's MigrateV0X / V10 paths.
+            ("0.3", 0.3, ""),
+            ("0.4", 0.4, ""),
+            ("1.0", 1.0, ""),
+            # Dev tag currently on DuckLake main (after MigrateV10): the
+            # leading numeric portion lands in the gauge value, the rest
+            # in the `suffix` label so dashboards can flag dev builds
+            # without losing PromQL ordering.
+            ("1.1-dev1", 1.1, "-dev1"),
+            # Hypothetical future shapes — don't be brittle to whatever
+            # -rcN / -betaN convention DuckLake settles on.
+            ("2.0-rc7", 2.0, "-rc7"),
+            ("2.0-beta", 2.0, "-beta"),
+        ],
+    )
+    def test_parses_each_known_version(self, conn, registry, version, expected_value, expected_suffix):
+        _stub_catalog(conn)
+        self._seed(conn, version)
+        q = _builtin("ducklake_catalog")
+        gauges = dm._build_query_gauges([q], registry=registry)
+        sm = dm._build_self_metrics(registry=registry)
+        dm._run_query(conn, q, gauges[q.name], sm)
+
+        assert (
+            _gauge_value(registry, "ducklake_catalog_format_version", {"suffix": expected_suffix})
+            == expected_value
+        )
+
+    def test_ignores_other_metadata_keys(self, conn, registry):
+        # The query filters on key='version' AND scope IS NULL. Other keys
+        # (created_by, data_path, encrypted) and any future scoped rows
+        # must not bleed into the metric.
+        _stub_catalog(conn)
+        self._seed(conn, "0.4")
+        q = _builtin("ducklake_catalog")
+        gauges = dm._build_query_gauges([q], registry=registry)
+        sm = dm._build_self_metrics(registry=registry)
+        dm._run_query(conn, q, gauges[q.name], sm)
+
+        assert _gauge_value(registry, "ducklake_catalog_format_version", {"suffix": ""}) == 0.4
+
+    def test_pure_junk_version_raises_through_error_path(self, conn, registry):
+        # The major.minor regex is intentionally permissive about the suffix
+        # (it strips '-dev1', '-rc7', etc.) but a pure-junk value with no
+        # leading digits has no useful numeric reading. Let CAST raise and
+        # land in the error path so operators see the dashboard go stale
+        # plus a non-zero error counter — better than silently coalescing.
+        _stub_catalog(conn)
+        conn.execute(
+            "INSERT INTO __ducklake_metadata_lake.ducklake_metadata VALUES "
+            "('version', 'totally-not-a-version', NULL, NULL)"
+        )
+        q = _builtin("ducklake_catalog")
+        gauges = dm._build_query_gauges([q], registry=registry)
+        sm = dm._build_self_metrics(registry=registry)
+        dm._run_query(conn, q, gauges[q.name], sm)
+
+        assert (
+            _gauge_value(registry, "ducklake_metrics_query_errors_total", {"query": "ducklake_catalog"}) == 1
+        )
+
+    def test_label_clears_on_upgrade(self, conn, registry):
+        # When a lake upgrades from a release ('') to a dev tag ('-dev1'),
+        # the previous {suffix=""} time series must clear so dashboards
+        # don't see two simultaneous "current versions". Relies on the
+        # scheduler's clear-and-set on labeled gauges.
+        _stub_catalog(conn)
+        q = _builtin("ducklake_catalog")
+        gauges = dm._build_query_gauges([q], registry=registry)
+        sm = dm._build_self_metrics(registry=registry)
+
+        self._seed(conn, "1.0")
+        dm._run_query(conn, q, gauges[q.name], sm)
+        assert _gauge_value(registry, "ducklake_catalog_format_version", {"suffix": ""}) == 1.0
+
+        conn.execute("DELETE FROM __ducklake_metadata_lake.ducklake_metadata WHERE key = 'version'")
+        conn.execute(
+            "INSERT INTO __ducklake_metadata_lake.ducklake_metadata VALUES "
+            "('version', '1.1-dev1', NULL, NULL)"
+        )
+        dm._run_query(conn, q, gauges[q.name], sm)
+        assert _gauge_value(registry, "ducklake_catalog_format_version", {"suffix": "-dev1"}) == 1.1
+        assert _gauge_value(registry, "ducklake_catalog_format_version", {"suffix": ""}) is None
+
+    def test_interval_is_60_minutes(self):
+        # Catalog version changes only on a DuckLake upgrade — there's no
+        # value polling it more often, and any human-noticeable change
+        # window is far longer than 60 minutes anyway.
+        q = _builtin("ducklake_catalog")
+        assert q.interval_seconds == 60 * 60
 
 
 # ---------------------------------------------------------------------------

--- a/tools/README.md
+++ b/tools/README.md
@@ -85,6 +85,7 @@ Built-in queries (lake-wide; no `table_name` label by design):
 | `ducklake_compaction_candidates` | `tier` | `count` | `ducklake_data_file`; tier buckets match `maintenance.py`'s `TIERS` (`tier1` < 1 MiB, `tier2` [1, 10) MiB, `tier3` [10, 64) MiB, `large` ≥ 64 MiB, plus `total`) |
 | `ducklake_snapshots` | — | `count`, `oldest_seconds_ago`, `newest_seconds_ago` | `ducklake_snapshot`; CASTs `snapshot_time` (VARCHAR) to TIMESTAMPTZ before time arithmetic |
 | `ducklake_files_per_partition_top20` | `partition` | `count` | Composite partition values joined with `/`; live files without partition_value rows surface as `<none>` |
+| `ducklake_catalog` | `suffix` | `format_version` | `ducklake_metadata` row with `key='version'` and `scope IS NULL`. Numeric `major.minor` (extracted via `regexp_extract`) lands in the gauge value; any trailing tag DuckLake attaches (`-dev1` on main after `MigrateV10`, future `-rcN`/`-betaN` shapes) lands in the `suffix` label. Empty `suffix=""` for clean releases. Polled every 60 minutes — value changes only on a DuckLake upgrade |
 
 Self-metrics (always on):
 

--- a/tools/ducklake_metrics.py
+++ b/tools/ducklake_metrics.py
@@ -151,6 +151,25 @@ queries:
       GROUP BY partition
       ORDER BY count DESC
       LIMIT 20
+
+  - name: ducklake_catalog
+    help: |
+      DuckLake catalog format version. The numeric major.minor lands in the
+      gauge value (1.0, 1.1, 2.0…); any trailing non-numeric tag DuckLake
+      attaches (currently '-dev1' on main after MigrateV10, future '-rcN' /
+      '-betaN' shapes welcome) lands in the `suffix` label so dashboards
+      can flag dev/pre-release builds without losing PromQL ordering on
+      the value. Empty `suffix=""` means a clean release. Pure-junk values
+      like 'foo' fail loudly via the error counter — the correct signal.
+    interval_mins: 60
+    labels: [suffix]
+    values: [format_version]
+    sql: |
+      SELECT
+        CAST(regexp_extract(value, '^[0-9]+(\\.[0-9]+)?') AS DOUBLE) AS format_version,
+        regexp_replace(value, '^[0-9]+(\\.[0-9]+)?', '') AS suffix
+      FROM __ducklake_metadata_lake.ducklake_metadata
+      WHERE key = 'version' AND scope IS NULL
 """
 
 # Intervals are specified in whole minutes via the YAML field `interval_mins`


### PR DESCRIPTION
## Summary

Adds a sixth built-in to the `ducklake-metrics` daemon: `ducklake_catalog_format_version`. Reads `ducklake_metadata` where `key='version' AND scope IS NULL` and publishes the result every 60 minutes (the value only changes on a DuckLake upgrade).

## Why a label, not just a float

The catalog stores `version` as VARCHAR and DuckLake's own dev tags include non-numeric suffixes — `1.1-dev1` currently lives on `main` after `MigrateV10`, and `-rcN` / `-betaN` shapes are likely future additions. Naive `CAST(value AS DOUBLE)` would crash on every dev build.

To keep PromQL ordering on the value while staying visible about dev/pre-release builds:

| Input | Gauge value | `suffix` label |
|---|---|---|
| `0.4` | `0.4` | `""` |
| `1.0` | `1.0` | `""` |
| `1.1-dev1` | `1.1` | `"-dev1"` |
| `2.0-rc7` | `2.0` | `"-rc7"` |
| `totally-not-a-version` | — | — (errors_total++) |

Empty `suffix=""` means a clean release. Pure-junk values fail loudly via the error counter — the right signal for an operator. Clear-and-set on labeled gauges already wipes the prior series on upgrade, so dashboards never show two simultaneous "current versions" (covered by a new test).

## Test plan

- [x] `uv run pytest tests/unit/test_ducklake_metrics.py::TestBuiltinCatalog -v` (10 cases: parametrized over six version shapes incl. `1.1-dev1`/`-rc7`/`-beta`, junk-string error path, label-clears-on-upgrade, interval-is-60m)
- [x] `uv run pytest tests/unit/ tests/integration/test_ducklake_metrics_integration.py` — 265 total, integration test verifies `ducklake_catalog_format_version` shows up in `/metrics`
- [x] `uv run ruff check` clean
- [x] `python tools/ducklake_metrics.py --list-queries` lists the new query at 3600s interval