### PR TITLE
Add Iceberg destination alongside DuckLake via thin Sink protocol

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
       with:
         fail-on-severity: moderate
-        allow-licenses: Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, PSF-2.0
+        allow-licenses: Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, Python-2.0
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,12 @@ jobs:
     - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
       with:
         fail-on-severity: moderate
-        allow-licenses: Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, Python-2.0
+        # SPDX atoms our transitive deps actually declare. Notes:
+        #   Python-2.0  — canonical SPDX id for the PSF License (pyparsing uses this form)
+        #   PSF-2.0     — informal alias for the same license (greenlet, typing_extensions use this form)
+        #   MPL-2.0     — certifi, and the MPL portion of orjson's "MPL-2.0 AND (Apache-2.0 OR MIT)"
+        # SPDX `AND` is conjunction: every atom in an expression must be on this list.
+        allow-licenses: Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, Python-2.0, PSF-2.0, MPL-2.0
 
   build:
     runs-on: ubuntu-latest

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,4 +1,4 @@
-# Millpond — Dead Simple Kafka to DuckLake
+# Millpond — Dead Simple Kafka to DuckLake or Iceberg
 
 ## Pre-push Checklist
 
@@ -24,15 +24,15 @@ Prefer fixup commits over amending and force-pushing.
 
 ## Maintenance Tooling
 
-`tools/maintenance.py` is a self-contained Python script for DuckLake maintenance operations (snapshot expiry, file cleanup, orphan deletion, checkpoint, tiered compaction, deletion-queue dedup, catalog-side orphan recovery, fsck). It connects to DuckLake using the same env vars as the main app (`DUCKLAKE_RDS_*`, `DUCKDB_S3_*`, `DUCKLAKE_DATA_PATH`) but does not import from the `millpond` package. Designed to run as a K8s CronJob reusing the same Docker image.
+`tools/ducklake_maintenance.py` is a self-contained Python script for DuckLake maintenance operations (snapshot expiry, file cleanup, orphan deletion, checkpoint, tiered compaction, deletion-queue dedup, catalog-side orphan recovery, fsck). It connects to DuckLake using the same env vars as the main app (`DUCKLAKE_RDS_*`, `DUCKDB_S3_*`, `DUCKLAKE_DATA_PATH`) but does not import from the `millpond` package. Designed to run as a K8s CronJob reusing the same Docker image.
 
 `connect()` does two ATTACHes against the same upstream Postgres: the DuckLake catalog as `lake` (the `ATTACH_NAME` constant) and a direct Postgres ATTACH as `pg` (the `PG_ATTACH_NAME` constant) used by `postgres_execute` / `postgres_query` for ctid-based DML and advisory-lock acquisition. S3 access is configured via both the legacy `SET s3_*` settings (honored by the ducklake catalog driver) and a `CREATE OR REPLACE SECRET s3` (required for ad-hoc httpfs ops like `glob('s3://...')` and `read_parquet('s3://...')` in DuckDB 1.4 — the legacy form alone returns 403 for those paths). Spills are pointed at `/tmp/duckdb_spill` so they land on the writable cron-pod emptyDir, not the read-only rootfs.
 
 The `compact` subcommand implements tiered compaction: each tier wraps `ducklake_merge_adjacent_files()` with a save/restore of the catalog's `target_file_size` option (which `ducklake_set_option` writes durably and cannot be unset). Tier specs and the steady-state default live in `TIERS` and `DEFAULT_TARGET_FILE_SIZE` at the top of the file. Bin semantics on DuckLake 1.4.x are `min_file_size` inclusive, `max_file_size` exclusive — so the tier ranges `[0, 1 MiB)`, `[1 MiB, 10 MiB)`, `[10 MiB, 64 MiB)` partition the file-size space without overlap. The `compact-probe` subcommand runs `ducklake_merge_adjacent_files()` against one table with a small `max_compacted_files` cap and no `target_file_size` change — used as a lightweight diagnostic from a periodic CronJob. `compact` exposes `--threads` (default 2) and `--memory-limit` (default 4GB) because `ducklake_merge_adjacent_files` over-uses memory relative to input volume in 1.4 and the conservative defaults keep the cron pod alive on real lakes; raise them when the lake fits.
 
-DuckLake stores its catalog tables (`ducklake_data_file`, `ducklake_table`, `ducklake_files_scheduled_for_deletion`, etc.) in a Postgres schema named `__ducklake_metadata_<attach_name>`, where `<attach_name>` is the alias from the `ATTACH … AS <name>` statement. `maintenance.py` exposes the alias as the `ATTACH_NAME` constant and the derived `METADATA_SCHEMA = f"__ducklake_metadata_{ATTACH_NAME}"`; any new code that reads the catalog directly (rather than through the `ducklake_*` SQL functions) must reference `METADATA_SCHEMA` so the attach name and schema name never drift.
+DuckLake stores its catalog tables (`ducklake_data_file`, `ducklake_table`, `ducklake_files_scheduled_for_deletion`, etc.) in a Postgres schema named `__ducklake_metadata_<attach_name>`, where `<attach_name>` is the alias from the `ATTACH … AS <name>` statement. `ducklake_maintenance.py` exposes the alias as the `ATTACH_NAME` constant and the derived `METADATA_SCHEMA = f"__ducklake_metadata_{ATTACH_NAME}"`; any new code that reads the catalog directly (rather than through the `ducklake_*` SQL functions) must reference `METADATA_SCHEMA` so the attach name and schema name never drift.
 
-`tools/maintenance.sql` is executed verbatim at every session start, both by `maintenance.py`'s `connect()` and by the `just shell` recipe (via the duckdb CLI's `.read` meta-command). The file contains no templating — `__ducklake_metadata_lake` and the rest are written literally so both load paths stay consistent. It defines runtime macros (`count_pending_dups()`, `find_catalog_orphans(data_path)`) and documents the constraints any new recipe must follow: no `LEFT ANTI JOIN` (DuckDB 1.4 limitation; use `LEFT JOIN ... WHERE rhs IS NULL`), no Postgres `ctid` from duckdb-side SQL (use `postgres_execute` / `postgres_query` instead), no literal `glob('s3://...')` inside `CREATE MACRO` bodies (DuckDB 1.4 evaluates them eagerly at macro creation, which would S3-LIST the lake on every connect — pass the path as a parameter), and the advisory-lock key.
+`tools/ducklake_maintenance.sql` is executed verbatim at every session start, both by `ducklake_maintenance.py`'s `connect()` and by the `just shell` recipe (via the duckdb CLI's `.read` meta-command). The file contains no templating — `__ducklake_metadata_lake` and the rest are written literally so both load paths stay consistent. It defines runtime macros (`count_pending_dups()`, `find_catalog_orphans(data_path)`) and documents the constraints any new recipe must follow: no `LEFT ANTI JOIN` (DuckDB 1.4 limitation; use `LEFT JOIN ... WHERE rhs IS NULL`), no Postgres `ctid` from duckdb-side SQL (use `postgres_execute` / `postgres_query` instead), no literal `glob('s3://...')` inside `CREATE MACRO` bodies (DuckDB 1.4 evaluates them eagerly at macro creation, which would S3-LIST the lake on every connect — pass the path as a parameter), and the advisory-lock key.
 
 The catalog-side orphan-recovery subcommands (`dedup-deletions`, `find-orphans`, `heal-orphans`, `cleanup-all-safe`, `fsck`) form a self-contained recovery toolkit for the failure mode where an interrupted `cleanup-all` leaves the catalog with rows pointing at S3 keys that no longer exist (because the upstream txn rolled back but the S3 deletes are permanent). `heal-orphans` runs two safety gates before deleting: B1 proves `ducklake_data_file` is non-empty AND no orphan path is still live (no vacuous pass on an empty catalog, no false positive that would delete a live file), and B3 aborts if any positional-delete vector references an "orphan" id (such a file is still live for vector lookups). `cleanup-all-safe` is the orchestrator that loops dedup + heal + cleanup-all under one advisory lock until cleanup-all exits clean; `fsck` adds the `ducklake_delete_orphaned_files` S3-side sweep on top. All destructive subcommands take `pg_try_advisory_lock(hashtext('millpond-ducklake-maintenance')::bigint)` on the `pg` ATTACH; the lock is held by the `pg` connection (not the `lake` connection that DuckLake uses internally), so it provides mutual exclusion between maintenance invocations but not catalog-write atomicity against arbitrary writers — document this caveat anywhere the lock is mentioned.
 
@@ -42,13 +42,13 @@ The catalog-side orphan-recovery subcommands (`dedup-deletions`, `find-orphans`,
 
 If `PUSHGATEWAY_URL` is set, the script pushes two metrics: `maintenance_start_time{operation}` (pushed immediately on start) and `maintenance_duration_seconds{operation, status}` (pushed on completion). This enables Grafana annotation queries for maintenance windows.
 
-DuckDB's HTTP logging and the postgres extension's `pg_debug_show_queries` are off by default — both add per-call overhead that compounds across tens of thousands of S3 deletes. Pass `--debug` at the maintenance.py command level to opt back into both for short-lived debugging.
+DuckDB's HTTP logging and the postgres extension's `pg_debug_show_queries` are off by default — both add per-call overhead that compounds across tens of thousands of S3 deletes. Pass `--debug` at the ducklake_maintenance.py command level to opt back into both for short-lived debugging.
 
-`tools/justfile` wraps the script for interactive use and is copied to `/justfile` in the Docker image. The `shell` recipe pre-ATTACHes both `lake` and `pg`, configures the S3 SECRET, and `.read`s `tools/maintenance.sql` so every session starts with the macros loaded; the `drop` recipe still uses the DuckDB CLI directly. The `DUCKDB` env var can override the duckdb binary path; `MAINTENANCE_SCRIPT`, `MAINTENANCE_SQL`, and `DUCKLAKE_METRICS_SCRIPT` env vars override the in-image paths for dev use.
+`tools/justfile` wraps the script for interactive use and is copied to `/justfile` in the Docker image. The `shell` recipe pre-ATTACHes both `lake` and `pg`, configures the S3 SECRET, and `.read`s `tools/ducklake_maintenance.sql` so every session starts with the macros loaded; the `drop` recipe still uses the DuckDB CLI directly. The `DUCKDB` env var can override the duckdb binary path; `DUCKLAKE_MAINTENANCE_SCRIPT`, `DUCKLAKE_MAINTENANCE_SQL`, and `DUCKLAKE_METRICS_SCRIPT` env vars override the in-image paths for dev use.
 
 ## State Metrics Daemon
 
-`tools/ducklake_metrics.py` is a long-running Python daemon that runs catalog-side queries against the DuckLake on a per-query schedule and publishes results as Prometheus gauges over HTTP. Same image, same env vars (`DUCKLAKE_RDS_*`, `DUCKDB_S3_*`, `DUCKLAKE_DATA_PATH`); intended to run as a small single-replica Deployment alongside the maintenance CronJob. Reuses `maintenance.connect()` so the lake + Postgres ATTACHes, S3 secret, `temp_directory`, and the `enable_http_logging` / `pg_debug_show_queries` quiets all match the maintenance side without duplication.
+`tools/ducklake_metrics.py` is a long-running Python daemon that runs catalog-side queries against the DuckLake on a per-query schedule and publishes results as Prometheus gauges over HTTP. Same image, same env vars (`DUCKLAKE_RDS_*`, `DUCKDB_S3_*`, `DUCKLAKE_DATA_PATH`); intended to run as a small single-replica Deployment alongside the maintenance CronJob. Reuses `ducklake_maintenance.connect()` so the lake + Postgres ATTACHes, S3 secret, `temp_directory`, and the `enable_http_logging` / `pg_debug_show_queries` quiets all match the maintenance side without duplication.
 
 Single-file design by intent: queries are described as YAML and `BUILTIN_YAML` is a string constant in the same module, parsed through the same loader as user-supplied YAML so the two paths can't diverge. User YAML supplied via `DUCKLAKE_METRICS_CONFIG` extends the built-ins by name (user wins on collision); `DUCKLAKE_METRICS_DISABLE` drops named built-ins. The YAML schema is `name`, `help`, `interval_mins` (positive integer; the unit is in the field name so there's no `1m`/`30s` suffix parsing), `labels` (column names → Prometheus label dimensions), `values` (column names → metric suffixes; metric name is `<query_name>_<value>`), and `sql`. Every metric is a gauge — no `type` field. Built-ins reference the metadata schema literally as `__ducklake_metadata_lake` because `connect()` always ATTACHes the lake under that alias; user-supplied SQL is passed through verbatim.
 
@@ -62,7 +62,7 @@ Built-ins are deliberately table-unaware (D8 in `state-metrics-plan.md`): no `ta
 
 ## What This Is
 
-A standalone Python app that replaces Kafka Connect for writing Kafka topic data to DuckLake. Single thread, single loop, no framework.
+A standalone Python app that replaces Kafka Connect for writing Kafka topic data to a lake table. Single thread, single loop, no framework. One deployment writes to exactly one destination — either DuckLake or Apache Iceberg, selected by `MILLPOND_DESTINATION`.
 
 Replaces: [PostHog/ducklake-kafka-connect](https://github.com/PostHog/ducklake-kafka-connect) (~1100 lines of lock management, scheduled executors, two-lock protocols imposed by the Kafka Connect framework).
 
@@ -97,14 +97,14 @@ while not shutdown:
         pending.append(batch)
 
     if should_flush(pending):
-        write_to_ducklake(pending)
+        sink.write(pending)                              # destination-agnostic
         consumer.commit(offsets, asynchronous=False)
         pending.clear()
 ```
 
 - **No consumer groups.** Each pod computes its partitions from its StatefulSet ordinal and total partition count, uses `consumer.assign()`.
-- **No threads, no queues.** Kafka is the queue. Backpressure is implicit: while flushing to DuckLake, the consumer simply doesn't call `consume()`. Kafka holds the data.
-- **Offset commit** is explicit: only after successful DuckLake write.
+- **No threads, no queues.** Kafka is the queue. Backpressure is implicit: while flushing to the lake, the consumer simply doesn't call `consume()`. Kafka holds the data.
+- **Offset commit** is explicit: only after a successful lake write.
 - **If a pod dies**, its partitions stop being consumed until K8s restarts it. No rebalance.
 
 
@@ -115,9 +115,9 @@ while not shutdown:
 Millpond has two independent credential paths that must not interfere:
 
 - **Kafka (MSK)**: SASL/OAUTHBEARER via IRSA. The `aws-msk-iam-sasl-signer-python` library uses the standard AWS credential chain (IRSA projected token → STS → temporary creds).
-- **S3 (DuckLake data)**: Static IAM credentials via `DUCKDB_S3_ACCESS_KEY_ID` / `DUCKDB_S3_SECRET_ACCESS_KEY`. DuckDB's aws extension does not support IRSA ([duckdb/duckdb-aws#31](https://github.com/duckdb/duckdb-aws/issues/31)).
+- **S3 (lake data)**: Static IAM credentials via destination-specific env vars — `DUCKDB_S3_ACCESS_KEY_ID` / `_SECRET_ACCESS_KEY` for DuckLake (DuckDB's aws extension does not support IRSA: [duckdb/duckdb-aws#31](https://github.com/duckdb/duckdb-aws/issues/31)); `MILLPOND_S3_ACCESS_KEY_ID` / `_SECRET_ACCESS_KEY` for Iceberg (passed through PyIceberg catalog properties so PyArrow's S3 filesystem reads them before falling through to the AWS env var chain).
 
-The S3 credentials use DuckDB-specific env var names, **not** the standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`. This is intentional — standard AWS env vars would shadow IRSA in the credential chain and break MSK IAM auth. Do not change the S3 credential env var names to standard AWS names.
+Neither backend's S3 credentials use the standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` — those take precedence in the credential chain and would shadow IRSA for MSK IAM auth. Do not change either backend's S3 credential env var names to the standard AWS names. The two families are kept distinct so a deployment switch between destinations is a clean swap rather than a re-use.
 
 `aws-msk-iam-sasl-signer-python` is an optional dependency (`pip install millpond[msk-iam]`) but the Dockerfile always installs it (`--extra msk-iam`). All production deployments use IAM auth. The optional dep is for local dev where boto3/botocore (~15MB) may not be wanted.
 
@@ -190,6 +190,20 @@ Ported from ducklake-kafka-connect's `SinkRecordToArrowConverter`:
 
 **Caveat**: `pa.Table.from_pylist()` infers the schema from the first record's keys only. `arrow_converter.py` works around this by pre-scanning all records to build the full key union and passing an explicit schema to `from_pylist()`. The pre-scan is effectively free (pointer iteration over dict keys).
 
+**`pa.null()` columns are filtered.** `_drop_null_typed_columns()` runs after type normalization and drops any column whose Arrow type is `pa.null()`. In normal use `_build_schema` falls back to `pa.string()` for keys that are None in every record, so this filter is defensive: if a `pa.null()` column ever slips through (e.g. via a future inference change), the two backends would diverge — DuckLake silently accepts; Iceberg v2 rejects with `ValueError("Null type ... is not supported")`. Dropping at the converter keeps the Sink contract uniform; the column gets reintroduced with a real type on the next batch that has a non-null value.
+
+### Sink Protocol
+
+`millpond/sink.py` defines a 3-method Protocol: `write(batch)`, `reset_caches()`, `close()`. `main.py` only sees this interface — it does not import either backend module. `make_sink(cfg)` is the factory; it dispatches on `cfg.destination` with lazy imports so a DuckLake-only deployment doesn't pay pyiceberg's ~150ms transitive import cost (cryptography, aiohttp, etc.). The same logic applies in reverse for Iceberg-only deployments.
+
+Per-Sink instance state: the table-ensured cache (set/dict) and the SchemaManager both live on the Sink instance, not at module level. Two Sink instances in the same process correctly do not share cache — each owns its own catalog/connection handle too. `reset_caches()` is called only by the write-retry loop in `main.py` after a failed write; sinks do not self-reset on internal recovery, they surface the failure and let the retry path drive cache invalidation.
+
+Empty-batch contract: callers must not invoke `write()` with a zero-row batch. `main.py` gates on `pending_records > 0` before flushing. The backends diverge defensively: DuckLake creates the table eagerly on any call (including empty); Iceberg short-circuits and skips the catalog round trip. Neither divergence is exercised in steady state, but both are documented on the `Sink` Protocol docstring so any future caller knows the contract.
+
+Reserved-column contract: source-schema columns must not collide with backend-managed metadata column names. `sink.py` exports a shared `check_reserved_collision(batch_schema, reserved, backend_name)` helper that each backend calls at the top of its module-level `write()` — raises `ValueError("Source schema column(s) [...] collide with X-reserved metadata column names...")` at the Sink boundary before any backend-specific work. The per-backend `RESERVED_COLUMNS` constants currently hold the same set (`{"_inserted_at", "year", "month", "day", "hour"}`) — DuckLake reserves the four partition cols defensively even though it doesn't produce them itself, so a deployment-time destination switch doesn't suddenly start accepting or rejecting batches based on column-name collisions. `SAFE_IDENTIFIER` (the regex for column names safe to embed in generated SQL / pass to PyIceberg's schema constructor) also lives in `sink.py` and is shared by both schema managers.
+
+Cross-backend behaviour and performance are locked by `tests/unit/test_backend_equivalence.py` — same Arrow batch through both Sinks, parametrized assertions over the documented divergences (empty-batch, partition cols, `_inserted_at` provenance), pathological value/name coverage, schema-evolution metric parity, and conservative performance smoke contracts. The suite catches a future "let's silently align these" or "let's silently diverge these" change before merge.
+
 ### DuckLake Initialization
 
 At startup, `ducklake.py` must:
@@ -212,9 +226,41 @@ conn.execute("INSERT INTO lake.main.{table} SELECT *, NOW() AS _inserted_at FROM
 conn.unregister('arrow_batch')
 ```
 
-Zero-copy Arrow scan. Table auto-created and evolved (ADD COLUMN, ALTER COLUMN SET DATA TYPE) to match Arrow schema.
+Zero-copy Arrow scan. Table auto-created and evolved (ADD COLUMN, ALTER COLUMN SET DATA TYPE) to match Arrow schema. `_inserted_at` is added by the SQL `NOW()` at INSERT time, so rows in a single flush can have microsecond drift in their timestamps.
 
-### Hive-Style Partitioning
+### Iceberg Initialization
+
+```python
+catalog = load_catalog("lake", **{
+    "type": "rest",
+    "uri": cfg.iceberg_catalog_uri,
+    "warehouse": cfg.iceberg_warehouse,
+    "s3.access-key-id": cfg.s3_access_key_id,
+    "s3.secret-access-key": cfg.s3_secret_access_key,
+    "s3.region": cfg.s3_region,
+})
+```
+
+PyIceberg's PyArrow S3 filesystem reads `s3.access-key-id` etc. from the catalog properties before falling back to the AWS env var chain (verified against pyiceberg 0.11.1). Passing them through catalog properties keeps the IRSA token used for Kafka MSK auth out of the S3 client's credential resolution — same isolation pattern `DUCKDB_S3_*` gave DuckDB.
+
+PyIceberg is pinned exactly (`pyiceberg[pyarrow]==0.11.1`) because `millpond/iceberg.py` depends on two private symbols (`_pyarrow_to_schema_without_ids`, `assign_fresh_schema_ids`) to build an Iceberg schema with fresh sequential field IDs before constructing the partition spec. A canary test (`tests/unit/test_pyiceberg_pin.py`) imports both symbols and asserts the version + module path on every CI run — bumping the pin requires revisiting the iceberg module's private-API usage.
+
+### Iceberg Write
+
+```python
+batch = _add_metadata_columns(source_batch)  # appends _inserted_at + year/month/day/hour (int32)
+table.append(batch)                            # commits a snapshot via Table.append
+```
+
+`_inserted_at` is added at write time in Python (single `datetime.datetime.now(UTC)` shared by every row in the flush). Year/month/day/hour are derived from that timestamp via PyArrow compute and cast to int32 — the locked width matters because the partition spec references those columns by field_id, and a width drift between table creation and write would mismatch.
+
+### Iceberg Partition Spec
+
+Hardcoded: identity transforms on `year` / `month` / `day` / `hour` (int32, derived from `_inserted_at`). No env var, no per-deployment customization. The spec is built once at table creation via `_build_partition_spec()` and references the four columns by field_id (starting at `_PARTITION_FIELD_ID_BASE = 1000` to stay well above any plausible source-column count).
+
+Hive-style on-disk layout (`year=2026/month=3/day=23/hour=21/*.parquet`) is preserved so S3-prefix consumers, lifecycle rules, and partition-discovery tooling all work the same as DuckLake. Reader-side ergonomics differ: Iceberg doesn't know the four columns are derived from `_inserted_at`, so queries need explicit partition-column filters to get pruning. A future spec evolution can layer hidden partitioning on top without rewriting data; not needed today.
+
+### Hive-Style Partitioning (DuckLake)
 
 If `DUCKLAKE_PARTITION_BY` is set, `_ensure_table()` runs `ALTER TABLE SET PARTITIONED BY (...)` after table creation. DuckLake writes files into Hive-style directories (`year=2026/month=3/day=23/hour=21/*.parquet`).
 
@@ -237,14 +283,34 @@ The ducklake-kafka-connect connector has two custom layers for schema evolution:
 
 **Batch consolidation is also free.** The connector has a 170-line `BatchConsolidator.java` that groups contiguous batches by schema compatibility and does vector-by-vector in-place append — because Java Arrow has no `concat_tables()` equivalent. In Python, `pa.concat_tables(pending)` does schema unification, type promotion, and concatenation in one call. Hundreds of lines of manual memory management and vector arithmetic replaced by a single function call.
 
-Millpond schema evolution approach:
+Each backend owns its own SchemaManager — neither shares with the other, by design (they target different type systems, different DDL APIs, and different concurrency models).
+
+**DuckLake** (`millpond/schema.py`):
 
 1. `pa.Table.from_pylist()` infers superset schema across all records in the batch
 2. Before write, compare `table.schema` against cached DuckLake table schema
 3. New field → `ALTER TABLE ADD COLUMN IF NOT EXISTS`
 4. Wider type → `ALTER TABLE ALTER COLUMN SET DATA TYPE` (DuckLake enforces widening-only)
-5. Incompatible change → DuckLake rejects it, log + metric + skip
+5. Incompatible change → DuckLake rejects it, log + metric + skip (per-column; does not abort the flush)
 6. `_inserted_at TIMESTAMP` added automatically, set to `NOW()` on write
+
+**Iceberg** (`millpond.iceberg.SchemaManager`, embedded in `iceberg.py`):
+
+1. `pa.Table.from_pylist()` infers superset schema (shared with DuckLake)
+2. Before write, compare against cached Iceberg table schema (read from `Catalog.load_table().schema()`)
+3. New field or widening → collect into one list; apply all in a single `table.update_schema()` transaction (single commit per flush)
+4. Reserved columns (`_inserted_at` + the four partition cols) are filtered out — source schema evolution must not touch them
+5. Incompatible change → `update_schema()` raises (e.g. `pyiceberg.exceptions.ValidationError` for narrowing); the broad `except Exception` in `evolve()` bumps `errors_total{type="schema"}`, invalidates the local cache, and **re-raises** so `_write_with_retry` can drive the recovery (this is different from DuckLake's per-column skip)
+6. `evolve()` returns `True` iff a commit happened, so `write()` can skip the post-evolve table reload when nothing changed
+
+Concurrency model differs too: DuckLake's idempotent DDL (`ADD COLUMN IF NOT EXISTS`) handles multi-pod races silently. Iceberg's `update_schema()` uses optimistic concurrency — a losing writer raises `CommitFailedException` and the retry path re-loads (possibly observing the winner's evolution) and tries again.
+
+**Why DuckLake swallows per-column failures while Iceberg re-raises.** This asymmetry is deliberate, not a bug:
+
+- DuckLake runs one ALTER per column (`ADD COLUMN` or `ALTER COLUMN SET DATA TYPE`). Each statement is its own transaction. If column N's ALTER fails (e.g. an invalid narrowing the extension rejects), columns 1..N-1 have already committed; the rest can still proceed. Aborting the whole flush would discard the legitimate successes. So `SchemaManager.evolve()` logs the failure, bumps `errors_total{type="schema"}`, and continues with the remaining columns; the failed column simply stays at its old type and the batch's values for it land NULL (or get cast if DuckDB can coerce them).
+- Iceberg's `update_schema()` is a single transaction — adds and widenings are batched into one commit at context-manager exit. There is no "partial success" state by construction. A `ValidationError` or `CommitFailedException` means the *whole* schema change rolled back; the subsequent `Table.append()` would write against a schema view that's now provably stale. Continuing would be wrong. So `SchemaManager.evolve()` re-raises and `_write_with_retry` invalidates caches and tries the whole flush again.
+
+Equivalent semantics across backends would require either rolling DuckLake's ALTERs into a single Postgres transaction (DuckDB ducklake extension doesn't expose that today) or splitting Iceberg's evolution into per-column commits (loses atomicity and multiplies catalog round-trips). Neither is worth the cost; the asymmetry is locked by `tests/unit/test_backend_equivalence.py` so any future "let's align these" PR has to explicitly address it.
 
 Source files for reference:
 - `DucklakeTableManager.java` — DDL detection and execution
@@ -281,12 +347,12 @@ Prometheus via `prometheus_client`, HTTP on port 8000.
 | Metric | Type | Description |
 |--------|------|-------------|
 | `millpond_records_consumed_total` | Counter | Records polled (by partition) |
-| `millpond_records_written_total` | Counter | Records written to DuckLake |
+| `millpond_records_written_total` | Counter | Records written to the lake |
 | `millpond_batches_flushed_total` | Counter | Flush cycles completed (by trigger: `size` or `time`) |
 | `millpond_records_skipped_total` | Counter | Records skipped (by reason: json_parse, schema) |
-| `millpond_errors_total` | Counter | Errors by type (kafka/duckdb/arrow/json) |
+| `millpond_errors_total` | Counter | Errors by type (kafka, write_retry, offset_commit, schema, …) |
 | `millpond_arrow_conversion_seconds` | Histogram | Time to convert JSON to Arrow table |
-| `millpond_flush_duration_seconds` | Histogram | Time per DuckLake write |
+| `millpond_flush_duration_seconds` | Histogram | Time per lake write |
 | `millpond_flush_size_bytes` | Histogram | Arrow bytes per flush |
 | `millpond_flush_size_records` | Histogram | Records per flush |
 | `millpond_pending_bytes` | Gauge | Current pending Arrow bytes awaiting flush |
@@ -307,7 +373,7 @@ Prometheus via `prometheus_client`, HTTP on port 8000.
 | Risk | Mitigation |
 |------|------------|
 | Partition count desync | Partition count discovered via `consumer.list_topics()` at startup — no env var. `REPLICA_COUNT` env var must match `spec.replicas`; desync causes uneven assignment but not data loss (some partitions double-assigned, some unassigned). |
-| Concurrent DDL from multiple pods (two pods both ALTER TABLE simultaneously) | `ADD COLUMN IF NOT EXISTS` is idempotent — multiple pods racing is harmless. `ALTER COLUMN SET DATA TYPE` widening to the same target is also idempotent. Postgres advisory locks (`pg_advisory_lock(hashtext('millpond-schema-' || table))`) available if contention materializes, but unlikely. Cannot designate a single schema-owner pod because schema discovery is distributed (new fields can appear in any partition). In practice, schema changes are rare — the primary use case (events) uses a stable schema that relies on maps/dictionaries for extensibility rather than adding columns. |
+| Concurrent DDL from multiple pods (two pods both evolve schema simultaneously) | DuckLake: `ADD COLUMN IF NOT EXISTS` is idempotent — multiple pods racing is harmless. `ALTER COLUMN SET DATA TYPE` widening to the same target is also idempotent. Iceberg: `update_schema()` uses optimistic concurrency; the loser raises `CommitFailedException`, the write-retry path invalidates the cache and re-reads (possibly observing the winner's evolution), then tries again. Cannot designate a single schema-owner pod because schema discovery is distributed (new fields can appear in any partition). In practice, schema changes are rare — the primary use case (events) uses a stable schema that relies on maps/dictionaries for extensibility rather than adding columns. |
 | Liveness probe only checks prometheus HTTP, not app health | Add `/healthz` endpoint that checks last-poll and last-flush recency. Pod is unhealthy if either exceeds a threshold. |
 
 ### High
@@ -403,10 +469,15 @@ Prometheus metrics and health checks on port 8000 via a custom `http.server.HTTP
 | Package | Why |
 |---------|-----|
 | `confluent-kafka>=2.6` | librdkafka Python wrapper |
-| `duckdb>=1.2` | DuckDB Python client |
-| `pyarrow>=18.0` | Arrow tables, zero-copy DuckDB integration |
+| `duckdb==1.5.1` | DuckDB Python client (pinned; the ducklake extension is sensitive to minor-version moves) |
+| `pyiceberg[pyarrow]==0.11.1` | PyIceberg REST catalog client — pinned exactly because `millpond/iceberg.py` uses two private symbols (`_pyarrow_to_schema_without_ids`, `assign_fresh_schema_ids`). The canary test in `tests/unit/test_pyiceberg_pin.py` fails loudly on any upgrade. |
+| `pyarrow>=18.0` | Arrow tables, zero-copy DuckDB/Iceberg integration |
 | `orjson>=3.10` | Fast JSON parsing (Rust) |
 | `prometheus-client>=0.21` | Metrics exposition |
+| `pytz>=2024.1` | Required by duckdb's TIMESTAMPTZ Python conversion (1.5.x doesn't accept stdlib zoneinfo) |
+| `pyyaml>=6.0.3` | `tools/ducklake_metrics.py` query definitions |
+
+Both `duckdb` and `pyiceberg` are always installed — there is no "ducklake-only" or "iceberg-only" build variant. The lazy import in `make_sink()` means a deployment that only uses one destination doesn't pay the other's import cost at startup, but the dependency footprint on disk is identical.
 
 ## Project Structure
 
@@ -426,19 +497,26 @@ millpond/
 │   └── pdb.yaml              # PodDisruptionBudget
 ├── millpond/
 │   ├── __init__.py
-│   ├── main.py               # Entry point, main loop, signal handling
-│   ├── config.py             # Env var → dataclass
+│   ├── main.py               # Entry point, main loop, signal handling — backend-agnostic via Sink
+│   ├── config.py             # Env var → dataclass; per-destination validation
+│   ├── sink.py               # Sink Protocol + make_sink(cfg) factory (lazy backend imports)
 │   ├── arrow_converter.py    # JSON → PyArrow Table (orjson + from_pylist + numeric normalization)
-│   ├── ducklake.py           # DuckDB/DuckLake connection, table mgmt, writes
+│   ├── ducklake.py           # DuckLake backend: connect, write, DuckLakeSink class
+│   ├── iceberg.py            # Iceberg backend: connect, write, SchemaManager, IcebergSink class
+│   ├── schema.py             # DuckLake SchemaManager (Iceberg's is embedded in iceberg.py)
 │   ├── metrics.py            # Prometheus metric definitions
 │   └── server.py             # HTTP server for /metrics and /healthz
 ├── tools/
-│   ├── maintenance.py           # Self-contained DuckLake maintenance script (K8s CronJob)
-│   ├── justfile                 # Interactive wrapper for maintenance.py + DuckDB CLI shell
-│   └── sizing-calculator.html   # Interactive flush/object sizing calculator
+│   ├── ducklake_maintenance.py     # Self-contained DuckLake maintenance script (K8s CronJob, DuckLake-only)
+│   ├── ducklake_maintenance.sql    # Macros loaded at session start
+│   ├── ducklake_metrics.py         # Long-running DuckLake state-metrics daemon (DuckLake-only)
+│   ├── justfile                    # Interactive wrapper for ducklake_maintenance.py + DuckDB CLI shell
+│   └── sizing-calculator.html      # Interactive flush/object sizing calculator
 ├── tests/
-│   ├── unit/                 # Fast, no external deps
-│   ├── integration/          # Local DuckDB write path + schema evolution
+│   ├── unit/                 # Fast, no external deps; uses PyIceberg SqlCatalog for iceberg-side
+│   ├── integration/          # Local DuckDB write path + MinIO+iceberg-rest via testcontainers
 │   └── e2e/                  # Full docker-compose stack via testcontainers
 └── test/                     # Dev fixtures (producer.py, ducklake-init.sql)
 ```
+
+`tools/` is intentionally DuckLake-only — Iceberg deployments use their catalog's native compaction/expiry tooling. No equivalent of `ducklake_maintenance.py` exists for Iceberg in this repo.

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ COPY --from=builder /app/.venv /app/.venv
 COPY --from=builder /app/millpond /app/millpond
 COPY --from=builder /root/.local/bin/duckdb /usr/local/bin/duckdb
 COPY tools/justfile /justfile
-COPY tools/maintenance.py /app/tools/maintenance.py
-COPY tools/maintenance.sql /app/tools/maintenance.sql
+COPY tools/ducklake_maintenance.py /app/tools/ducklake_maintenance.py
+COPY tools/ducklake_maintenance.sql /app/tools/ducklake_maintenance.sql
 COPY tools/ducklake_metrics.py /app/tools/ducklake_metrics.py
 
 ENV PATH="/app/.venv/bin:$PATH"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Millpond — Kafka to DuckLake
+# Millpond — Kafka to DuckLake or Iceberg
 
-A standalone Python app that consumes from a Kafka topic and writes to a DuckLake table. Single thread, single loop, no Kafka Connect.
+A standalone Python app that consumes from a Kafka topic and writes to a lake table. Single thread, single loop, no Kafka Connect. One deployment writes to exactly one destination — either [DuckLake](https://github.com/duckdb/ducklake) or [Apache Iceberg](https://iceberg.apache.org/), selected via `MILLPOND_DESTINATION`.
 
 ## Naming
 
@@ -9,7 +9,7 @@ A standalone Python app that consumes from a Kafka topic and writes to a DuckLak
 > **millpond** (noun): a pond created by damming a stream to produce a head of water for operating a mill.
 > — [Merriam-Webster](https://www.merriam-webster.com/dictionary/millpond)
 
-Millpond accumulates a stream of Kafka records until a threshold is reached, then releases them into the [DuckLake](https://github.com/duckdb/ducklake). Like a [mill pond](https://en.wikipedia.org/wiki/Mill_pond) feeding a lake.
+Millpond accumulates a stream of Kafka records until a threshold is reached, then releases them into a downstream lake. Like a [mill pond](https://en.wikipedia.org/wiki/Mill_pond) feeding a lake.
 
 ## Why
 
@@ -19,7 +19,7 @@ Kafka Connect imposes ~1100 lines of lock management, scheduled executors, and r
 loop:
   consume() → JSON → Arrow → accumulate
   when buffer full or time elapsed:
-    write to DuckLake → commit offsets
+    write to lake → commit offsets
 ```
 
 Single thread, single loop. Kafka is the buffer. Offset commit is explicit (after successful write only). No data loss window.
@@ -35,6 +35,23 @@ K8s StatefulSet (N replicas)
 - One topic and one table per deployment
 - Static partition assignment via pod ordinal — no consumer groups
 - If a pod dies, its partitions stop being consumed until K8s restarts it
+
+## Destinations
+
+Millpond writes to one of two lake formats, selected at startup by `MILLPOND_DESTINATION` (default `ducklake`). A single deployment writes to exactly one — there is no per-batch routing. Switching destinations requires redeploying with different env vars; the at-rest data is not portable between the two without a separate migration.
+
+|  | DuckLake | Iceberg |
+|---|---|---|
+| Catalog | Postgres (via DuckDB ducklake extension) | REST catalog (e.g. Polaris, Tabular, AWS Glue REST adapter) |
+| Storage | S3 / S3-compatible | S3 / S3-compatible |
+| Reader ecosystem | DuckDB-native; growing third-party support | Broad (Spark, Trino, Athena, Snowflake, DuckDB ≥1.5) |
+| Partitioning | Caller-supplied via `DUCKLAKE_PARTITION_BY`; arbitrary DDL expression | Hardcoded identity transforms on derived `year`/`month`/`day`/`hour` int32 columns; Hive-style layout |
+| Schema evolution | DuckDB DDL (`ADD COLUMN IF NOT EXISTS`, `ALTER COLUMN SET DATA TYPE` with widening enforcement) | PyIceberg `update_schema()` transaction (single commit per flush) |
+| Maintenance tooling | Bundled (`tools/ducklake_maintenance.py` CronJob, `tools/ducklake_metrics.py` daemon) | Not bundled — use your catalog's native compaction/expiry |
+| `_inserted_at` column | Added at INSERT via DuckDB `NOW()` (per-row, microsecond drift possible within a flush) | Added at write time in Python (single timestamp shared by every row in a flush) |
+| Multi-pod concurrent writes | Native; idempotent DDL handles races | Native; PyIceberg optimistic concurrency + retry loop handles races |
+
+The selection is a thin Protocol-based abstraction (`millpond/sink.py`) — `main.py` only sees `Sink.write(batch)`, `reset_caches()`, `close()`. Both implementations are in their own module (`ducklake.py`, `iceberg.py`).
 
 ## Adaptive Backpressure
 
@@ -76,15 +93,17 @@ just run
 ```bash
 just fmt               # format code
 just lint              # lint code
-just test              # run unit tests
-just test-integration  # run integration tests (local DuckDB)
+just test              # run unit tests (includes both backends' suites + cross-backend equivalence)
+just test-integration  # run integration tests (local DuckDB + MinIO/iceberg-rest via testcontainers)
 just test-e2e          # run E2E tests (docker-compose, builds stack automatically)
 just ci                # format check + lint + unit tests
-just up                # start docker-compose stack (plaintext Kafka)
-just up-ssl            # start docker-compose stack with SSL Kafka (closer to prod)
+just up                # start docker-compose stack (DuckLake — plaintext Kafka)
+just up-ssl            # start docker-compose stack (DuckLake — SSL Kafka, closer to prod)
 just down              # stop docker-compose stack
 just down-ssl          # stop SSL docker-compose stack
 ```
+
+The `just up` / `just up-ssl` dev stacks are DuckLake-only. For Iceberg local dev, the integration test fixture in `tests/integration/compose.yaml` brings up MinIO + a tabulario/iceberg-rest catalog; that stack is what the iceberg integration tests use and what to point at for ad-hoc Iceberg work.
 
 ### SSL Kafka Testing
 
@@ -94,22 +113,22 @@ Requires Docker (uses `keytool` from the Kafka container image for cert generati
 
 ### DuckLake Maintenance
 
-`tools/maintenance.py` is a self-contained Python script for DuckLake maintenance operations (snapshot expiry, file cleanup, orphan deletion, checkpoint, tiered compaction, deletion-queue dedup, catalog-side orphan recovery). It is baked into the Docker image at `/app/tools/maintenance.py` and designed to run as a K8s CronJob reusing the same image and credentials as the main application.
+`tools/ducklake_maintenance.py` is a self-contained Python script for DuckLake maintenance operations (snapshot expiry, file cleanup, orphan deletion, checkpoint, tiered compaction, deletion-queue dedup, catalog-side orphan recovery). It is baked into the Docker image at `/app/tools/ducklake_maintenance.py` and designed to run as a K8s CronJob reusing the same image and credentials as the main application.
 
 ```bash
-python /app/tools/maintenance.py maintain --days 7           # expire snapshots + cleanup files
-python /app/tools/maintenance.py maintain --days 7 --dry-run # preview only
-python /app/tools/maintenance.py expire --days 3             # expire snapshots only
-python /app/tools/maintenance.py cleanup --days 1            # cleanup scheduled files only
-python /app/tools/maintenance.py cleanup-all                 # cleanup all scheduled files regardless of age
-python /app/tools/maintenance.py dedup-deletions             # drop duplicate rows in the pending-deletion queue
-python /app/tools/maintenance.py find-orphans                # list catalog rows whose S3 key no longer exists
-python /app/tools/maintenance.py heal-orphans                # delete those catalog rows (gated B1/B3 safety checks)
-python /app/tools/maintenance.py cleanup-all-safe            # dedup + heal-orphans + cleanup-all in a loop until clean
-python /app/tools/maintenance.py fsck                        # cleanup-all-safe + ducklake_delete_orphaned_files
-python /app/tools/maintenance.py checkpoint                  # integrated merge + expire + cleanup
-python /app/tools/maintenance.py orphans                     # delete S3-side orphaned files (catalog has no row)
-python /app/tools/maintenance.py compact --tier 1            # tiered compaction (see "When to add a merge job")
+python /app/tools/ducklake_maintenance.py maintain --days 7           # expire snapshots + cleanup files
+python /app/tools/ducklake_maintenance.py maintain --days 7 --dry-run # preview only
+python /app/tools/ducklake_maintenance.py expire --days 3             # expire snapshots only
+python /app/tools/ducklake_maintenance.py cleanup --days 1            # cleanup scheduled files only
+python /app/tools/ducklake_maintenance.py cleanup-all                 # cleanup all scheduled files regardless of age
+python /app/tools/ducklake_maintenance.py dedup-deletions             # drop duplicate rows in the pending-deletion queue
+python /app/tools/ducklake_maintenance.py find-orphans                # list catalog rows whose S3 key no longer exists
+python /app/tools/ducklake_maintenance.py heal-orphans                # delete those catalog rows (gated B1/B3 safety checks)
+python /app/tools/ducklake_maintenance.py cleanup-all-safe            # dedup + heal-orphans + cleanup-all in a loop until clean
+python /app/tools/ducklake_maintenance.py fsck                        # cleanup-all-safe + ducklake_delete_orphaned_files
+python /app/tools/ducklake_maintenance.py checkpoint                  # integrated merge + expire + cleanup
+python /app/tools/ducklake_maintenance.py orphans                     # delete S3-side orphaned files (catalog has no row)
+python /app/tools/ducklake_maintenance.py compact --tier 1            # tiered compaction (see "When to add a merge job")
 ```
 
 The script logs `cleanup throughput: files_processed=N elapsed_s=T rate_obj_s=R queue_depth_after=A` after every `cleanup` / `cleanup-all` (skipped on `--dry-run`), so you can confirm steady-state throughput without enabling debug logging. `files_processed` is the actual count of files the call returned, not a queue-depth delta, so the number is accurate even when other writers enqueue deletions during the run. Pass `--debug` to opt back into DuckDB's HTTP and Postgres-extension query logging — both are off by default because they add per-call overhead that compounds across tens of thousands of S3 deletes.
@@ -129,7 +148,7 @@ If a `cleanup-all` run is interrupted (DuckLake bug: an S3 NoSuchKey on DELETE r
 
 Mutual exclusion comes from `pg_try_advisory_lock(hashtext('millpond-ducklake-maintenance')::bigint)` taken on the `pg` ATTACH; concurrent maintenance invocations bail with a clear error rather than racing each other's DELETEs.
 
-`tools/maintenance.sql` is loaded at every session start (both by `maintenance.py` and by the `just shell` recipe) and defines small DuckDB macros for ad-hoc inspection — `SELECT count_pending_dups()` for queue dup count, `SELECT * FROM find_catalog_orphans('s3://bucket/lake/data')` for the orphan list. The header documents the conventions (no `LEFT ANTI JOIN`, no duckdb-side `ctid`, advisory-lock key) that any new recipe must follow.
+`tools/ducklake_maintenance.sql` is loaded at every session start (both by `ducklake_maintenance.py` and by the `just shell` recipe) and defines small DuckDB macros for ad-hoc inspection — `SELECT count_pending_dups()` for queue dup count, `SELECT * FROM find_catalog_orphans('s3://bucket/lake/data')` for the orphan list. The header documents the conventions (no `LEFT ANTI JOIN`, no duckdb-side `ctid`, advisory-lock key) that any new recipe must follow.
 
 `tools/justfile` wraps the script and is also baked into the image at `/justfile` for interactive use:
 
@@ -154,7 +173,7 @@ All commands use the pod's existing env vars (`DUCKLAKE_RDS_*`, `DUCKDB_S3_*`, `
 
 ### DuckLake state metrics
 
-`tools/ducklake_metrics.py` is a small long-running daemon that runs catalog-side queries against the DuckLake on a schedule and exposes results as Prometheus gauges over HTTP. Same Docker image as `maintenance.py`; intended to run as a single-replica Deployment so a Prometheus scraper can watch lake shape, compaction backlog, snapshot age, partition skew, and the pending-deletion queue without S3 round trips.
+`tools/ducklake_metrics.py` is a small long-running daemon that runs catalog-side queries against the DuckLake on a schedule and exposes results as Prometheus gauges over HTTP. Same Docker image as `ducklake_maintenance.py`; intended to run as a single-replica Deployment so a Prometheus scraper can watch lake shape, compaction backlog, snapshot age, partition skew, and the pending-deletion queue without S3 round trips.
 
 ```bash
 just ducklake-metrics                       # built-ins only, listens on :9100
@@ -196,7 +215,7 @@ queries:
 
 Built-ins are intentionally lake-wide (no `table_name` label); per-table breakdowns belong in user YAML when needed.
 
-Configuration env vars (in addition to the standard `DUCKLAKE_*` / `DUCKDB_*` set used by `maintenance.py`):
+Configuration env vars (in addition to the standard `DUCKLAKE_*` / `DUCKDB_*` set used by `ducklake_maintenance.py`):
 
 | Variable | Default | Description |
 |---|---|---|
@@ -206,13 +225,29 @@ Configuration env vars (in addition to the standard `DUCKLAKE_*` / `DUCKDB_*` se
 
 ## Configuration
 
-All configuration via environment variables:
+All configuration via environment variables.
+
+### Shared (always required)
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `KAFKA_BOOTSTRAP_SERVERS` | yes | | Kafka broker addresses |
 | `KAFKA_TOPIC` | yes | | Topic to consume |
 | `REPLICA_COUNT` | yes | | Number of StatefulSet replicas (must match `spec.replicas`) |
+| `MILLPOND_DESTINATION` | no | `ducklake` | Destination format: `ducklake` or `iceberg`. Case-insensitive; empty/whitespace falls back to `ducklake`. |
+| `FLUSH_SIZE` | no | `104857600` | Flush after this many bytes of accumulated Arrow data (default 100MB) |
+| `FLUSH_INTERVAL_MS` | no | `60000` | Flush after this many ms |
+| `GROUP_ID` | no | `millpond-{topic}-{table}` | Kafka group.id — used for offset storage in `__consumer_offsets` only, no consumer group semantics. Changing this loses committed offsets and triggers full replay. For Iceberg the default is `millpond-{topic}-{iceberg_table}` (the namespace prefix only shows up in metrics/client.id, not group.id). |
+| `CONSUME_BATCH_SIZE` | no | `1000` | Max messages per `consume()` call — amortizes Python↔C boundary cost |
+| `FETCH_MIN_BYTES` | no | `1048576` | Broker accumulates at least this many bytes before responding (1MB) |
+| `FETCH_MAX_WAIT_MS` | no | `500` | Max broker wait when `fetch.min.bytes` not yet satisfied |
+| `STATS_INTERVAL_MS` | no | `5000` | librdkafka internal stats emission interval (0 to disable) |
+| `LOG_LEVEL` | no | `INFO` | Python log level (DEBUG, INFO, WARNING, ERROR) |
+
+### DuckLake (required when `MILLPOND_DESTINATION=ducklake`)
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
 | `DUCKLAKE_TABLE` | yes | | Target DuckLake table name |
 | `DUCKLAKE_DATA_PATH` | yes | | S3 path for DuckLake data files |
 | `DUCKLAKE_CONNECTION` | yes | | DuckDB connection string |
@@ -222,14 +257,29 @@ All configuration via environment variables:
 | `DUCKLAKE_RDS_USERNAME` | no | `ducklake` | Postgres username |
 | `DUCKLAKE_RDS_PASSWORD` | yes | | Postgres password |
 | `DUCKLAKE_PARTITION_BY` | no | | Hive-style partition expression (e.g. `year(_inserted_at),month(_inserted_at),day(_inserted_at),hour(_inserted_at)`). Applied via `ALTER TABLE SET PARTITIONED BY` on first write. |
-| `FLUSH_SIZE` | no | `104857600` | Flush after this many bytes of accumulated Arrow data (default 100MB) |
-| `FLUSH_INTERVAL_MS` | no | `60000` | Flush after this many ms |
-| `GROUP_ID` | no | `millpond-{topic}-{table}` | Kafka group.id — used for offset storage in `__consumer_offsets` only, no consumer group semantics. Changing this loses committed offsets and triggers full replay. |
-| `CONSUME_BATCH_SIZE` | no | `1000` | Max messages per `consume()` call — amortizes Python↔C boundary cost |
-| `FETCH_MIN_BYTES` | no | `1048576` | Broker accumulates at least this many bytes before responding (1MB) |
-| `FETCH_MAX_WAIT_MS` | no | `500` | Max broker wait when `fetch.min.bytes` not yet satisfied |
-| `STATS_INTERVAL_MS` | no | `5000` | librdkafka internal stats emission interval (0 to disable) |
-| `LOG_LEVEL` | no | `INFO` | Python log level (DEBUG, INFO, WARNING, ERROR) |
+| `DUCKDB_S3_ACCESS_KEY_ID` | yes | | Static S3 access key for DuckDB |
+| `DUCKDB_S3_SECRET_ACCESS_KEY` | yes | | Static S3 secret for DuckDB |
+| `DUCKDB_S3_REGION` | no | | S3 region |
+| `DUCKDB_S3_ENDPOINT` | no | | S3 endpoint override (MinIO, etc.) |
+| `DUCKDB_S3_USE_SSL` | no | | `true` / `false` |
+| `DUCKDB_S3_URL_STYLE` | no | | `vhost` / `path` |
+
+### Iceberg (required when `MILLPOND_DESTINATION=iceberg`)
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ICEBERG_CATALOG_URI` | yes | | REST catalog endpoint (e.g. `https://catalog.example.com`) |
+| `ICEBERG_WAREHOUSE` | yes | | Warehouse identifier, typically the S3 root (`s3://warehouse/`) |
+| `ICEBERG_NAMESPACE` | yes | | Catalog namespace (validated as a safe identifier) |
+| `ICEBERG_TABLE` | yes | | Target table name within the namespace |
+| `ICEBERG_TABLE_LOCATION` | no | | Explicit `s3://...` table location; if unset, catalog picks |
+| `ICEBERG_CATALOG_TOKEN` | no | | Bearer / OAuth token for the REST catalog |
+| `MILLPOND_S3_ACCESS_KEY_ID` | yes | | Static S3 access key for PyIceberg's PyArrow S3 filesystem |
+| `MILLPOND_S3_SECRET_ACCESS_KEY` | yes | | Static S3 secret |
+| `MILLPOND_S3_REGION` | yes | | S3 region |
+| `MILLPOND_S3_ENDPOINT` | no | | S3 endpoint override (MinIO, etc.) |
+
+`MILLPOND_S3_*` is a separate env var family from `DUCKDB_S3_*` deliberately — they target different client libraries, and a deployment switch from DuckLake to Iceberg should be a clean swap of env vars rather than re-using the DuckDB-specific names.
 
 ## Releases
 
@@ -268,6 +318,10 @@ Downtime = drain time + startup time (~2-3 min). Kafka buffers trivially.
 
 ## Partitioning
 
+Partitioning is per-destination — DuckLake takes a caller-supplied expression, Iceberg is hardcoded.
+
+### DuckLake
+
 Set `DUCKLAKE_PARTITION_BY` to enable Hive-style partitioning on S3. Files are written into `key=value/` directories (e.g. `year=2026/month=3/day=23/hour=21/*.parquet`), enabling S3 prefix filtering, bulk lifecycle rules, and partition discovery by external tools.
 
 ```bash
@@ -275,6 +329,12 @@ DUCKLAKE_PARTITION_BY="year(_inserted_at),month(_inserted_at),day(_inserted_at),
 ```
 
 Partition on `_inserted_at` (always a real TIMESTAMP), not source `timestamp` fields (typically VARCHAR). Applied via `ALTER TABLE SET PARTITIONED BY` on first write — idempotent, safe for multiple pods and restarts. If added to an existing unpartitioned table, new files get HSP layout while old files remain flat; DuckLake queries both transparently via metadata.
+
+### Iceberg
+
+The partition spec is hardcoded: identity transforms on four int32 columns (`year`, `month`, `day`, `hour`) derived from `_inserted_at` at write time. This produces the same Hive-style layout as DuckLake — `year=2026/month=3/day=23/hour=21/*.parquet` — for the same S3-prefix-filter and lifecycle reasons. There is no env var; every Iceberg deployment gets the same spec.
+
+Trade-off: Iceberg doesn't know the four columns are derived from `_inserted_at`, so reader queries need to filter on the partition columns explicitly to get pruning. A future spec evolution can layer hidden partitioning on top without rewriting data if reader ergonomics start to matter; not needed today.
 
 ## Object Sizing
 
@@ -338,12 +398,14 @@ The flush path has two failure points, each with its own retry policy:
 
 | Operation | Attempts | Backoff between failures | On exhaustion |
 |-----------|----------|--------------------------|---------------|
-| DuckLake write | 3 | 1s, 2s (last attempt raises immediately) | Re-raise → pod crashes, K8s restarts, replays from last committed offset |
+| Lake write | 3 | 1s, 2s (last attempt raises immediately) | Re-raise → pod crashes, K8s restarts, replays from last committed offset |
 | Offset commit | 3 | 0.5s, 1s (last attempt raises immediately) | Re-raise → pod crashes, replays from last committed offset (duplicates bounded by one flush batch) |
 
 Both use `errors_total{type="write_retry"}` and `errors_total{type="offset_commit"}` counters so transient vs persistent failures are distinguishable in dashboards.
 
-**Why crash after exhausting retries?** A persistent write failure means S3 or Postgres is down — continuing would just accumulate pending data in memory until OOM. A persistent commit failure means the Kafka coordinator is unreachable — the write already succeeded, but without committed offsets the next restart will replay the batch (at-least-once duplicates). In both cases, crashing lets K8s apply its restart backoff, and Kafka holds the data safely until the dependency recovers.
+The write-retry loop catches `Exception` broadly to cover both backends' failure modes — `duckdb.Error` for DuckLake; `pyiceberg.exceptions.CommitFailedException`, `CommitStateUnknownException`, `ServerError`, `ServiceUnavailableError` for Iceberg REST catalog 5xx; `OSError` for S3; `KafkaException` for broker disconnects. Each retry invokes `sink.reset_caches()` to drop cached table/schema state so the next attempt re-checks the catalog (covers the case where another pod evolved the schema or recreated the table between attempts).
+
+**Why crash after exhausting retries?** A persistent write failure means S3 or the catalog is down — continuing would just accumulate pending data in memory until OOM. A persistent commit failure means the Kafka coordinator is unreachable — the write already succeeded, but without committed offsets the next restart will replay the batch (at-least-once duplicates). In both cases, crashing lets K8s apply its restart backoff, and Kafka holds the data safely until the dependency recovers.
 
 ## Multiple Pipelines
 
@@ -378,11 +440,11 @@ Millpond uses two separate AWS credential paths that must not interfere with eac
 | Component | Auth | Credential source |
 |---|---|---|
 | Kafka (MSK) | SASL/OAUTHBEARER | IRSA (standard AWS credential chain) |
-| S3 (DuckLake data files) | Static IAM keys | `DUCKDB_S3_ACCESS_KEY_ID` / `DUCKDB_S3_SECRET_ACCESS_KEY` |
+| S3 (lake data files) | Static IAM keys | `DUCKDB_S3_*` (DuckLake) or `MILLPOND_S3_*` (Iceberg) |
 
-DuckDB's [aws extension does not support IRSA](https://github.com/duckdb/duckdb-aws/issues/31) — it cannot perform the `AssumeRoleWithWebIdentity` token exchange that IRSA requires. Until that is resolved, S3 access requires static credentials.
+Neither backend uses the standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars — those take precedence in the credential chain and would shadow the IRSA role used for Kafka authentication. DuckDB-specific names for DuckLake, Millpond-specific names for Iceberg. The two families are deliberately separate so a deployment switch between destinations is a clean env-var swap rather than a re-use.
 
-These static credentials are passed via DuckDB-specific env var names, not the standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`. This is deliberate: standard AWS env vars take precedence in the credential chain and would shadow the IRSA role used for Kafka authentication.
+DuckDB's [aws extension does not support IRSA](https://github.com/duckdb/duckdb-aws/issues/31) — it cannot perform the `AssumeRoleWithWebIdentity` token exchange that IRSA requires. PyIceberg's S3 access is similarly handled via static credentials passed through catalog properties (`s3.access-key-id` etc.) to keep the IRSA token out of the S3 client's credential resolution. Same isolation pattern, different transport.
 
 ## Operational Notes
 

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-# Millpond — Kafka to DuckLake
+# Millpond — Kafka to DuckLake or Iceberg
 
 # Default recipe: list all available recipes
 default:
@@ -69,7 +69,8 @@ ci: fmt-check lint test
 ssl-certs:
     ./test/generate-ssl-certs.sh
 
-# Start the docker-compose dev environment (Kafka, Postgres, MinIO, producer, 2 millpond pods)
+# Start the docker-compose dev environment (DuckLake stack — Kafka, Postgres, MinIO, producer, 2 millpond pods).
+# For Iceberg-flavored local dev, use the tests/integration/compose.yaml stack (MinIO + iceberg-rest) directly.
 [group('docker')]
 up:
     docker compose build
@@ -91,7 +92,7 @@ down:
 down-ssl:
     docker compose -f docker-compose.yaml -f docker-compose.ssl.yaml down -v
 
-# Open a DuckDB shell attached to the local DuckLake (requires `just up` first)
+# Open a DuckDB shell attached to the local DuckLake (DuckLake stack only; requires `just up` first)
 [group('docker')]
 duck:
     duckdb -init test/ducklake-init.sql

--- a/millpond/arrow_converter.py
+++ b/millpond/arrow_converter.py
@@ -6,6 +6,27 @@ import pyarrow as pa
 log = logging.getLogger(__name__)
 
 
+def _drop_null_typed_columns(table: pa.Table) -> pa.Table:
+    """Drop columns whose Arrow type is ``pa.null()`` before they reach a Sink.
+
+    In normal use ``_build_schema`` falls back to ``pa.string()`` for keys
+    where every record has None across the whole batch, so ``pa.null()``
+    shouldn't appear via this path. This filter is defensive: if a
+    ``pa.null()`` column ever slips through (e.g. via a future inference
+    change), both backends would diverge — DuckLake silently accepts it,
+    Iceberg rejects with ``ValueError("Null type ... is not supported in
+    Iceberg format version 2")``. Dropping at the converter keeps the
+    Sink contract uniform across backends: a column with no schema info
+    is a column with no data, and it'll be re-introduced with a real
+    type on the next batch that has a non-null value.
+    """
+    null_cols = [field.name for field in table.schema if pa.types.is_null(field.type)]
+    if not null_cols:
+        return table
+    log.info("Dropping all-null columns with pa.null() type: %s", null_cols)
+    return table.drop_columns(null_cols)
+
+
 def _normalize_numeric_types(table: pa.Table) -> pa.Table:
     """Normalize numeric columns: integers→int64, floats→float64.
 
@@ -165,4 +186,5 @@ def convert(messages: list[bytes]) -> pa.Table | None:
         schema = _build_schema(patched)
     table = pa.Table.from_pylist(patched, schema=schema)
     table = _normalize_numeric_types(table)
+    table = _drop_null_typed_columns(table)
     return table

--- a/millpond/config.py
+++ b/millpond/config.py
@@ -2,13 +2,18 @@ import logging
 import os
 import re
 from dataclasses import dataclass
+from typing import Literal
 
 _SAFE_TABLE_NAME = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+_SAFE_NAMESPACE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
 # Shared with ducklake._validate_partition_expr — keep in sync or import from here.
 SAFE_PARTITION_EXPR = re.compile(r"^[a-zA-Z0-9_(),\s]+$")
 
 log = logging.getLogger(__name__)
+
+Destination = Literal["ducklake", "iceberg"]
+_DESTINATIONS: tuple[Destination, ...] = ("ducklake", "iceberg")
 
 
 @dataclass(frozen=True)
@@ -22,24 +27,45 @@ class Config:
     replica_count: int
     ordinal: int
 
-    # DuckLake
-    ducklake_table: str
-    ducklake_data_path: str
-    ducklake_connection: str
+    # Destination selection — a pod writes to exactly one of these for its lifetime.
+    destination: Destination
 
-    # RDS (DuckLake metadata store)
-    rds_host: str
-    rds_port: str
-    rds_database: str
-    rds_username: str
-    rds_password: str
+    # The DuckLake-* and Iceberg-* fields below are kept as `str | None`
+    # rather than split into a tagged union (DuckLakeConfig | IcebergConfig)
+    # because the load-time `if destination == ...` branch already enforces
+    # presence of the right subset, and the Sink constructors raise
+    # RuntimeError on missing fields (so `python -O` doesn't strip the
+    # guards). A tagged-union refactor is a reasonable next step but
+    # doesn't buy correctness on top of what we already have.
+
+    # DuckLake — required when destination == "ducklake", else None.
+    ducklake_table: str | None
+    ducklake_data_path: str | None
+    ducklake_connection: str | None
+    rds_host: str | None
+    rds_port: str | None
+    rds_database: str | None
+    rds_username: str | None
+    rds_password: str | None
+    partition_by: str | None  # e.g. "year(timestamp),month(timestamp),day(timestamp),hour(timestamp)"
+
+    # Iceberg — required when destination == "iceberg", else None.
+    iceberg_catalog_uri: str | None
+    iceberg_warehouse: str | None
+    iceberg_namespace: str | None
+    iceberg_table: str | None
+    iceberg_table_location: str | None  # explicit s3:// path; None lets the catalog decide
+    iceberg_catalog_token: str | None  # bearer / OAuth token, optional
+
+    # S3 for Iceberg data files. Ducklake uses DUCKDB_S3_* env vars read directly by ducklake.connect.
+    s3_access_key_id: str | None
+    s3_secret_access_key: str | None
+    s3_region: str | None
+    s3_endpoint: str | None
 
     # Flush triggers
     flush_size: int  # bytes of accumulated Arrow data
     flush_interval_ms: int  # ms since last flush
-
-    # Partitioning
-    partition_by: str | None  # e.g. "year(timestamp),month(timestamp),day(timestamp),hour(timestamp)"
 
     # Consumer tuning
     fetch_min_bytes: int
@@ -57,6 +83,14 @@ class Config:
     def flush_interval_s(self) -> float:
         return self.flush_interval_ms / 1000.0
 
+    @property
+    def table_label(self) -> str:
+        """Single human-readable identifier for the destination table.
+        Used in metrics pipeline labels and the Kafka client.id."""
+        if self.destination == "iceberg":
+            return f"{self.iceberg_namespace}.{self.iceberg_table}"
+        return self.ducklake_table or "unknown"
+
 
 def _parse_ordinal(pod_name: str) -> int:
     """Extract ordinal from pod name (e.g. 'millpond-events-3' -> 3)."""
@@ -73,13 +107,70 @@ def _require(name: str) -> str:
     return val
 
 
-def load() -> Config:
-    topic = _require("KAFKA_TOPIC")
+def _load_ducklake_fields() -> dict[str, str | None]:
     ducklake_table = _require("DUCKLAKE_TABLE")
     if not _SAFE_TABLE_NAME.match(ducklake_table):
         raise RuntimeError(
             f"DUCKLAKE_TABLE {ducklake_table!r} contains unsafe characters (must match [a-zA-Z_][a-zA-Z0-9_]*)"
         )
+
+    partition_by = os.environ.get("DUCKLAKE_PARTITION_BY", "").strip() or None
+    if partition_by and not SAFE_PARTITION_EXPR.match(partition_by):
+        raise RuntimeError(
+            f"DUCKLAKE_PARTITION_BY {partition_by!r} contains unsafe characters (must match [a-zA-Z0-9_(),\\s]+)"
+        )
+
+    return {
+        "ducklake_table": ducklake_table,
+        "ducklake_data_path": _require("DUCKLAKE_DATA_PATH"),
+        "ducklake_connection": _require("DUCKLAKE_CONNECTION"),
+        "rds_host": _require("DUCKLAKE_RDS_HOST"),
+        "rds_port": os.environ.get("DUCKLAKE_RDS_PORT", "5432"),
+        "rds_database": os.environ.get("DUCKLAKE_RDS_DATABASE", "ducklake"),
+        "rds_username": os.environ.get("DUCKLAKE_RDS_USERNAME", "ducklake"),
+        "rds_password": _require("DUCKLAKE_RDS_PASSWORD"),
+        "partition_by": partition_by,
+    }
+
+
+def _load_iceberg_fields() -> dict[str, str | None]:
+    iceberg_table = _require("ICEBERG_TABLE")
+    if not _SAFE_TABLE_NAME.match(iceberg_table):
+        raise RuntimeError(
+            f"ICEBERG_TABLE {iceberg_table!r} contains unsafe characters (must match [a-zA-Z_][a-zA-Z0-9_]*)"
+        )
+
+    iceberg_namespace = _require("ICEBERG_NAMESPACE")
+    if not _SAFE_NAMESPACE.match(iceberg_namespace):
+        raise RuntimeError(
+            f"ICEBERG_NAMESPACE {iceberg_namespace!r} contains unsafe characters (must match [a-zA-Z_][a-zA-Z0-9_]*)"
+        )
+
+    return {
+        "iceberg_catalog_uri": _require("ICEBERG_CATALOG_URI"),
+        "iceberg_warehouse": _require("ICEBERG_WAREHOUSE"),
+        "iceberg_namespace": iceberg_namespace,
+        "iceberg_table": iceberg_table,
+        "iceberg_table_location": os.environ.get("ICEBERG_TABLE_LOCATION") or None,
+        "iceberg_catalog_token": os.environ.get("ICEBERG_CATALOG_TOKEN") or None,
+        "s3_access_key_id": _require("MILLPOND_S3_ACCESS_KEY_ID"),
+        "s3_secret_access_key": _require("MILLPOND_S3_SECRET_ACCESS_KEY"),
+        "s3_region": _require("MILLPOND_S3_REGION"),
+        "s3_endpoint": os.environ.get("MILLPOND_S3_ENDPOINT") or None,
+    }
+
+
+def load() -> Config:
+    topic = _require("KAFKA_TOPIC")
+
+    # Tolerate the common helm-template gotcha where an unset variable
+    # renders as the empty string instead of being absent. Empty,
+    # whitespace-only, and unset all fall back to the default. Single
+    # collapsed expression: `.strip().lower()` first, then `or` once.
+    destination_raw = os.environ.get("MILLPOND_DESTINATION", "").strip().lower() or "ducklake"
+    if destination_raw not in _DESTINATIONS:
+        raise RuntimeError(f"MILLPOND_DESTINATION {destination_raw!r} must be one of: {', '.join(_DESTINATIONS)}")
+    destination: Destination = destination_raw  # type: ignore[assignment]
 
     pod_name = os.environ.get("POD_NAME") or os.environ.get("HOSTNAME", "millpond-0")
     ordinal = _parse_ordinal(pod_name)
@@ -88,13 +179,44 @@ def load() -> Config:
     if ordinal >= replica_count:
         raise RuntimeError(f"Ordinal {ordinal} >= REPLICA_COUNT {replica_count}")
 
-    group_id = os.environ.get("GROUP_ID", f"millpond-{topic}-{ducklake_table}")
+    ducklake_kwargs: dict[str, str | None] = dict.fromkeys(
+        (
+            "ducklake_table",
+            "ducklake_data_path",
+            "ducklake_connection",
+            "rds_host",
+            "rds_port",
+            "rds_database",
+            "rds_username",
+            "rds_password",
+            "partition_by",
+        ),
+        None,
+    )
+    iceberg_kwargs: dict[str, str | None] = dict.fromkeys(
+        (
+            "iceberg_catalog_uri",
+            "iceberg_warehouse",
+            "iceberg_namespace",
+            "iceberg_table",
+            "iceberg_table_location",
+            "iceberg_catalog_token",
+            "s3_access_key_id",
+            "s3_secret_access_key",
+            "s3_region",
+            "s3_endpoint",
+        ),
+        None,
+    )
 
-    partition_by = os.environ.get("DUCKLAKE_PARTITION_BY", "").strip() or None
-    if partition_by and not SAFE_PARTITION_EXPR.match(partition_by):
-        raise RuntimeError(
-            f"DUCKLAKE_PARTITION_BY {partition_by!r} contains unsafe characters (must match [a-zA-Z0-9_(),\\s]+)"
-        )
+    if destination == "ducklake":
+        ducklake_kwargs.update(_load_ducklake_fields())
+        table_label_part = ducklake_kwargs["ducklake_table"]
+    else:
+        iceberg_kwargs.update(_load_iceberg_fields())
+        table_label_part = iceberg_kwargs["iceberg_table"]
+
+    group_id = os.environ.get("GROUP_ID", f"millpond-{topic}-{table_label_part}")
 
     # Collect KAFKA_CONSUMER_* env vars as librdkafka config overrides.
     # e.g. KAFKA_CONSUMER_SECURITY_PROTOCOL=SASL_SSL -> security.protocol=SASL_SSL
@@ -111,15 +233,9 @@ def load() -> Config:
         group_id=group_id,
         replica_count=replica_count,
         ordinal=ordinal,
-        ducklake_table=ducklake_table,
-        ducklake_data_path=_require("DUCKLAKE_DATA_PATH"),
-        ducklake_connection=_require("DUCKLAKE_CONNECTION"),
-        rds_host=_require("DUCKLAKE_RDS_HOST"),
-        rds_port=os.environ.get("DUCKLAKE_RDS_PORT", "5432"),
-        rds_database=os.environ.get("DUCKLAKE_RDS_DATABASE", "ducklake"),
-        rds_username=os.environ.get("DUCKLAKE_RDS_USERNAME", "ducklake"),
-        rds_password=_require("DUCKLAKE_RDS_PASSWORD"),
-        partition_by=partition_by,
+        destination=destination,
+        **ducklake_kwargs,
+        **iceberg_kwargs,
         flush_size=int(os.environ.get("FLUSH_SIZE", "104857600")),
         flush_interval_ms=int(os.environ.get("FLUSH_INTERVAL_MS", "60000")),
         fetch_min_bytes=int(os.environ.get("FETCH_MIN_BYTES", "1048576")),
@@ -131,9 +247,10 @@ def load() -> Config:
     )
 
     log.info(
-        "Config: topic=%s table=%s ordinal=%d/%d group_id=%s",
+        "Config: destination=%s topic=%s table=%s ordinal=%d/%d group_id=%s",
+        destination,
         topic,
-        ducklake_table,
+        cfg.table_label,
         ordinal,
         replica_count,
         cfg.group_id,

--- a/millpond/consumer.py
+++ b/millpond/consumer.py
@@ -55,7 +55,7 @@ def _base_kafka_config(cfg: Config) -> dict:
     """Base config shared by all Kafka clients (AdminClient, Consumer)."""
     base = {
         "bootstrap.servers": cfg.bootstrap_servers,
-        "client.id": f"millpond-{cfg.topic}-{cfg.ducklake_table}-{cfg.ordinal}",
+        "client.id": f"millpond-{cfg.topic}-{cfg.table_label}-{cfg.ordinal}",
     }
     for key, val in cfg.kafka_config_overrides:
         base[key] = val

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -219,8 +219,23 @@ class DuckLakeSink:
     """
 
     def __init__(self, cfg: Config):
-        if cfg.ducklake_table is None:
-            raise RuntimeError("DuckLakeSink requires cfg.ducklake_table; config.load() should have enforced this")
+        # Explicit guards rather than assert: `python -O` strips asserts and
+        # would forward None to connect(), producing a cryptic libpq
+        # "host=None" failure instead of a clear startup error. Symmetric
+        # with IcebergSink. All fields below are read either by connect()
+        # building the Postgres connstring or by this constructor.
+        for name in (
+            "ducklake_table",
+            "ducklake_connection",
+            "ducklake_data_path",
+            "rds_host",
+            "rds_port",
+            "rds_database",
+            "rds_username",
+            "rds_password",
+        ):
+            if getattr(cfg, name) is None:
+                raise RuntimeError(f"DuckLakeSink requires cfg.{name}; config.load() should have enforced this")
         self._cfg = cfg
         self._conn = connect(cfg)
         self._table_name = cfg.ducklake_table

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import re
@@ -7,10 +9,20 @@ import pyarrow as pa
 
 from millpond import schema
 from millpond.config import Config
+from millpond.sink import check_reserved_collision
 
 log = logging.getLogger(__name__)
 
 _SETTING_VALUE_RE = re.compile(r"^[a-zA-Z0-9_.:/\-@+=]+$")
+
+# Column names reserved as metadata. DuckLake itself only writes
+# `_inserted_at`, but the set is kept identical to
+# `millpond.iceberg.RESERVED_COLUMNS` so a deployment-time switch between
+# destinations doesn't suddenly start rejecting (or quietly accepting)
+# batches based on user-column collisions. The shared set is the union of
+# both backends' actual managed columns; DuckLake reserves the extras
+# defensively even though it doesn't produce them itself.
+RESERVED_COLUMNS: frozenset[str] = frozenset({"_inserted_at", "year", "month", "day", "hour"})
 
 
 def _escape_libpq(value: str | None) -> str:
@@ -103,15 +115,6 @@ def _validate_partition_expr(expr: str) -> str:
     return expr
 
 
-# Assumes single connection for pod lifetime. Must be cleared if connection is ever recycled.
-_tables_ensured: set[str] = set()
-
-
-def reset_table_cache() -> None:
-    """Clear the table creation cache. Call when the DuckDB connection is recycled."""
-    _tables_ensured.clear()
-
-
 def _table_exists(conn: duckdb.DuckDBPyConnection, table_name: str) -> bool:
     """Check if a table exists in the DuckLake catalog."""
     result = conn.execute(
@@ -126,20 +129,30 @@ def _ensure_table(
     conn: duckdb.DuckDBPyConnection,
     table_name: str,
     batch: pa.Table,
+    tables_ensured: set[str],
     partition_by: str | None = None,
 ) -> None:
-    """Create the DuckLake table if it doesn't exist. Cached after first call.
+    """Create the DuckLake table if it doesn't exist. Caller-owned cache.
 
     Handles concurrent creation by multiple pods: if CREATE or ALTER fails
     with a serialization/catalog error, we check if the table now exists
-    and treat that as success.
+    and treat that as success. `tables_ensured` is owned by the caller
+    (a Sink instance) so cache lifetime tracks the connection's.
+
+    Multi-writer DDL safety: `CREATE TABLE IF NOT EXISTS` and the
+    `_table_exists` re-check on error make CREATE idempotent across pods.
+    `ADD COLUMN IF NOT EXISTS` in schema.SchemaManager makes evolution
+    idempotent too. A pod with a stale `_known_columns` view that races
+    against another writer's ADD COLUMN will either succeed (the INSERT
+    `BY NAME` tolerates the extra column existing) or fail and trip the
+    write-retry path that invalidates the schema cache.
     """
-    if table_name in _tables_ensured:
+    if table_name in tables_ensured:
         return
 
     if _table_exists(conn, table_name):
         log.info("Table %s already exists", table_name)
-        _tables_ensured.add(table_name)
+        tables_ensured.add(table_name)
         return
 
     conn.register("_schema_batch", batch.slice(0, 0))  # empty batch, just schema
@@ -169,18 +182,20 @@ def _ensure_table(
             else:
                 raise RuntimeError(f"Failed to partition table {table_name}: {e}") from e
 
-    _tables_ensured.add(table_name)
+    tables_ensured.add(table_name)
 
 
 def write(
     conn: duckdb.DuckDBPyConnection,
     table_name: str,
     batch: pa.Table,
-    schema_mgr: "schema.SchemaManager | None" = None,
+    tables_ensured: set[str],
+    schema_mgr: schema.SchemaManager | None = None,
     partition_by: str | None = None,
 ) -> None:
     """Write an Arrow table to DuckLake with _inserted_at timestamp."""
-    _ensure_table(conn, table_name, batch, partition_by)
+    check_reserved_collision(batch.schema, RESERVED_COLUMNS, "DuckLake")
+    _ensure_table(conn, table_name, batch, tables_ensured, partition_by)
     if schema_mgr is not None:
         schema_mgr.evolve(batch.schema)
     conn.register("_arrow_batch", batch)
@@ -188,3 +203,37 @@ def write(
         conn.execute(f"INSERT INTO lake.main.{table_name} BY NAME (SELECT *, NOW() AS _inserted_at FROM _arrow_batch)")
     finally:
         conn.unregister("_arrow_batch")
+
+
+class DuckLakeSink:
+    """`Sink` implementation for DuckLake.
+
+    Thin wrapper around the module-level `connect`/`write` helpers and the
+    existing `schema.SchemaManager`. main.py only sees the Sink protocol;
+    whether schema evolution happens via DuckLake DDL or Iceberg
+    `update_schema()` is none of its business.
+
+    The table cache and SchemaManager are instance state — each Sink owns
+    its own — so multiple Sink instances in the same process (tests, future
+    features) don't trample one another.
+    """
+
+    def __init__(self, cfg: Config):
+        if cfg.ducklake_table is None:
+            raise RuntimeError("DuckLakeSink requires cfg.ducklake_table; config.load() should have enforced this")
+        self._cfg = cfg
+        self._conn = connect(cfg)
+        self._table_name = cfg.ducklake_table
+        self._partition_by = cfg.partition_by
+        self._tables_ensured: set[str] = set()
+        self._schema_mgr = schema.SchemaManager(self._conn, self._table_name)
+
+    def write(self, batch: pa.Table) -> None:
+        write(self._conn, self._table_name, batch, self._tables_ensured, self._schema_mgr, self._partition_by)
+
+    def reset_caches(self) -> None:
+        self._tables_ensured.clear()
+        self._schema_mgr.invalidate()
+
+    def close(self) -> None:
+        self._conn.close()

--- a/millpond/iceberg.py
+++ b/millpond/iceberg.py
@@ -65,8 +65,11 @@ _PARTITION_FIELD_ID_BASE = 1000
 
 # Columns IcebergSink manages itself; source schemas must not shadow them.
 # `_inserted_at` is added at write time; the four partition cols are derived
-# from it. Shared structure with `millpond.ducklake.RESERVED_COLUMNS` (which
-# is a smaller set — DuckLake doesn't derive partition columns).
+# from it. `millpond.ducklake.RESERVED_COLUMNS` holds the same five names
+# today — DuckLake reserves the partition cols defensively even though it
+# doesn't produce them itself, so a deployment-time switch between
+# destinations can't suddenly start accepting or rejecting batches based on
+# user-column collisions.
 RESERVED_COLUMNS: frozenset[str] = frozenset({"_inserted_at", *PARTITION_COLS})
 
 
@@ -107,8 +110,14 @@ def connect(
 
 
 def _now_utc_us() -> datetime.datetime:
-    """Microsecond-precision UTC now, matching the timestamp type Iceberg expects."""
-    return datetime.datetime.now(datetime.UTC).replace(microsecond=0)
+    """Microsecond-precision UTC now, matching the timestamp type Iceberg expects.
+
+    `datetime.datetime.now(UTC)` is microsecond-precision on every platform
+    we support; the Arrow `pa.timestamp("us", tz="UTC")` type carried in
+    `_inserted_at` is also microsecond, so no rounding happens on the
+    way through PyIceberg's append path.
+    """
+    return datetime.datetime.now(datetime.UTC)
 
 
 def _add_metadata_columns(batch: pa.Table) -> pa.Table:

--- a/millpond/iceberg.py
+++ b/millpond/iceberg.py
@@ -1,0 +1,478 @@
+"""Iceberg write path.
+
+``connect()`` returns a long-lived PyIceberg ``Catalog`` handle, ``write()``
+appends an Arrow batch via a REST commit. ``IcebergSink`` wraps both plus
+an internal schema manager and conforms to the `Sink` protocol consumed by
+`main.py`.
+
+Partition layout is fixed: identity transforms on ``year`` / ``month`` /
+``day`` / ``hour`` derived from ``_inserted_at`` at write time. This produces
+a Hive-style layout (``year=2026/month=5/day=13/hour=14/*.parquet``) on S3
+that downstream tooling can prefix-filter, at the cost of reader ergonomics
+— Iceberg doesn't know the four columns are derived from the timestamp, so
+queries need to filter on the partition columns explicitly for pruning. If
+reader ergonomics ever bite, we can layer a second hidden-partitioning spec
+on top via Iceberg's spec evolution; not needed today.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+
+import pyarrow as pa
+import pyarrow.compute as pc
+from pyiceberg.catalog import Catalog, load_catalog
+from pyiceberg.exceptions import (
+    CommitFailedException,
+    NoSuchTableError,
+    TableAlreadyExistsError,
+)
+from pyiceberg.io.pyarrow import _pyarrow_to_schema_without_ids
+from pyiceberg.partitioning import PartitionField, PartitionSpec
+from pyiceberg.schema import assign_fresh_schema_ids
+from pyiceberg.table import Table
+from pyiceberg.transforms import IdentityTransform
+from pyiceberg.types import (
+    BinaryType,
+    BooleanType,
+    DateType,
+    DoubleType,
+    FloatType,
+    IcebergType,
+    IntegerType,
+    LongType,
+    StringType,
+    TimestampType,
+    TimestamptzType,
+)
+
+from millpond import metrics
+from millpond.config import Config
+from millpond.sink import SAFE_IDENTIFIER, check_reserved_collision
+
+log = logging.getLogger(__name__)
+
+# Names of the derived partition columns appended to every batch before append.
+# Order matters: it defines the on-disk directory nesting in the Hive layout.
+PARTITION_COLS: tuple[str, ...] = ("year", "month", "day", "hour")
+
+# Iceberg requires every PartitionField to have a stable field_id that's
+# distinct from any column's field_id. We start the partition field IDs well
+# above any plausible source-schema field count so they never collide with
+# columns the converter assigns. Field IDs are catalog-wide so this matters.
+_PARTITION_FIELD_ID_BASE = 1000
+
+# Columns IcebergSink manages itself; source schemas must not shadow them.
+# `_inserted_at` is added at write time; the four partition cols are derived
+# from it. Shared structure with `millpond.ducklake.RESERVED_COLUMNS` (which
+# is a smaller set — DuckLake doesn't derive partition columns).
+RESERVED_COLUMNS: frozenset[str] = frozenset({"_inserted_at", *PARTITION_COLS})
+
+
+def connect(
+    catalog_uri: str,
+    warehouse: str,
+    s3_access_key_id: str,
+    s3_secret_access_key: str,
+    s3_region: str,
+    *,
+    catalog_token: str | None = None,
+    s3_endpoint: str | None = None,
+) -> Catalog:
+    """Load the REST catalog with S3 credentials passed as catalog properties.
+
+    PyIceberg's PyArrow S3 filesystem reads ``s3.access-key-id`` /
+    ``s3.secret-access-key`` / ``s3.region`` from the catalog properties
+    before falling back to the AWS env var chain (verified against
+    pyiceberg 0.11.1). Passing them here keeps the IRSA token used for
+    Kafka MSK auth out of the S3 client's credential resolution, exactly
+    the way ``DUCKDB_S3_*`` env vars did for DuckDB.
+    """
+    props: dict[str, str] = {
+        "type": "rest",
+        "uri": catalog_uri,
+        "warehouse": warehouse,
+        "s3.access-key-id": s3_access_key_id,
+        "s3.secret-access-key": s3_secret_access_key,
+        "s3.region": s3_region,
+    }
+    if catalog_token:
+        props["token"] = catalog_token
+    if s3_endpoint:
+        props["s3.endpoint"] = s3_endpoint
+    cat = load_catalog("lake", **props)
+    log.info("Iceberg REST catalog loaded: uri=%s warehouse=%s", catalog_uri, warehouse)
+    return cat
+
+
+def _now_utc_us() -> datetime.datetime:
+    """Microsecond-precision UTC now, matching the timestamp type Iceberg expects."""
+    return datetime.datetime.now(datetime.UTC).replace(microsecond=0)
+
+
+def _add_metadata_columns(batch: pa.Table) -> pa.Table:
+    """Append ``_inserted_at`` plus the four partition columns.
+
+    All rows in a single batch share the same ``_inserted_at`` value so
+    a flush always lands in exactly one partition. Year/month/day/hour
+    are derived from that timestamp via PyArrow compute; cast to int32
+    explicitly because pc.year/month/day/hour all return int64.
+    """
+    now = _now_utc_us()
+    ts_type = pa.timestamp("us", tz="UTC")
+    ts_array = pa.array([now] * len(batch), ts_type)
+    batch = batch.append_column("_inserted_at", ts_array)
+    ts = batch.column("_inserted_at")
+    batch = batch.append_column("year", pc.cast(pc.year(ts), pa.int32()))
+    batch = batch.append_column("month", pc.cast(pc.month(ts), pa.int32()))
+    batch = batch.append_column("day", pc.cast(pc.day(ts), pa.int32()))
+    batch = batch.append_column("hour", pc.cast(pc.hour(ts), pa.int32()))
+    return batch
+
+
+def _schema_sample(source_batch: pa.Table) -> pa.Table:
+    """Empty Arrow table with the on-disk schema (source cols + metadata cols)."""
+    sample = source_batch.slice(0, 0)
+    sample = sample.append_column("_inserted_at", pa.array([], pa.timestamp("us", tz="UTC")))
+    for name in PARTITION_COLS:
+        sample = sample.append_column(name, pa.array([], pa.int32()))
+    return sample
+
+
+def _build_partition_spec(iceberg_schema) -> PartitionSpec:
+    """Identity transform on each of year/month/day/hour."""
+    return PartitionSpec(
+        *(
+            PartitionField(
+                source_id=iceberg_schema.find_field(name).field_id,
+                field_id=_PARTITION_FIELD_ID_BASE + i,
+                transform=IdentityTransform(),
+                name=name,
+            )
+            for i, name in enumerate(PARTITION_COLS)
+        )
+    )
+
+
+def _ensure_table(
+    catalog: Catalog,
+    namespace: str,
+    table_name: str,
+    source_batch: pa.Table,
+    tables_ensured: dict[str, Table],
+    location: str | None = None,
+) -> Table:
+    """Get-or-create the Iceberg table. Caller-owned cache (`tables_ensured`).
+
+    Concurrent creation: if ``create_table`` raises with a known
+    already-exists / commit-conflict signal, we fall back to ``load_table``.
+    The first writer's schema wins for now — schema evolution from a
+    concurrent newer-schema pod is handled by ``SchemaManager`` on
+    subsequent writes, not here.
+    """
+    key = f"{namespace}.{table_name}"
+    if (cached := tables_ensured.get(key)) is not None:
+        return cached
+
+    identifier = (namespace, table_name)
+    try:
+        table = catalog.load_table(identifier)
+        log.info("Iceberg table %s.%s already exists, loaded", namespace, table_name)
+    except NoSuchTableError:
+        sample = _schema_sample(source_batch)
+        # _pyarrow_to_schema_without_ids converts the PyArrow schema but
+        # leaves every field_id at -1 (it's meant to feed a name-mapping
+        # pass downstream). For our purposes we want sequential IDs so the
+        # partition spec can reference columns by ID. assign_fresh_schema_ids
+        # walks the schema and replaces -1s with monotonically increasing
+        # IDs starting from 1 — the same thing create_table does internally
+        # for pa.Schema inputs, but we need the IDs *before* building the
+        # partition spec.
+        iceberg_schema = assign_fresh_schema_ids(_pyarrow_to_schema_without_ids(sample.schema))
+        spec = _build_partition_spec(iceberg_schema)
+        catalog.create_namespace_if_not_exists(namespace)
+        create_kwargs: dict[str, object] = {"partition_spec": spec}
+        if location:
+            create_kwargs["location"] = location
+        try:
+            table = catalog.create_table(identifier, schema=iceberg_schema, **create_kwargs)
+            log.info("Created Iceberg table %s.%s with partition spec %s", namespace, table_name, PARTITION_COLS)
+        except (TableAlreadyExistsError, CommitFailedException):
+            # Another writer beat us to it; load what they created.
+            table = catalog.load_table(identifier)
+            log.info("Iceberg table %s.%s created by another writer, loaded", namespace, table_name)
+
+    tables_ensured[key] = table
+    return table
+
+
+def _arrow_to_iceberg(arrow_type: pa.DataType) -> IcebergType:
+    """Map a PyArrow type to an Iceberg type.
+
+    Source data has nested types (struct/list/map) JSON-stringified upstream
+    in arrow_converter, so by the time a field reaches us its type should be
+    flat. Anything we don't recognise falls back to ``StringType``.
+    """
+    if pa.types.is_boolean(arrow_type):
+        return BooleanType()
+    # Iceberg has no signed int width below 32; widen on the way in. uint32
+    # exceeds int32 range so widen to LongType to be safe.
+    if pa.types.is_int8(arrow_type) or pa.types.is_int16(arrow_type) or pa.types.is_int32(arrow_type):
+        return IntegerType()
+    if pa.types.is_uint8(arrow_type) or pa.types.is_uint16(arrow_type):
+        return IntegerType()
+    # uint64 → LongType is a width truncation: uint64 max (2^64-1) exceeds
+    # int63 max (2^63-1) so values above 2^63-1 will fail to write. This
+    # matches Iceberg's type system limits (no unsigned types) and we accept
+    # the trade-off — flag it in deployment docs if your producer can emit
+    # values that large.
+    if pa.types.is_int64(arrow_type) or pa.types.is_uint32(arrow_type) or pa.types.is_uint64(arrow_type):
+        return LongType()
+    if pa.types.is_float16(arrow_type) or pa.types.is_float32(arrow_type):
+        return FloatType()
+    if pa.types.is_float64(arrow_type):
+        return DoubleType()
+    if pa.types.is_string(arrow_type) or pa.types.is_large_string(arrow_type):
+        return StringType()
+    if pa.types.is_binary(arrow_type) or pa.types.is_large_binary(arrow_type):
+        return BinaryType()
+    if pa.types.is_date(arrow_type):
+        return DateType()
+    if pa.types.is_timestamp(arrow_type):
+        return TimestamptzType() if arrow_type.tz else TimestampType()
+    return StringType()
+
+
+class SchemaManager:
+    """Tracks the Iceberg table schema and evolves it as needed.
+
+    Internal to the Iceberg backend — main.py only sees `IcebergSink.write()`.
+    Schema state is cached per instance to avoid round-tripping the catalog on
+    every flush. ``invalidate()`` forces a reload on the next ``evolve()``;
+    called by the write-retry path after a failed write since another writer
+    may have changed the schema underneath us.
+    """
+
+    def __init__(self, catalog: Catalog, namespace: str, table_name: str):
+        self._catalog = catalog
+        self._namespace = namespace
+        self._table_name = table_name
+        self._known: dict[str, IcebergType] = {}
+        self._initialized = False
+
+    def _identifier(self) -> tuple[str, str]:
+        return (self._namespace, self._table_name)
+
+    def _load_table_schema(self) -> None:
+        try:
+            table = self._catalog.load_table(self._identifier())
+            self._known = {f.name: f.field_type for f in table.schema().fields}
+        except NoSuchTableError:
+            # Table not created yet; _ensure_table will land it on the next
+            # write. evolve() returns early in this case and picks it up
+            # after the table is created.
+            self._known = {}
+        except Exception:
+            # Transient catalog failure (network, server 5xx). Log at WARNING
+            # with the exception so an operator sees what blipped, and leave
+            # _known empty. The next evolve() call will retry the load.
+            log.warning(
+                "Failed to load Iceberg table schema for %s.%s",
+                self._namespace,
+                self._table_name,
+                exc_info=True,
+            )
+            self._known = {}
+        self._initialized = True
+
+    def evolve(self, batch_schema: pa.Schema) -> bool:
+        """Reconcile the live table schema with the columns in ``batch_schema``.
+
+        Returns True iff this call committed a schema change (caller can use
+        the signal to skip a redundant post-evolve table reload). Adds and
+        widenings are collected and applied in a single ``update_schema()``
+        transaction.
+
+        On commit failure (CommitFailedException, etc.) this **re-raises**
+        rather than swallowing — the write-retry loop in ``main.py`` then
+        invalidates caches and retries. Earlier versions caught broadly and
+        continued to ``Table.append`` with a stale schema view; that defeated
+        the retry contract.
+        """
+        if not self._initialized:
+            self._load_table_schema()
+        if not self._known:
+            # Table not yet present; _ensure_table will create it with the
+            # source schema on the next write. Force a reload on the
+            # following evolve() call so we pick up the new state.
+            self._initialized = False
+            return False
+
+        additions: list[tuple[str, IcebergType]] = []
+        widenings: list[tuple[str, IcebergType, IcebergType]] = []
+
+        for field in batch_schema:
+            if field.name in RESERVED_COLUMNS:
+                continue
+            if not SAFE_IDENTIFIER.match(field.name):
+                log.warning("Skipping unsafe field name: %r", field.name)
+                metrics.records_skipped_total.labels(reason="unsafe_field_name").inc()
+                continue
+
+            ice_type = _arrow_to_iceberg(field.type)
+            if field.name not in self._known:
+                additions.append((field.name, ice_type))
+            elif type(self._known[field.name]) is not type(ice_type):
+                widenings.append((field.name, self._known[field.name], ice_type))
+
+        if not additions and not widenings:
+            return False
+
+        try:
+            table = self._catalog.load_table(self._identifier())
+            with table.update_schema() as us:
+                for name, ice_type in additions:
+                    us.add_column(name, ice_type)
+                for name, _old, new in widenings:
+                    us.update_column(name, field_type=new)
+        except Exception:
+            # Bump the schema-error counter, invalidate, re-raise. The retry
+            # path will reload (possibly observing another writer's evolution)
+            # and try again.
+            metrics.errors_total.labels(type="schema").inc()
+            self._initialized = False
+            raise
+
+        # update_schema auto-commits on context exit. The commit
+        # succeeded; from here on we're only updating local mirror state
+        # and emitting observability. Errors past this point must NOT lose
+        # the success metrics — count by intent (what we asked for and
+        # what update_schema accepted) rather than by post-commit
+        # observation, which can transiently fail.
+        for name, ice_type in additions:
+            metrics.schema_columns_added_total.inc()
+            log.info("Schema evolution: added column %s (%s)", name, ice_type)
+        for name, old, new in widenings:
+            metrics.schema_columns_widened_total.inc()
+            log.info("Schema evolution: widened column %s from %s to %s", name, old, new)
+
+        # Re-mirror local state from the post-commit snapshot. If this
+        # reload transiently fails, `_load_table_schema` clears `_known`
+        # and the *next* evolve() will retry the load — metrics are
+        # already counted, so no double-counting risk.
+        self._load_table_schema()
+        return True
+
+    def invalidate(self) -> None:
+        """Force a reload of the table schema on the next ``evolve()`` call."""
+        self._initialized = False
+
+
+def write(
+    catalog: Catalog,
+    namespace: str,
+    table_name: str,
+    source_batch: pa.Table,
+    tables_ensured: dict[str, Table],
+    schema_mgr: SchemaManager | None = None,
+    location: str | None = None,
+) -> None:
+    """Append an Arrow batch to the Iceberg table.
+
+    Per the Sink contract callers must not invoke ``write()`` with a
+    zero-row batch (``main.py`` gates on ``pending_records > 0``).
+    This function defensively short-circuits if it ever happens — an
+    empty append would still incur a REST commit for no benefit. Note
+    this means a never-touched Iceberg table is created lazily on the
+    first non-empty batch; the DuckLake backend instead creates the
+    table eagerly on any write call. The divergence is acceptable
+    because main.py never exercises the empty-batch path.
+
+    Adds ``_inserted_at`` plus the four partition columns derived from
+    it, then calls ``Table.append(...)``. ``schema_mgr`` (when supplied)
+    evolves the catalog schema to accommodate any new source columns in
+    the batch — and only re-loads the cached Table object when evolution
+    actually committed a change.
+    """
+    if len(source_batch) == 0:
+        return
+    check_reserved_collision(source_batch.schema, RESERVED_COLUMNS, "Iceberg")
+
+    table = _ensure_table(catalog, namespace, table_name, source_batch, tables_ensured, location)
+    if schema_mgr is not None and schema_mgr.evolve(source_batch.schema):
+        # Schema changed; refresh the cached Table so the append sees the
+        # new columns. Skip the round-trip when nothing committed (common
+        # case after the first flush).
+        table = catalog.load_table((namespace, table_name))
+        tables_ensured[f"{namespace}.{table_name}"] = table
+
+    batch_with_meta = _add_metadata_columns(source_batch)
+    table.append(batch_with_meta)
+
+
+class IcebergSink:
+    """`Sink` implementation for Iceberg.
+
+    Thin wrapper around the module-level `connect` / `write` helpers and the
+    in-module `SchemaManager`. main.py only sees the Sink protocol; whether
+    schema evolution happens via DuckLake DDL or Iceberg `update_schema()`
+    is none of its business.
+
+    The table cache and SchemaManager are instance state — each Sink owns
+    its own — so multiple Sink instances in the same process (tests, future
+    features) don't trample one another.
+    """
+
+    def __init__(self, cfg: Config):
+        # Explicit guards rather than assert: `python -O` strips asserts and
+        # would forward None to connect(), producing a cryptic pyiceberg
+        # failure on first write instead of a clear startup error.
+        for name in (
+            "iceberg_catalog_uri",
+            "iceberg_warehouse",
+            "iceberg_namespace",
+            "iceberg_table",
+            "s3_access_key_id",
+            "s3_secret_access_key",
+            "s3_region",
+        ):
+            if getattr(cfg, name) is None:
+                raise RuntimeError(f"IcebergSink requires cfg.{name}; config.load() should have enforced this")
+        self._cfg = cfg
+        self._catalog = connect(
+            catalog_uri=cfg.iceberg_catalog_uri,
+            warehouse=cfg.iceberg_warehouse,
+            s3_access_key_id=cfg.s3_access_key_id,
+            s3_secret_access_key=cfg.s3_secret_access_key,
+            s3_region=cfg.s3_region,
+            catalog_token=cfg.iceberg_catalog_token,
+            s3_endpoint=cfg.s3_endpoint,
+        )
+        self._namespace = cfg.iceberg_namespace
+        self._table_name = cfg.iceberg_table
+        self._location = cfg.iceberg_table_location
+        self._tables_ensured: dict[str, Table] = {}
+        self._schema_mgr = SchemaManager(self._catalog, self._namespace, self._table_name)
+
+    def write(self, batch: pa.Table) -> None:
+        write(
+            self._catalog,
+            self._namespace,
+            self._table_name,
+            batch,
+            self._tables_ensured,
+            self._schema_mgr,
+            self._location,
+        )
+
+    def reset_caches(self) -> None:
+        # Called by _write_with_retry after a failed write — drops cached
+        # table state so the next attempt re-checks the catalog. Invariant:
+        # main.py is the only caller; sink internals do not self-reset.
+        self._tables_ensured.clear()
+        self._schema_mgr.invalidate()
+
+    def close(self) -> None:
+        # PyIceberg REST catalog has no persistent connection to close.
+        pass

--- a/millpond/main.py
+++ b/millpond/main.py
@@ -7,7 +7,8 @@ from importlib.metadata import PackageNotFoundError, version
 import pyarrow as pa
 from confluent_kafka import TopicPartition
 
-from millpond import arrow_converter, backpressure, config, consumer, ducklake, logging_config, metrics, schema, server
+from millpond import arrow_converter, backpressure, config, consumer, logging_config, metrics, server
+from millpond import sink as sink_mod
 
 log = logging.getLogger(__name__)
 
@@ -29,11 +30,11 @@ def _convert_batch(values: list[bytes]) -> pa.Table | None:
     return table
 
 
-def _write_with_retry(db, table_name, consolidated, schema_mgr, partition_by=None):
-    """Write to DuckLake with exponential backoff on transient failures."""
+def _write_with_retry(sink, consolidated):
+    """Write to the sink with exponential backoff on transient failures."""
     for attempt in range(_WRITE_MAX_RETRIES):
         try:
-            ducklake.write(db, table_name, consolidated, schema_mgr, partition_by)
+            sink.write(consolidated)
             return
         except Exception:
             metrics.errors_total.labels(type="write_retry").inc()
@@ -49,16 +50,14 @@ def _write_with_retry(db, table_name, consolidated, schema_mgr, partition_by=Non
             )
             # Invalidate caches so retry re-checks table existence and schema —
             # another pod may have created the table or changed columns.
-            ducklake.reset_table_cache()
-            if schema_mgr is not None:
-                schema_mgr.invalidate()
+            sink.reset_caches()
             time.sleep(delay)
 
 
-def _flush(db, cfg, kafka, consolidated, pending_bytes, pending_records, offsets, elapsed, schema_mgr, trigger="time"):
-    """Write to DuckLake, commit offsets, update metrics."""
+def _flush(sink, cfg, kafka, consolidated, pending_bytes, pending_records, offsets, elapsed, trigger="time"):
+    """Write to the sink, commit offsets, update metrics."""
     t0 = time.monotonic()
-    _write_with_retry(db, cfg.ducklake_table, consolidated, schema_mgr, cfg.partition_by)
+    _write_with_retry(sink, consolidated)
     write_duration = time.monotonic() - t0
 
     # Commit offsets synchronously — at-least-once requires knowing commit succeeded
@@ -128,33 +127,14 @@ def main():
         __version__ = "0.0.0+unknown"
     log.info("millpond %s starting", __version__)
 
+    # Initialize close-targets to None so the finally block doesn't NameError
+    # if a startup step (make_sink, kafka.create, server.start) raises.
+    http = None
+    sink = None
+    kafka = None
+
     cfg = config.load()
-    metrics.init(f"{cfg.topic}-{cfg.ducklake_table}", broker_source=cfg.broker_source)
-    http = server.start()
-    server.health.mark_started()
-    log.info("Health server started, probes passing")
-
-    # No connection recovery logic — if DuckLake/Postgres fails, the pod crashes
-    # and K8s restarts it. Reconnection adds complexity for no benefit when the
-    # restart path already handles offset replay correctly.
-    db = ducklake.connect(cfg)
-    schema_mgr = schema.SchemaManager(db, cfg.ducklake_table)
-    log.info("DuckLake connected, schema manager initialized")
-    kafka = consumer.create(cfg)
-    log.info("Kafka consumer created, partitions assigned")
-    backpressure.init(cfg.consume_batch_size)
-
-    shutdown = False
-
-    def on_signal(signum, _frame):
-        nonlocal shutdown
-        log.info("Received signal %s, shutting down", signal.Signals(signum).name)
-        shutdown = True
-
-    signal.signal(signal.SIGTERM, on_signal)
-    signal.signal(signal.SIGINT, on_signal)
-
-    log.info("millpond ready, entering main loop")
+    metrics.init(f"{cfg.topic}-{cfg.table_label}", broker_source=cfg.broker_source)
 
     pending: list[pa.Table] = []
     pending_bytes = 0
@@ -165,6 +145,31 @@ def main():
     last_heartbeat = time.monotonic()
 
     try:
+        http = server.start()
+        server.health.mark_started()
+        log.info("Health server started, probes passing")
+
+        # No connection recovery logic — if the destination fails, the pod
+        # crashes and K8s restarts it. Reconnection adds complexity for no
+        # benefit when the restart path already handles offset replay correctly.
+        sink = sink_mod.make_sink(cfg)
+        log.info("Sink ready: destination=%s", cfg.destination)
+        kafka = consumer.create(cfg)
+        log.info("Kafka consumer created, partitions assigned")
+        backpressure.init(cfg.consume_batch_size)
+
+        shutdown = False
+
+        def on_signal(signum, _frame):
+            nonlocal shutdown
+            log.info("Received signal %s, shutting down", signal.Signals(signum).name)
+            shutdown = True
+
+        signal.signal(signal.SIGTERM, on_signal)
+        signal.signal(signal.SIGINT, on_signal)
+
+        log.info("millpond ready, entering main loop")
+
         while not shutdown:
             remaining = cfg.flush_interval_s - (time.monotonic() - last_flush)
             timeout = max(remaining, 0.1)
@@ -221,7 +226,7 @@ def main():
                 trigger = "size" if size_triggered else "time"
                 consolidated = pa.concat_tables(pending, promote_options="default")
                 _flush(
-                    db,
+                    sink,
                     cfg,
                     kafka,
                     consolidated,
@@ -229,7 +234,6 @@ def main():
                     pending_records,
                     offsets,
                     elapsed,
-                    schema_mgr,
                     trigger,
                 )
 
@@ -253,19 +257,35 @@ def main():
         log.exception("Fatal error in main loop")
         raise
     finally:
-        if pending_records > 0:
+        # Final flush only makes sense if both sink and kafka were created;
+        # if startup failed earlier, there's no consumed data to flush.
+        if pending_records > 0 and sink is not None and kafka is not None:
             try:
                 consolidated = pa.concat_tables(pending, promote_options="default")
                 elapsed = time.monotonic() - last_flush
                 log.info("Final flush: %d records, %d bytes", len(consolidated), pending_bytes)
-                _flush(db, cfg, kafka, consolidated, pending_bytes, pending_records, offsets, elapsed, schema_mgr)
+                _flush(sink, cfg, kafka, consolidated, pending_bytes, pending_records, offsets, elapsed)
             except Exception:
                 log.exception("Final flush failed — data safe in Kafka, will replay on restart")
 
-        log.info("Closing consumer")
-        kafka.close()
-        db.close()
-        http.shutdown()
+        # Close in reverse-startup order. Each close is guarded so a partial
+        # startup (e.g. make_sink raised) doesn't NameError its way through here.
+        if kafka is not None:
+            log.info("Closing consumer")
+            try:
+                kafka.close()
+            except Exception:
+                log.exception("Kafka consumer close failed")
+        if sink is not None:
+            try:
+                sink.close()
+            except Exception:
+                log.exception("Sink close failed")
+        if http is not None:
+            try:
+                http.shutdown()
+            except Exception:
+                log.exception("HTTP server shutdown failed")
         log.info("millpond shutdown complete")
 
     return 0

--- a/millpond/schema.py
+++ b/millpond/schema.py
@@ -10,16 +10,14 @@ Schema is cached per table to avoid repeated PRAGMA round-trips.
 """
 
 import logging
-import re
 
 import duckdb
 import pyarrow as pa
 
 from millpond import metrics
+from millpond.sink import SAFE_IDENTIFIER
 
 log = logging.getLogger(__name__)
-
-_SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
 # PyArrow type → DuckDB SQL type
 _ARROW_TO_DUCKDB: dict[str, str] = {
@@ -115,7 +113,7 @@ class SchemaManager:
             if field.name == "_inserted_at":
                 continue
 
-            if not _SAFE_IDENTIFIER.match(field.name):
+            if not SAFE_IDENTIFIER.match(field.name):
                 log.warning("Skipping unsafe field name: %r", field.name)
                 metrics.records_skipped_total.labels(reason="unsafe_field_name").inc()
                 continue

--- a/millpond/sink.py
+++ b/millpond/sink.py
@@ -1,0 +1,125 @@
+"""Sink protocol — the thin interface between main.py and a destination backend.
+
+A `Sink` is the only thing `main.py` knows about. Both `DuckLakeSink` and
+`IcebergSink` implement it; `make_sink(cfg)` picks one based on
+`cfg.destination`. A given Millpond pod writes to exactly one destination
+for its lifetime — there is no per-batch routing.
+
+This module also exports two shared helpers the backends both use:
+
+* `SAFE_IDENTIFIER` — regex for column names that are safe to embed in
+  generated SQL / pass to PyIceberg's schema constructor.
+* `check_reserved_collision(batch_schema, reserved, backend_name)` —
+  raises early with a uniform `ValueError` when a source-schema column
+  collides with a backend-managed metadata column (`_inserted_at`,
+  `year`, `month`, `day`, `hour`). Each backend keeps its own
+  `RESERVED_COLUMNS` constant; both happen to hold the same set today
+  so a deployment-time destination switch doesn't suddenly start
+  accepting or rejecting batches based on column-name collisions.
+  DuckLake reserves `year/month/day/hour` defensively even though it
+  doesn't produce them itself — that's the trade-off for deployment-
+  swap safety. Sinks call this at the top of `write()`; the validation
+  produces a clear error instead of PyIceberg's cryptic
+  "Invalid schema, multiple fields for name" deep in the stack.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+    from millpond.config import Config
+
+
+# Column names safe to embed in SQL / pass to PyIceberg's schema constructor.
+# Both backends apply this check; field names that don't match are skipped
+# with a `records_skipped_total{reason="unsafe_field_name"}` metric bump.
+SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def check_reserved_collision(
+    batch_schema: pa.Schema,
+    reserved: Iterable[str],
+    backend_name: str,
+) -> None:
+    """Raise early on source-schema collision with backend-managed columns.
+
+    Each backend appends one or more metadata columns at write time
+    (`_inserted_at` always, plus `year/month/day/hour` on Iceberg). If a
+    source column has the same name, the backend's append step explodes
+    deep in the stack (Iceberg: `ValueError("Invalid schema, multiple
+    fields for name year")`; DuckLake: duplicate column on the post-
+    write projection). Catch it here with a clear message instead.
+
+    Raised at the Sink boundary — before any backend-specific work — so
+    a single misconfigured producer surfaces uniformly across backends.
+    """
+    reserved_set = set(reserved)
+    collisions = sorted(name for name in batch_schema.names if name in reserved_set)
+    if collisions:
+        raise ValueError(
+            f"Source schema column(s) {collisions!r} collide with "
+            f"{backend_name}-reserved metadata column names; rename them "
+            f"upstream or filter them out before write()."
+        )
+
+
+class Sink(Protocol):
+    """A destination for Arrow batches. Owns its own connection, table cache, and schema state.
+
+    Contract:
+      * `write()` must not be called with a zero-row batch. `main.py` gates
+        on `pending_records > 0` before flushing; backends may short-circuit
+        on empty input but are not required to. (The two backends diverge
+        here: DuckLake creates the table eagerly on any call; Iceberg
+        skips the catalog round-trip and creates lazily on first non-empty
+        batch. Neither path is exercised in steady state.)
+      * `reset_caches()` is invoked only by the write-retry loop in
+        `main.py` after a write failure. Sinks should not self-reset
+        on internal recovery; surface the failure and let the retry path
+        drive cache invalidation.
+      * `close()` is called exactly once at pod shutdown.
+    """
+
+    def write(self, batch: pa.Table) -> None:
+        """Append `batch` (must be non-empty) to the destination table.
+        Implementations handle schema evolution, table creation, and
+        per-backend metadata columns internally."""
+        ...
+
+    def reset_caches(self) -> None:
+        """Drop any cached table/schema state. Called from the write-retry path
+        after a failure, so the next attempt re-checks the catalog."""
+        ...
+
+    def close(self) -> None:
+        """Release any underlying resources. Called once at pod shutdown."""
+        ...
+
+
+def make_sink(cfg: Config) -> Sink:
+    """Dispatch on `cfg.destination`. Imports the backend module lazily so we
+    don't pay the import cost of an unused backend.
+
+    Lazy import matters: pyiceberg pulls cryptography/aiohttp/etc.
+    transitively (~150ms cold start on a small pod), so DuckLake-only
+    deployments shouldn't pay it. The conformance test in test_sink.py
+    asserts this stays a lazy import by source inspection.
+    """
+    if cfg.destination == "iceberg":
+        from millpond.iceberg import IcebergSink
+
+        return IcebergSink(cfg)
+    if cfg.destination == "ducklake":
+        from millpond.ducklake import DuckLakeSink
+
+        return DuckLakeSink(cfg)
+    # ValueError, not RuntimeError — this is an unknown-enum input, the
+    # idiomatic Python exception for "the value I got isn't in the set
+    # I accept." config.load() should have already rejected this at
+    # startup; reaching here means the caller bypassed config.load().
+    raise ValueError(f"Unknown destination: {cfg.destination!r}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ version-file = "millpond/_version.py"
 [project]
 name = "millpond"
 dynamic = ["version"]
-description = "Kafka to DuckLake"
+description = "Kafka to DuckLake or Iceberg"
 license = {file = "LICENSE"}
 requires-python = ">=3.12"
 dependencies = [
@@ -24,6 +24,12 @@ dependencies = [
     # stdlib zoneinfo module isn't accepted as a substitute as of 1.4.x.
     "pytz>=2024.1",
     "pyyaml>=6.0.3",
+    # Pinned exactly. millpond/iceberg.py depends on two private symbols
+    # (_pyarrow_to_schema_without_ids, assign_fresh_schema_ids) and PyIceberg
+    # is pre-1.0 — minor-version bumps reshuffle internals. The canary test
+    # tests/unit/test_pyiceberg_pin.py imports both and will fail loudly on
+    # any upgrade; treat that as the signal to revisit this module.
+    "pyiceberg[pyarrow]==0.11.1",
 ]
 
 [project.optional-dependencies]
@@ -36,6 +42,7 @@ millpond = "millpond.main:main"
 dev = [
     "pytest>=9.0.3",
     "ruff>=0.8",
+    "sqlalchemy>=2.0.49",
     "testcontainers>=4.14.2",
 ]
 

--- a/state-metrics-plan.md
+++ b/state-metrics-plan.md
@@ -4,7 +4,7 @@ Goes in `tools/` as a single Python file, `ducklake_metrics.py`. Small Python da
 
 ## Shape
 
-Single file. Connects once via `maintenance.connect()` — that already configures the lake ATTACH, the Postgres extension ATTACH, the S3 secret, `temp_directory`, and the `enable_http_logging` / `pg_debug_show_queries` quiets from a14. Reusing it means the daemon inherits all that without duplication. Queries run sequentially on per-query schedules. Prometheus served via `prometheus_client.start_http_server`.
+Single file. Connects once via `ducklake_maintenance.connect()` — that already configures the lake ATTACH, the Postgres extension ATTACH, the S3 secret, `temp_directory`, and the `enable_http_logging` / `pg_debug_show_queries` quiets from a14. Reusing it means the daemon inherits all that without duplication. Queries run sequentially on per-query schedules. Prometheus served via `prometheus_client.start_http_server`.
 
 ## Layout (one file)
 
@@ -71,7 +71,7 @@ Built-ins are lake-wide — no `table_name` label. User-supplied YAML may emit t
 
 Readiness must NOT wait for slow queries. The Prom port opens immediately at startup; `/metrics` may briefly return only self-metrics until the first scheduled queries run.
 
-## Config (env-driven, matches `maintenance.py`)
+## Config (env-driven, matches `ducklake_maintenance.py`)
 
 | Var | Purpose |
 |---|---|

--- a/tests/integration/compose.yaml
+++ b/tests/integration/compose.yaml
@@ -1,0 +1,53 @@
+# Minimal stack for the integration test: MinIO (S3 storage) + an
+# Iceberg REST catalog pointing at it. No Kafka, no millpond container —
+# the test drives `millpond.iceberg.write()` directly from Python.
+
+# Image pins:
+#   - minio + mc: tagged release. Update by bumping both tags together.
+#   - tabulario/iceberg-rest: pinned by digest because the upstream only
+#     ever publishes `:latest`. Bump the digest when revalidating against a
+#     newer REST spec; the canary test in tests/unit/test_pyiceberg_pin.py
+#     pins the client side. Server-side drift surfaces here when tests
+#     flake against a fresh digest pull.
+services:
+  minio:
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000"
+      - "9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+  minio-init:
+    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minioadmin minioadmin;
+      mc mb -p local/warehouse;
+      "
+
+  iceberg-rest:
+    image: tabulario/iceberg-rest@sha256:3b7d31bdfec626b68e97531c9778a1b9119659e456fe28545a49f6aa6a9ce472
+    depends_on:
+      minio-init:
+        condition: service_completed_successfully
+    environment:
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      AWS_REGION: us-east-1
+      CATALOG_WAREHOUSE: s3://warehouse/
+      CATALOG_IO__IMPL: org.apache.iceberg.aws.s3.S3FileIO
+      CATALOG_S3_ENDPOINT: http://minio:9000
+      CATALOG_S3_PATH__STYLE__ACCESS: "true"
+    ports:
+      - "8181"

--- a/tests/integration/test_iceberg_integration.py
+++ b/tests/integration/test_iceberg_integration.py
@@ -1,0 +1,146 @@
+"""Integration test for the Iceberg write path.
+
+Brings up MinIO + an Iceberg REST catalog via docker-compose and drives
+``millpond.iceberg.connect()`` / ``write()`` against it from Python.
+Verifies the full commit cycle (metadata.json + manifest + parquet land
+in MinIO, the catalog atomically updates) without standing up Kafka or
+the millpond container.
+
+Skipped from the default unit run (``pytest -m "not integration and not e2e"``).
+"""
+
+from __future__ import annotations
+
+import socket
+import time
+import urllib.request
+from pathlib import Path
+
+import pyarrow as pa
+import pytest
+from testcontainers.compose import DockerCompose
+
+from millpond import iceberg
+
+
+def _wait_for_http(url: str, timeout: float = 60.0) -> None:
+    deadline = time.monotonic() + timeout
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=2) as resp:
+                if 200 <= resp.status < 300:
+                    return
+        except Exception as e:
+            last_err = e
+        time.sleep(1.0)
+    raise RuntimeError(f"endpoint {url} never came up within {timeout}s; last error: {last_err!r}")
+
+
+def _wait_for_tcp(host: str, port: int, timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=2):
+                return
+        except Exception as e:
+            last_err = e
+        time.sleep(0.5)
+    raise RuntimeError(f"{host}:{port} never accepted a connection within {timeout}s; last error: {last_err!r}")
+
+
+@pytest.fixture(scope="module")
+def stack():
+    """Bring up MinIO + iceberg-rest; yield (catalog_uri, minio_endpoint)."""
+    compose_dir = Path(__file__).parent
+    with DockerCompose(str(compose_dir), compose_file_name="compose.yaml", pull=True) as compose:
+        rest_host, rest_port = compose.get_service_host_and_port("iceberg-rest", 8181)
+        minio_host, minio_port = compose.get_service_host_and_port("minio", 9000)
+        catalog_uri = f"http://{rest_host}:{rest_port}"
+        minio_endpoint = f"http://{minio_host}:{minio_port}"
+        # iceberg-rest takes a few seconds to come up after the port binds.
+        _wait_for_tcp(rest_host, int(rest_port))
+        _wait_for_http(f"{catalog_uri}/v1/config")
+        _wait_for_tcp(minio_host, int(minio_port))
+        yield catalog_uri, minio_endpoint
+
+
+@pytest.fixture
+def cache() -> dict:
+    """Per-test caller-owned ensure cache (formerly module-level)."""
+    return {}
+
+
+def _connect(catalog_uri: str, minio_endpoint: str):
+    return iceberg.connect(
+        catalog_uri=catalog_uri,
+        warehouse="s3://warehouse/",
+        s3_access_key_id="minioadmin",
+        s3_secret_access_key="minioadmin",
+        s3_region="us-east-1",
+        s3_endpoint=minio_endpoint,
+    )
+
+
+@pytest.mark.integration
+class TestIcebergIntegration:
+    def test_write_round_trips_through_real_catalog_and_s3(self, stack, cache):
+        catalog_uri, minio_endpoint = stack
+        catalog = _connect(catalog_uri, minio_endpoint)
+
+        batch = pa.table({"event": ["click", "view", "scroll"], "team_id": [1, 2, 3]})
+        # Use a unique table name so module-scoped fixture reuse across
+        # tests doesn't see each other's rows (we don't drop between tests).
+        table_name = "events_roundtrip"
+        iceberg.write(catalog, "millpond", table_name, batch, cache)
+
+        # Re-read via the catalog; full path: metadata.json -> manifest -> parquet on MinIO.
+        table = catalog.load_table(("millpond", table_name))
+        rows = table.scan().to_arrow()
+        assert rows.num_rows == 3
+        assert sorted(rows.column("event").to_pylist()) == ["click", "scroll", "view"]
+        assert set(rows.column_names) >= {
+            "event",
+            "team_id",
+            "_inserted_at",
+            "year",
+            "month",
+            "day",
+            "hour",
+        }
+        # Partition column should have a sensible year — verifies the
+        # PyArrow compute + Iceberg roundtrip preserved the int type.
+        year = rows.column("year").to_pylist()[0]
+        assert 2020 <= year <= 2099
+
+    def test_multiple_writes_accumulate(self, stack, cache):
+        catalog_uri, minio_endpoint = stack
+        catalog = _connect(catalog_uri, minio_endpoint)
+
+        batch = pa.table({"event": ["click"], "team_id": [1]})
+        table_name = "events_accumulate"
+        iceberg.write(catalog, "millpond", table_name, batch, cache)
+        iceberg.write(catalog, "millpond", table_name, batch, cache)
+        iceberg.write(catalog, "millpond", table_name, batch, cache)
+
+        rows = catalog.load_table(("millpond", table_name)).scan().to_arrow()
+        assert rows.num_rows == 3
+
+    def test_partition_layout_is_hive_style(self, stack, cache):
+        """File paths on S3 must include year=/month=/day=/hour= segments."""
+        catalog_uri, minio_endpoint = stack
+        catalog = _connect(catalog_uri, minio_endpoint)
+
+        batch = pa.table({"event": ["x"], "team_id": [1]})
+        table_name = "events_partitions"
+        iceberg.write(catalog, "millpond", table_name, batch, cache)
+
+        # The catalog records each data file's path; check the layout.
+        table = catalog.load_table(("millpond", table_name))
+        files = list(table.scan().plan_files())
+        assert files, "expected at least one data file after write()"
+        file_path = files[0].file.file_path
+        # Path should look like: s3://warehouse/.../year=YYYY/month=MM/day=DD/hour=HH/<uuid>.parquet
+        for segment in ("year=", "month=", "day=", "hour="):
+            assert segment in file_path, f"{segment} missing from data file path: {file_path}"

--- a/tests/integration/test_write_integration.py
+++ b/tests/integration/test_write_integration.py
@@ -11,7 +11,7 @@ import duckdb
 import pyarrow as pa
 import pytest
 
-from millpond.ducklake import _tables_ensured, write
+from millpond.ducklake import write
 from millpond.schema import SchemaManager
 
 
@@ -24,26 +24,24 @@ def conn():
     c.close()
 
 
-@pytest.fixture(autouse=True)
-def _clear_ensure_cache():
-    """Clear the _tables_ensured cache between tests."""
-    _tables_ensured.clear()
-    yield
-    _tables_ensured.clear()
+@pytest.fixture()
+def cache() -> set[str]:
+    """Per-test caller-owned ensure cache (formerly module-level `_tables_ensured`)."""
+    return set()
 
 
 @pytest.mark.integration
 class TestWritePath:
-    def test_basic_write(self, conn):
+    def test_basic_write(self, conn, cache):
         batch = pa.table({"event": ["click", "view"], "team_id": [1, 2]})
-        write(conn, "events", batch)
+        write(conn, "events", batch, cache)
 
         rows = conn.execute("SELECT event, team_id FROM lake.main.events").fetchall()
         assert set(rows) == {("click", 1), ("view", 2)}
 
-    def test_inserted_at_column_added(self, conn):
+    def test_inserted_at_column_added(self, conn, cache):
         batch = pa.table({"event": ["click"]})
-        write(conn, "events", batch)
+        write(conn, "events", batch, cache)
 
         cols = conn.execute(
             "SELECT column_name FROM information_schema.columns "
@@ -52,18 +50,18 @@ class TestWritePath:
         col_names = {row[0] for row in cols}
         assert "_inserted_at" in col_names
 
-    def test_multiple_writes_accumulate(self, conn):
+    def test_multiple_writes_accumulate(self, conn, cache):
         batch1 = pa.table({"x": [1, 2]})
         batch2 = pa.table({"x": [3, 4]})
-        write(conn, "events", batch1)
-        write(conn, "events", batch2)
+        write(conn, "events", batch1, cache)
+        write(conn, "events", batch2, cache)
 
         rows = conn.execute("SELECT x FROM lake.main.events ORDER BY x").fetchall()
         assert [r[0] for r in rows] == [1, 2, 3, 4]
 
-    def test_empty_batch_creates_table(self, conn):
+    def test_empty_batch_creates_table(self, conn, cache):
         batch = pa.table({"a": pa.array([], type=pa.int64())})
-        write(conn, "events", batch)
+        write(conn, "events", batch, cache)
 
         cols = conn.execute(
             "SELECT column_name FROM information_schema.columns "
@@ -76,14 +74,14 @@ class TestWritePath:
 
 @pytest.mark.integration
 class TestSchemaEvolution:
-    def test_add_new_column(self, conn):
+    def test_add_new_column(self, conn, cache):
         batch1 = pa.table({"event": ["click"]})
         schema_mgr = SchemaManager(conn, "events")
-        write(conn, "events", batch1, schema_mgr)
+        write(conn, "events", batch1, cache, schema_mgr)
 
         # Second write introduces a new column — full write, not just evolve
         batch2 = pa.table({"event": ["view"], "source": ["web"]})
-        write(conn, "events", batch2, schema_mgr)
+        write(conn, "events", batch2, cache, schema_mgr)
 
         cols = conn.execute(
             "SELECT column_name FROM information_schema.columns "
@@ -124,14 +122,14 @@ class TestSchemaEvolution:
         ).fetchone()
         assert type_result[0] == "DOUBLE"
 
-    def test_multiple_new_columns_at_once(self, conn):
+    def test_multiple_new_columns_at_once(self, conn, cache):
         batch1 = pa.table({"a": [1]})
         schema_mgr = SchemaManager(conn, "events")
-        write(conn, "events", batch1, schema_mgr)
+        write(conn, "events", batch1, cache, schema_mgr)
 
         # Full write with multiple new columns
         batch2 = pa.table({"a": [2], "b": ["x"], "c": [3.0]})
-        write(conn, "events", batch2, schema_mgr)
+        write(conn, "events", batch2, cache, schema_mgr)
 
         cols = conn.execute(
             "SELECT column_name FROM information_schema.columns "
@@ -144,18 +142,18 @@ class TestSchemaEvolution:
         rows = conn.execute("SELECT a, b, c FROM lake.main.events ORDER BY a").fetchall()
         assert rows == [(1, None, None), (2, "x", 3.0)]
 
-    def test_schema_cached_across_writes(self, conn):
+    def test_schema_cached_across_writes(self, conn, cache):
         batch = pa.table({"event": ["click"]})
         schema_mgr = SchemaManager(conn, "events")
-        write(conn, "events", batch, schema_mgr)
+        write(conn, "events", batch, cache, schema_mgr)
 
         assert schema_mgr._initialized
         assert "event" in schema_mgr._known_columns
 
-    def test_invalidate_forces_reload(self, conn):
+    def test_invalidate_forces_reload(self, conn, cache):
         batch = pa.table({"event": ["click"]})
         schema_mgr = SchemaManager(conn, "events")
-        write(conn, "events", batch, schema_mgr)
+        write(conn, "events", batch, cache, schema_mgr)
 
         schema_mgr.invalidate()
         assert not schema_mgr._initialized
@@ -165,10 +163,10 @@ class TestSchemaEvolution:
         assert schema_mgr._initialized
 
     @patch("millpond.schema.metrics")
-    def test_column_added_increments_counter(self, mock_metrics, conn):
+    def test_column_added_increments_counter(self, mock_metrics, conn, cache):
         batch1 = pa.table({"event": ["click"]})
         schema_mgr = SchemaManager(conn, "events")
-        write(conn, "events", batch1, schema_mgr)
+        write(conn, "events", batch1, cache, schema_mgr)
 
         batch2 = pa.table({"event": ["view"], "source": ["web"]})
         schema_mgr.evolve(batch2.schema)
@@ -186,10 +184,10 @@ class TestSchemaEvolution:
         mock_metrics.schema_columns_widened_total.inc.assert_called_once()
 
     @patch("millpond.schema.metrics")
-    def test_no_change_no_counter(self, mock_metrics, conn):
+    def test_no_change_no_counter(self, mock_metrics, conn, cache):
         batch = pa.table({"event": ["click"]})
         schema_mgr = SchemaManager(conn, "events")
-        write(conn, "events", batch, schema_mgr)
+        write(conn, "events", batch, cache, schema_mgr)
 
         # Same schema again — no evolution needed
         schema_mgr.evolve(batch.schema)
@@ -232,11 +230,11 @@ class TestSchemaEvolution:
         assert schema_mgr._known_columns["x"] == "BIGINT"
 
     @patch("millpond.schema.metrics")
-    def test_unsafe_field_name_skipped(self, mock_metrics, conn):
+    def test_unsafe_field_name_skipped(self, mock_metrics, conn, cache):
         """Fields with unsafe names (SQL injection risk) should be skipped."""
         batch1 = pa.table({"event": ["click"]})
         schema_mgr = SchemaManager(conn, "events")
-        write(conn, "events", batch1, schema_mgr)
+        write(conn, "events", batch1, cache, schema_mgr)
 
         # Simulate a batch with an unsafe field name
         unsafe_schema = pa.schema([pa.field("event", pa.string()), pa.field("x; DROP TABLE", pa.string())])

--- a/tests/unit/test_arrow_converter.py
+++ b/tests/unit/test_arrow_converter.py
@@ -1,7 +1,7 @@
 import orjson
 import pyarrow as pa
 
-from millpond.arrow_converter import convert
+from millpond.arrow_converter import _drop_null_typed_columns, convert
 
 
 class TestConvert:
@@ -164,6 +164,14 @@ class TestConvert:
         assert table is not None
         assert table.schema.field("price").type == pa.float64()
 
+    def test_all_null_field_does_not_produce_pa_null_column(self):
+        # In normal use _build_schema falls back to pa.string() for keys
+        # that are None in every record — so convert() should never emit
+        # a pa.null() column. Lock that.
+        table = convert([orjson.dumps({"x": None, "y": "data"})])
+        assert table is not None
+        assert all(not pa.types.is_null(f.type) for f in table.schema)
+
     def test_cross_batch_concat_with_promote(self):
         """Tables from separate convert() calls may have different schemas.
         pa.concat_tables must use promote_options to handle this."""
@@ -175,3 +183,37 @@ class TestConvert:
         assert len(merged) == 2
         assert "b" in merged.schema.names
         assert merged.column("b").to_pylist() == [None, "new"]
+
+
+class TestDropNullTypedColumns:
+    """Defensive filter against pa.null() columns slipping through to a Sink.
+
+    Backends diverge on pa.null() — DuckLake stores nulls; Iceberg raises
+    `ValueError("Null type ... is not supported in Iceberg format version
+    2")`. Dropping at the converter keeps the Sink contract uniform.
+    """
+
+    def test_drops_pa_null_column(self):
+        table = pa.table(
+            {"a": pa.array([None, None], pa.null()), "b": ["x", "y"]}
+        )
+        out = _drop_null_typed_columns(table)
+        assert out.column_names == ["b"]
+
+    def test_passthrough_when_no_null_columns(self):
+        table = pa.table({"a": [1, 2], "b": ["x", "y"]})
+        out = _drop_null_typed_columns(table)
+        # No re-allocation when there's nothing to do.
+        assert out is table
+
+    def test_drops_only_null_typed_columns_not_columns_with_nulls(self):
+        # A regular string column with all-None values is NOT pa.null() —
+        # it's a string column with nulls. Must not be dropped.
+        table = pa.table(
+            {
+                "actually_null_type": pa.array([None], pa.null()),
+                "string_with_nulls": pa.array([None], pa.string()),
+            }
+        )
+        out = _drop_null_typed_columns(table)
+        assert out.column_names == ["string_with_nulls"]

--- a/tests/unit/test_backend_equivalence.py
+++ b/tests/unit/test_backend_equivalence.py
@@ -1,0 +1,1014 @@
+"""Cross-backend behaviour + performance equivalence contract.
+
+The two destination backends (DuckLake and Iceberg) are expected to be
+swappable at deployment time. main.py only ever talks to a Sink, and a
+DuckLake-shaped Sink must behave indistinguishably from an Iceberg-shaped
+Sink in the dimensions that matter to a downstream consumer of the lake
+(rows land, columns are addressable, types are preserved within a
+documented coercion table).
+
+The tests in this file are the forward-looking contract for that
+equivalence. Where behaviour SHOULD match, the test is parametrized over
+both backends via the `sink_factory` fixture. Where behaviour DIVERGES
+INTENTIONALLY (per the Sink Protocol docstring or the schema/iceberg
+module commentary), the divergence is named explicitly with two
+separate, single-backend tests that lock the actual behaviour. A change
+that silently aligns or splits the two surfaces will fail at least one
+of these.
+
+If a test reveals a genuine defect, it is marked
+`@pytest.mark.xfail(strict=True, reason=...)` rather than fixed
+in-place — the goal here is observation, not patching.
+
+Categories:
+  1. make_sink dispatch + Protocol cross-backend smoke
+  2. Empty-batch behaviour (DIVERGENT — locked separately)
+  3. _inserted_at provenance (DIVERGENT)
+  4. Partition column emission (DIVERGENT)
+  5. Type mapping equivalence + per-backend mapping lock
+  6. Round-trip fidelity (parametrized)
+  7. Pathological column names / shapes (parametrized)
+  8. Pathological values (NaN/Inf/NUL/long/unicode) (parametrized)
+  9. Schema evolution semantics + metric parity (parametrized + divergent)
+ 10. Caller-contract enforcement in main._write_with_retry
+ 11. Performance smoke contracts (parametrized)
+
+Test infrastructure:
+  * DuckLake uses the `ATTACH ':memory:' AS lake` pattern from
+    `tests/integration/test_write_integration.py` — no Postgres required.
+  * Iceberg uses pyiceberg's `SqlCatalog` against a tmp SQLite file with
+    a local-filesystem warehouse — no S3, no testcontainers.
+
+Each backend "Sink-like" handle bundles the connection/catalog, the
+table name(s), the caller-owned cache, and its SchemaManager so the
+parametrized tests can drive both through a uniform .write(batch)
+interface without standing up the full Config-aware Sink wrappers.
+"""
+
+from __future__ import annotations
+
+import datetime
+import time
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import duckdb
+import pyarrow as pa
+import pytest
+from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.exceptions import NoSuchTableError
+
+from millpond import ducklake as ducklake_mod
+from millpond import iceberg as iceberg_mod
+from millpond import schema as schema_mod
+
+# ---------------------------------------------------------------------------
+# Backend harnesses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _BackendHandle:
+    """A uniform write-and-read handle over either backend.
+
+    Carries enough state to be both a thin Sink replacement (`.write(batch)`)
+    and a tester (`.read_all()` returns an Arrow table of everything that
+    landed). Both backends use real local stores; no mocks.
+    """
+
+    name: str  # "ducklake" or "iceberg"
+    write_fn: Any  # callable(batch: pa.Table) -> None
+    read_fn: Any  # callable() -> pa.Table (or None if table absent)
+    table_exists_fn: Any  # callable() -> bool
+    schema_mgr: Any  # whichever SchemaManager backs this handle
+    raw: dict  # backend-specific bag for test-specific pokes
+
+
+def _make_ducklake_handle(tmp_path) -> _BackendHandle:
+    """In-memory DuckDB attached as `lake`, mirroring DuckLakeSink internals
+    without requiring a real Postgres catalog."""
+    conn = duckdb.connect()
+    conn.execute("ATTACH ':memory:' AS lake")
+    cache: set[str] = set()
+    schema_mgr = schema_mod.SchemaManager(conn, "events")
+
+    def write(batch: pa.Table) -> None:
+        ducklake_mod.write(conn, "events", batch, cache, schema_mgr)
+
+    def read() -> pa.Table | None:
+        # Pull all source columns + _inserted_at into a single Arrow table
+        # in column order. SELECT * is enough because DuckLake adds nothing
+        # except _inserted_at.
+        if not _table_exists():
+            return None
+        # fetch_arrow_table is deprecated in DuckDB 1.5 but to_arrow_table
+        # isn't a method on the result cursor — pyarrow().to_table works
+        # but is more roundabout. Suppress the deprecation warning locally;
+        # the existing integration tests use fetch_arrow_table similarly.
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return conn.execute("SELECT * FROM lake.main.events").fetch_arrow_table()
+
+    def _table_exists() -> bool:
+        return ducklake_mod._table_exists(conn, "events")
+
+    return _BackendHandle(
+        name="ducklake",
+        write_fn=write,
+        read_fn=read,
+        table_exists_fn=_table_exists,
+        schema_mgr=schema_mgr,
+        raw={"conn": conn, "cache": cache},
+    )
+
+
+def _make_iceberg_handle(tmp_path) -> _BackendHandle:
+    """PyIceberg SqlCatalog + filesystem warehouse, mirroring IcebergSink
+    internals without requiring S3 or testcontainers."""
+    catalog = SqlCatalog(
+        "test",
+        **{
+            "uri": f"sqlite:///{tmp_path}/cat.db",
+            "warehouse": f"file://{tmp_path}/warehouse",
+        },
+    )
+    cache: dict = {}
+    schema_mgr = iceberg_mod.SchemaManager(catalog, "ns", "events")
+
+    def write(batch: pa.Table) -> None:
+        iceberg_mod.write(catalog, "ns", "events", batch, cache, schema_mgr)
+
+    def read() -> pa.Table | None:
+        try:
+            return catalog.load_table(("ns", "events")).scan().to_arrow()
+        except NoSuchTableError:
+            return None
+
+    def _table_exists() -> bool:
+        try:
+            catalog.load_table(("ns", "events"))
+            return True
+        except NoSuchTableError:
+            return False
+
+    return _BackendHandle(
+        name="iceberg",
+        write_fn=write,
+        read_fn=read,
+        table_exists_fn=_table_exists,
+        schema_mgr=schema_mgr,
+        raw={"catalog": catalog, "cache": cache},
+    )
+
+
+@pytest.fixture
+def ducklake_handle(tmp_path) -> _BackendHandle:
+    h = _make_ducklake_handle(tmp_path)
+    yield h
+    h.raw["conn"].close()
+
+
+@pytest.fixture
+def iceberg_handle(tmp_path) -> _BackendHandle:
+    yield _make_iceberg_handle(tmp_path)
+
+
+@pytest.fixture(params=["ducklake", "iceberg"])
+def handle(request, tmp_path) -> _BackendHandle:
+    """Parametrized handle — same test body runs once against each backend."""
+    if request.param == "ducklake":
+        h = _make_ducklake_handle(tmp_path)
+        yield h
+        h.raw["conn"].close()
+    else:
+        yield _make_iceberg_handle(tmp_path)
+
+
+def _three_row_batch() -> pa.Table:
+    """Canonical flat batch used by most equivalence tests."""
+    return pa.table(
+        {
+            "event": pa.array(["click", "view", "scroll"], pa.string()),
+            "team_id": pa.array([1, 2, 3], pa.int64()),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. make_sink dispatch + Protocol cross-backend smoke
+# ---------------------------------------------------------------------------
+
+
+class TestCrossBackendSmoke:
+    """The whole point of the Sink abstraction is that swapping
+    `cfg.destination` Just Works. Drive both backends through a single
+    identical batch via their .write() entry points (skipping the heavy
+    Config-aware Sink wrappers — the wiring is covered by
+    test_sink.py / test_sink_wrappers.py). Both must accept the batch,
+    persist it, and let us read back the source rows."""
+
+    def test_same_batch_lands_on_both_backends(self, ducklake_handle, iceberg_handle):
+        batch = _three_row_batch()
+        ducklake_handle.write_fn(batch)
+        iceberg_handle.write_fn(batch)
+
+        dl = ducklake_handle.read_fn()
+        ic = iceberg_handle.read_fn()
+        assert dl is not None
+        assert ic is not None
+
+        # Source columns and values land identically. Metadata columns
+        # diverge intentionally (different sets, different timestamps); the
+        # divergence is locked separately below.
+        assert dl.column("event").to_pylist() == ["click", "view", "scroll"]
+        assert ic.column("event").to_pylist() == ["click", "view", "scroll"]
+        assert dl.column("team_id").to_pylist() == [1, 2, 3]
+        assert ic.column("team_id").to_pylist() == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# 2. Empty-batch behaviour (DIVERGENT)
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyBatchDivergence:
+    """The Sink protocol explicitly documents this divergence: DuckLake
+    creates the table eagerly on any call including len==0; Iceberg short-
+    circuits and does not create the table. Both are correct given that
+    main.py gates on pending_records > 0. Lock both shapes; also lock that
+    main.py honours the contract."""
+
+    def test_ducklake_creates_table_on_empty_batch(self, ducklake_handle):
+        empty = pa.table({"a": pa.array([], pa.int64())})
+        ducklake_handle.write_fn(empty)
+        # Table exists with the source col + DuckLake's _inserted_at.
+        out = ducklake_handle.read_fn()
+        assert out is not None
+        assert out.num_rows == 0
+        assert "a" in out.schema.names
+        assert "_inserted_at" in out.schema.names
+
+    def test_iceberg_skips_table_on_empty_batch(self, iceberg_handle):
+        empty = pa.table({"a": pa.array([], pa.int64())})
+        iceberg_handle.write_fn(empty)
+        assert iceberg_handle.read_fn() is None
+        assert iceberg_handle.table_exists_fn() is False
+
+    def test_main_write_with_retry_does_not_call_write_on_empty_caller_contract(self):
+        """main.py is the source of truth for the empty-batch contract.
+        The flush trigger is `pending_records > 0`, so a Sink never sees
+        an empty batch in steady state. Verify by source inspection that
+        the gate exists — if somebody refactors that condition away, the
+        divergence above becomes user-visible."""
+        import inspect
+
+        from millpond import main
+
+        src = inspect.getsource(main.main)
+        assert "pending_records > 0" in src, (
+            "main.py must gate flush on pending_records > 0 — both backends "
+            "rely on this to never see an empty batch in steady state."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. _inserted_at provenance (DIVERGENT)
+# ---------------------------------------------------------------------------
+
+
+class TestInsertedAtProvenance:
+    """Both backends stamp _inserted_at, but with different semantics:
+
+      * DuckLake uses DuckDB's NOW() at INSERT time — every row may receive
+        a slightly different timestamp (microsecond drift across the
+        partitioned-insert batches).
+      * Iceberg uses Python `datetime.now()` once per batch and broadcasts
+        it across every row, so a flush always lands in exactly one
+        partition.
+
+    Both encode the same intent ("flush time, not event time") but the
+    actual values diverge. Lock both shapes."""
+
+    def test_iceberg_all_rows_share_one_inserted_at(self, iceberg_handle):
+        # Larger batch makes the contrast obvious.
+        batch = pa.table({"event": [f"e{i}" for i in range(50)]})
+        iceberg_handle.write_fn(batch)
+        ts = iceberg_handle.read_fn().column("_inserted_at").to_pylist()
+        assert len(set(ts)) == 1
+
+    def test_ducklake_all_rows_share_one_inserted_at_via_now(self, ducklake_handle):
+        # In practice DuckDB's NOW() returns a single value per statement,
+        # so all 50 rows of a single INSERT also land with the same
+        # timestamp — but that's an implementation detail of NOW() vs
+        # CURRENT_TIMESTAMP / TRANSACTION_TIMESTAMP. Lock the observed
+        # behaviour: same statement → same timestamp.
+        batch = pa.table({"event": [f"e{i}" for i in range(50)]})
+        ducklake_handle.write_fn(batch)
+        ts = ducklake_handle.read_fn().column("_inserted_at").to_pylist()
+        assert len(set(ts)) == 1
+
+    def test_ducklake_writes_use_distinct_timestamps_across_statements(self, ducklake_handle):
+        """Two separate write() calls = two separate INSERTs = two NOW()
+        evaluations. The Iceberg side achieves the same property via
+        per-batch datetime.now()."""
+        ducklake_handle.write_fn(pa.table({"event": ["a"]}))
+        # NOW() resolution in DuckDB is microseconds; the second statement
+        # is guaranteed to be later as long as the prior one took >0us.
+        time.sleep(0.001)
+        ducklake_handle.write_fn(pa.table({"event": ["b"]}))
+        ts = ducklake_handle.read_fn().column("_inserted_at").to_pylist()
+        assert len(set(ts)) == 2
+
+    def test_iceberg_writes_use_distinct_timestamps_across_batches(self, iceberg_handle, monkeypatch):
+        """iceberg._now_utc_us truncates to seconds (microsecond=0), so two
+        batches within the same wall-clock second naturally share a
+        timestamp. To prove the per-batch evaluation behaviour
+        deterministically, monkeypatch _now_utc_us to return distinct
+        values on successive calls — same shape as the production code
+        path, just without the second-resolution flake risk."""
+        import datetime as _dt
+
+        ts_iter = iter(
+            [
+                _dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=_dt.UTC),
+                _dt.datetime(2026, 1, 1, 12, 0, 1, tzinfo=_dt.UTC),
+            ]
+        )
+        monkeypatch.setattr(iceberg_mod, "_now_utc_us", lambda: next(ts_iter))
+
+        iceberg_handle.write_fn(pa.table({"event": ["a"]}))
+        iceberg_handle.write_fn(pa.table({"event": ["b"]}))
+        ts = iceberg_handle.read_fn().column("_inserted_at").to_pylist()
+        assert len(set(ts)) == 2, (
+            "Each batch should evaluate _now_utc_us() once — second batch "
+            "must get a distinct timestamp value from the first."
+        )
+
+    def test_inserted_at_is_tz_aware_on_both_backends(self, handle):
+        handle.write_fn(_three_row_batch())
+        ts_field = handle.read_fn().schema.field("_inserted_at")
+        assert isinstance(ts_field.type, pa.TimestampType)
+        assert ts_field.type.tz is not None, (
+            f"{handle.name} _inserted_at must be tz-aware; "
+            "downstream queries assume UTC."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. Partition column emission (DIVERGENT)
+# ---------------------------------------------------------------------------
+
+
+class TestPartitionColumnEmission:
+    """Iceberg always materialises year/month/day/hour as identity-partition
+    columns; DuckLake never does (its partitioning is a caller-provided
+    expression, not a column-emission contract). Lock the cardinal facts."""
+
+    def test_iceberg_emits_four_derived_partition_cols(self, iceberg_handle):
+        iceberg_handle.write_fn(_three_row_batch())
+        names = set(iceberg_handle.read_fn().schema.names)
+        assert {"year", "month", "day", "hour"} <= names
+
+    def test_ducklake_does_not_emit_partition_cols(self, ducklake_handle):
+        ducklake_handle.write_fn(_three_row_batch())
+        names = set(ducklake_handle.read_fn().schema.names)
+        # None of Iceberg's derived cols should appear in a DuckLake table
+        # unless the source batch happened to carry them by the same name.
+        assert names.isdisjoint({"year", "month", "day", "hour"})
+
+    @pytest.mark.parametrize("col_name", ["year", "month", "day", "hour", "_inserted_at"])
+    def test_both_backends_raise_early_on_reserved_column_collision(
+        self, handle, col_name
+    ):
+        """Reserved-column-collision contract: if a producer emits a
+        column named after a backend-managed metadata column, the Sink
+        raises `ValueError` at the `write()` boundary — before any
+        backend-specific work — with a uniform error message.
+
+        The reserved set is held identical between backends (DuckLake
+        reserves `year/month/day/hour` defensively even though it
+        doesn't produce them itself) so a deployment-time destination
+        swap doesn't suddenly start accepting or rejecting batches
+        based on column-name collisions."""
+        if col_name == "_inserted_at":
+            # Build the offending column with a tz-aware timestamp type
+            # so the source schema is something a real producer could emit.
+            offending = pa.array(
+                [datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)],
+                pa.timestamp("us", tz="UTC"),
+            )
+        else:
+            offending = pa.array([1999], pa.int32())
+        batch = pa.table({"event": ["x"], col_name: offending})
+
+        with pytest.raises(ValueError, match="collide with"):
+            handle.write_fn(batch)
+
+
+# ---------------------------------------------------------------------------
+# 5. Type mapping equivalence + per-backend mapping lock
+# ---------------------------------------------------------------------------
+
+
+class TestTypeMappingMatrix:
+    """Both backends accept arrow types; the SQL-side types differ, but
+    the round-trip Python values should match for types in the common
+    subset. The full per-backend mapping is locked module-by-module in
+    test_schema.py / test_iceberg_schema.py — this class focuses on
+    cross-backend equivalence and the documented widening rules."""
+
+    # Date intentionally excluded — see test_date_column_round_trip below
+    # (DuckLake date mapping is broken; see xfail).
+    _COMMON_SUBSET = {
+        "bool": pa.array([True, False, None], pa.bool_()),
+        "int32": pa.array([1, -1, 2_147_483_647], pa.int32()),
+        "int64": pa.array([1, -1, 2**62], pa.int64()),
+        "float32": pa.array([1.5, -1.5, 0.0], pa.float32()),
+        "float64": pa.array([1.5, -1.5, 1e300], pa.float64()),
+        "string": pa.array(["a", "b", "c"], pa.string()),
+    }
+
+    def test_common_subset_round_trips_on_both_backends(self, handle):
+        cols = dict(self._COMMON_SUBSET)
+        batch = pa.table(cols)
+        handle.write_fn(batch)
+        out = handle.read_fn()
+
+        # Equality test per column, in Python values. Numeric widening
+        # (int32→long on Iceberg) doesn't change the Python int value.
+        for name in cols:
+            assert out.column(name).to_pylist() == cols[name].to_pylist(), (
+                f"{handle.name}: column {name} did not round-trip"
+            )
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "schema._arrow_type_to_duckdb keys on str(arrow_type) but "
+            "pa.date32() stringifies as 'date32[day]' (not 'date32'), so "
+            "DATE columns are silently mapped to VARCHAR by the schema "
+            "manager. The eager CREATE TABLE path lands DATE correctly, "
+            "but the subsequent evolve() call widens DATE -> VARCHAR. "
+            "Real defect symmetric to the float16 issue above."
+        ),
+    )
+    def test_date_column_round_trips_on_ducklake(self, ducklake_handle):
+        batch = pa.table(
+            {"d": pa.array([18262, 18263, 18264], pa.date32())}
+        )
+        ducklake_handle.write_fn(batch)
+        out = ducklake_handle.read_fn().column("d").to_pylist()
+        import datetime as _dt
+
+        assert out == [
+            _dt.date(2020, 1, 1),
+            _dt.date(2020, 1, 2),
+            _dt.date(2020, 1, 3),
+        ]
+
+    def test_date_column_round_trips_on_iceberg(self, iceberg_handle):
+        batch = pa.table(
+            {"d": pa.array([18262, 18263, 18264], pa.date32())}
+        )
+        iceberg_handle.write_fn(batch)
+        out = iceberg_handle.read_fn().column("d").to_pylist()
+        import datetime as _dt
+
+        assert out == [
+            _dt.date(2020, 1, 1),
+            _dt.date(2020, 1, 2),
+            _dt.date(2020, 1, 3),
+        ]
+
+    def test_ducklake_uint64_max_round_trips(self, ducklake_handle):
+        """DuckLake has UBIGINT, so uint64 max survives. Iceberg has only
+        signed Long → values > int63 max overflow (see next test)."""
+        max_u64 = (1 << 64) - 1
+        batch = pa.table({"big": pa.array([max_u64], pa.uint64())})
+        ducklake_handle.write_fn(batch)
+        assert ducklake_handle.read_fn().column("big").to_pylist() == [max_u64]
+
+    def test_iceberg_uint64_above_int63_max_raises(self, iceberg_handle):
+        """Locked divergence: iceberg.py docs explicitly call out the
+        data-loss risk for uint64 > 2^63-1 (no UnsignedLongType in
+        Iceberg). The actual write raises rather than silently
+        truncating, which is the right failure mode — lock it."""
+        too_big = (1 << 64) - 1
+        batch = pa.table({"big": pa.array([too_big], pa.uint64())})
+        # PyIceberg surfaces this as a struct.pack ValueError from
+        # Arrow→Parquet's "q" (int64) format. The specific class isn't
+        # the contract — the contract is "this fails loudly, not silently".
+        with pytest.raises(Exception):
+            iceberg_handle.write_fn(batch)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "schema._arrow_type_to_duckdb keys on str(arrow_type) but "
+            "pa.float16() stringifies as 'halffloat' (not 'float16'), so "
+            "float16 falls through to VARCHAR on DuckLake. Iceberg "
+            "correctly maps float16 to FloatType via is_float16(). Real "
+            "divergence + real defect in the DuckLake mapping."
+        ),
+    )
+    def test_float16_maps_consistently_on_both_backends(self):
+        # The Iceberg side returns FloatType — i.e. a numeric type — so
+        # the parity check is "DuckLake also returns a numeric type."
+        from millpond.iceberg import _arrow_to_iceberg
+        from millpond.schema import _arrow_type_to_duckdb
+
+        dl_type = _arrow_type_to_duckdb(pa.float16())
+        ic_type = _arrow_to_iceberg(pa.float16())
+        # Iceberg side is numeric.
+        from pyiceberg.types import FloatType
+
+        assert isinstance(ic_type, FloatType)
+        # DuckLake side should also be numeric (FLOAT or DOUBLE).
+        assert dl_type in ("FLOAT", "DOUBLE"), (
+            f"DuckLake mapped float16 to {dl_type!r}, expected FLOAT/DOUBLE"
+        )
+
+    def test_pa_null_columns_filtered_at_converter_so_backends_never_see_them(self):
+        """`pa.null()`-typed columns are dropped by `arrow_converter.convert()`
+        before any Sink sees them — that's the contract that gives the two
+        backends uniform behaviour for an Arrow type Iceberg v2 rejects
+        outright.
+
+        In normal use `_build_schema` falls back to `pa.string()` for keys
+        that are None in every record, so `pa.null()` shouldn't appear via
+        the converter. This test pushes a record where the only key has a
+        None value to exercise the all-null path end-to-end, then asserts
+        the resulting table has no `pa.null()` columns. Test the contract
+        at the converter, not the Sinks."""
+        from millpond.arrow_converter import _drop_null_typed_columns, convert
+
+        # End-to-end: a record where the only field is None.
+        table = convert([b'{"only_null": null, "real": "x"}'])
+        assert table is not None
+        assert all(not pa.types.is_null(f.type) for f in table.schema), (
+            "convert() must not emit pa.null() columns"
+        )
+
+        # Defensive layer: if a pa.null() column somehow appears in an
+        # Arrow Table fed to _drop_null_typed_columns directly, it gets
+        # dropped. (Both Sinks would otherwise diverge: DuckLake stores,
+        # Iceberg raises.)
+        synth = pa.table(
+            {"all_null": pa.array([None, None], pa.null()), "kept": ["x", "y"]}
+        )
+        filtered = _drop_null_typed_columns(synth)
+        assert filtered.column_names == ["kept"]
+
+
+# ---------------------------------------------------------------------------
+# 6. Round-trip fidelity (parametrized)
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTripFidelity:
+    """For values that should round-trip identically up to documented
+    coercions, prove it does on both backends."""
+
+    def test_all_null_typed_int_column_preserves_nulls(self, handle):
+        batch = pa.table(
+            {
+                "event": pa.array(["x", "y"], pa.string()),
+                "score": pa.array([None, None], pa.int64()),
+            }
+        )
+        handle.write_fn(batch)
+        assert handle.read_fn().column("score").to_pylist() == [None, None]
+
+    def test_mixed_some_null_some_present(self, handle):
+        batch = pa.table(
+            {
+                "event": pa.array(["a", None, "c"], pa.string()),
+                "team_id": pa.array([1, None, 3], pa.int64()),
+            }
+        )
+        handle.write_fn(batch)
+        out = handle.read_fn()
+        assert out.column("event").to_pylist() == ["a", None, "c"]
+        assert out.column("team_id").to_pylist() == [1, None, 3]
+
+    def test_two_writes_accumulate(self, handle):
+        handle.write_fn(_three_row_batch())
+        handle.write_fn(_three_row_batch())
+        assert handle.read_fn().num_rows == 6
+
+    def test_post_arrow_converter_json_stringified_nested(self, handle):
+        """arrow_converter JSON-stringifies nested dicts before they hit
+        the sink. By the time a batch arrives, a struct column is just a
+        VARCHAR. Lock that we preserve the bytes."""
+        json_blob = '{"k":1,"nested":{"a":[1,2,3]}}'
+        batch = pa.table(
+            {"event": ["x"], "payload": pa.array([json_blob], pa.string())}
+        )
+        handle.write_fn(batch)
+        assert handle.read_fn().column("payload").to_pylist() == [json_blob]
+
+
+# ---------------------------------------------------------------------------
+# 7. Pathological column names / shapes (parametrized)
+# ---------------------------------------------------------------------------
+
+
+class TestPathologicalColumnNames:
+    def test_one_column_batch(self, handle):
+        batch = pa.table({"only": pa.array([1, 2, 3], pa.int64())})
+        handle.write_fn(batch)
+        assert handle.read_fn().column("only").to_pylist() == [1, 2, 3]
+
+    def test_many_columns_smoke(self, handle):
+        # Iceberg's create_table with 1000 columns is measurable; cap at
+        # 500 for the parametrized test to keep CI total under the
+        # performance budget.
+        cols = {f"c{i}": pa.array([i], pa.int64()) for i in range(500)}
+        handle.write_fn(pa.table(cols))
+        out = handle.read_fn()
+        assert "c0" in out.schema.names
+        assert "c499" in out.schema.names
+
+    def test_long_column_name_accepted(self, handle):
+        long_name = "a" * 200  # well over typical SQL identifier limits
+        batch = pa.table({long_name: pa.array([1, 2], pa.int64())})
+        handle.write_fn(batch)
+        assert handle.read_fn().column(long_name).to_pylist() == [1, 2]
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        [
+            "événement",  # non-ASCII Unicode
+            "1starts_with_digit",
+            "has space",
+            "has-dash",
+            "drop; --",
+        ],
+    )
+    def test_unsafe_field_names_skipped_by_schema_manager(self, handle, bad_name):
+        """Both backends' SchemaManagers gate on the same regex
+        ^[a-zA-Z_][a-zA-Z0-9_]*$. They should both refuse to ADD the
+        column rather than risk SQL injection or pyiceberg parser
+        errors. Lock the regex behaviour at the manager layer."""
+        # Seed the table with a safe shape first so the schema manager
+        # has something to compare against. (Iceberg's SchemaManager
+        # returns early when the table doesn't exist yet — we want to
+        # exercise the post-existence path.)
+        handle.write_fn(_three_row_batch())
+
+        # Now arrive with the bad name in the schema. Iceberg's
+        # SchemaManager.evolve receives a pa.Schema; DuckLake's
+        # signature is the same. Drive both directly to avoid the
+        # iceberg.write defensive short-circuit.
+        bad_schema = pa.schema(
+            [
+                pa.field("event", pa.string()),
+                pa.field("team_id", pa.int64()),
+                pa.field(bad_name, pa.string()),
+            ]
+        )
+        handle.schema_mgr.evolve(bad_schema)
+
+        out = handle.read_fn()
+        assert bad_name not in out.schema.names, (
+            f"{handle.name}: unsafe field name {bad_name!r} leaked into the table"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 8. Pathological values (parametrized)
+# ---------------------------------------------------------------------------
+
+
+class TestPathologicalValues:
+    def test_max_int64_round_trips(self, handle):
+        big = (1 << 63) - 1
+        small = -(1 << 63)
+        batch = pa.table({"x": pa.array([big, small, 0], pa.int64())})
+        handle.write_fn(batch)
+        assert handle.read_fn().column("x").to_pylist() == [big, small, 0]
+
+    def test_nan_and_inf_round_trip(self, handle):
+        batch = pa.table(
+            {
+                "f": pa.array(
+                    [float("inf"), float("-inf"), float("nan"), 0.0],
+                    pa.float64(),
+                )
+            }
+        )
+        handle.write_fn(batch)
+        out = handle.read_fn().column("f").to_pylist()
+        # NaN doesn't equal itself; compare positionally.
+        assert out[0] == float("inf")
+        assert out[1] == float("-inf")
+        assert out[2] != out[2]  # NaN
+        assert out[3] == 0.0
+
+    def test_empty_string_round_trips(self, handle):
+        batch = pa.table({"s": pa.array(["", "x", ""], pa.string())})
+        handle.write_fn(batch)
+        assert handle.read_fn().column("s").to_pylist() == ["", "x", ""]
+
+    def test_embedded_nul_byte_in_string(self, handle):
+        # NUL inside a VARCHAR is a routine pathology when JSON came from
+        # a binary-tinted upstream. Both backends should preserve.
+        batch = pa.table({"s": pa.array(["a\x00b", "no\x00ul"], pa.string())})
+        handle.write_fn(batch)
+        assert handle.read_fn().column("s").to_pylist() == ["a\x00b", "no\x00ul"]
+
+    def test_unicode_value_round_trip(self, handle):
+        batch = pa.table({"s": pa.array(["日本語", "café", "🦆"], pa.string())})
+        handle.write_fn(batch)
+        assert handle.read_fn().column("s").to_pylist() == ["日本語", "café", "🦆"]
+
+    def test_very_long_string_value(self, handle):
+        big = "x" * 100_000
+        batch = pa.table({"s": pa.array(["small", big], pa.string())})
+        handle.write_fn(batch)
+        got = handle.read_fn().column("s").to_pylist()
+        assert got[0] == "small"
+        assert len(got[1]) == 100_000
+
+
+# ---------------------------------------------------------------------------
+# 9. Schema evolution semantics + metric parity (parametrized + divergent)
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaEvolutionParity:
+    """Both backends share the schema-evolution use cases (add column,
+    widen, reject narrowing). The metric names emitted should match. The
+    exception-handling semantics on commit failure DIVERGE — locked
+    separately below."""
+
+    def test_add_column_works_on_both(self, handle):
+        handle.write_fn(_three_row_batch())
+        # Second write introduces a new column.
+        batch2 = pa.table(
+            {
+                "event": ["x"],
+                "team_id": pa.array([4], pa.int64()),
+                "country": ["US"],
+            }
+        )
+        handle.write_fn(batch2)
+        names = set(handle.read_fn().schema.names)
+        assert "country" in names
+
+    def test_add_column_increments_schema_columns_added(self, handle):
+        handle.write_fn(_three_row_batch())
+        # Patch the metrics module that *the backend imports* — DuckLake
+        # imports `from millpond import metrics`, Iceberg the same.
+        with patch(f"millpond.{handle.name if handle.name=='iceberg' else 'schema'}.metrics") as mock_metrics:
+            handle.write_fn(
+                pa.table(
+                    {
+                        "event": ["x"],
+                        "team_id": pa.array([4], pa.int64()),
+                        "country": ["US"],
+                    }
+                )
+            )
+            # Both must call schema_columns_added_total.inc() at least once.
+            assert mock_metrics.schema_columns_added_total.inc.called, (
+                f"{handle.name} did not increment schema_columns_added_total on column add"
+            )
+
+    def test_widen_int_increments_schema_columns_widened(self, handle):
+        # Seed with int32 → IntegerType / INTEGER on each side.
+        handle.write_fn(
+            pa.table(
+                {
+                    "event": ["x"],
+                    "team_id": pa.array([1], pa.int32()),
+                }
+            )
+        )
+        # Force the schema manager to know the current state. The Iceberg
+        # SchemaManager re-loads on its own; the DuckLake one too.
+        with patch(f"millpond.{handle.name if handle.name=='iceberg' else 'schema'}.metrics") as mock_metrics:
+            handle.write_fn(
+                pa.table(
+                    {
+                        "event": ["x"],
+                        "team_id": pa.array([1], pa.int64()),
+                    }
+                )
+            )
+            assert mock_metrics.schema_columns_widened_total.inc.called, (
+                f"{handle.name} did not increment schema_columns_widened_total on int32→int64"
+            )
+
+    def test_unsafe_field_name_increments_records_skipped(self, handle):
+        handle.write_fn(_three_row_batch())
+        target = "iceberg" if handle.name == "iceberg" else "schema"
+        with patch(f"millpond.{target}.metrics") as mock_metrics:
+            handle.schema_mgr.evolve(
+                pa.schema(
+                    [
+                        pa.field("event", pa.string()),
+                        pa.field("team_id", pa.int64()),
+                        pa.field("évil", pa.string()),  # unsafe (non-ASCII)
+                    ]
+                )
+            )
+            mock_metrics.records_skipped_total.labels.assert_called_with(
+                reason="unsafe_field_name"
+            )
+
+    def test_repeated_evolution_back_and_forth(self, handle):
+        """A batch with col A, then col A+B, then col A again (no col B
+        in the new arrival). The schema must still hold both columns —
+        evolution is additive, dropping is not supported on either side."""
+        handle.write_fn(pa.table({"event": ["a"]}))
+        handle.write_fn(pa.table({"event": ["b"], "extra": ["x"]}))
+        handle.write_fn(pa.table({"event": ["c"]}))
+        names = set(handle.read_fn().schema.names)
+        assert "extra" in names
+
+    def test_no_change_does_not_increment_added(self, handle):
+        handle.write_fn(_three_row_batch())
+        target = "iceberg" if handle.name == "iceberg" else "schema"
+        with patch(f"millpond.{target}.metrics") as mock_metrics:
+            handle.write_fn(_three_row_batch())
+            mock_metrics.schema_columns_added_total.inc.assert_not_called()
+
+
+class TestSchemaEvolutionErrorDivergence:
+    """DuckLake.SchemaManager swallows per-column ALTER failures
+    (log + metric, then keep evolving the other columns). Iceberg's
+    SchemaManager wraps all changes in one update_schema() transaction
+    and RE-RAISES on commit failure (per the module docstring: "the
+    write-retry loop in main.py then invalidates caches and retries").
+
+    Both bump errors_total{type="schema"} before either reaches its
+    branch. Lock the actual divergence."""
+
+    def test_ducklake_swallows_per_column_failure(self, ducklake_handle):
+        """A failed ALTER on one column doesn't stop the next ALTER.
+
+        DuckDBPyConnection objects don't allow attribute reassignment, so
+        we wrap the SchemaManager's conn reference instead — the manager
+        only uses it via `._conn.execute(...)`, which is exactly the
+        attribute we need to intercept."""
+        # Seed.
+        ducklake_handle.write_fn(_three_row_batch())
+        real_conn = ducklake_handle.raw["conn"]
+
+        def execute_side_effect(sql, *a, **kw):
+            if "ADD COLUMN" in sql and "a_extra" in sql:
+                raise duckdb.Error("simulated transient failure")
+            return real_conn.execute(sql, *a, **kw)
+
+        wrapped = MagicMock(wraps=real_conn)
+        wrapped.execute = execute_side_effect
+
+        # Swap in the wrapped conn just for this evolve() call.
+        ducklake_handle.schema_mgr._conn = wrapped
+        try:
+            with patch("millpond.schema.metrics"):
+                ducklake_handle.schema_mgr.evolve(
+                    pa.schema(
+                        [
+                            pa.field("event", pa.string()),
+                            pa.field("team_id", pa.int64()),
+                            pa.field("a_extra", pa.string()),
+                            pa.field("b_extra", pa.string()),
+                        ]
+                    )
+                )
+        finally:
+            ducklake_handle.schema_mgr._conn = real_conn
+
+        names = set(ducklake_handle.read_fn().schema.names)
+        assert "b_extra" in names, (
+            "DuckLake.SchemaManager.evolve must continue past a "
+            "per-column failure (locks the swallow-and-continue semantic)."
+        )
+        assert "a_extra" not in names, (
+            "The failed column should NOT have been added."
+        )
+
+    def test_iceberg_reraises_on_commit_failure(self, iceberg_handle):
+        """Iceberg's evolve re-raises after invalidate+metric on
+        update_schema failure; main.py's retry path is responsible for
+        recovery. Simulate by patching the catalog's load_table to raise
+        during the evolve transaction."""
+        from unittest.mock import patch as _patch
+
+        iceberg_handle.write_fn(_three_row_batch())
+        # Pre-init the manager so evolve doesn't return early.
+        iceberg_handle.schema_mgr.evolve(
+            pa.schema(
+                [pa.field("event", pa.string()), pa.field("team_id", pa.int64())]
+            )
+        )
+
+        catalog = iceberg_handle.raw["catalog"]
+        real_load = catalog.load_table
+
+        def explode(_ident):
+            raise RuntimeError("simulated catalog blip during update")
+
+        with _patch.object(catalog, "load_table", side_effect=explode):
+            with _patch("millpond.iceberg.metrics") as mock_metrics:
+                with pytest.raises(Exception):
+                    iceberg_handle.schema_mgr.evolve(
+                        pa.schema(
+                            [
+                                pa.field("event", pa.string()),
+                                pa.field("team_id", pa.int64()),
+                                pa.field("user_id", pa.string()),
+                            ]
+                        )
+                    )
+                # errors_total{type=schema} fired before re-raise.
+                mock_metrics.errors_total.labels.assert_any_call(type="schema")
+        # And the manager invalidated itself for the next retry.
+        assert iceberg_handle.schema_mgr._initialized is False
+
+        # Restore real load_table so teardown can use it.
+        catalog.load_table = real_load  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# 10. Caller-contract enforcement in main._write_with_retry
+# ---------------------------------------------------------------------------
+
+
+class TestWriteRetryHonoursSinkContract:
+    """_write_with_retry must treat both Sinks identically: call
+    .write(batch), on failure call .reset_caches() and retry up to
+    _WRITE_MAX_RETRIES. This is parity at the orchestrator layer."""
+
+    @pytest.mark.parametrize("backend", ["ducklake", "iceberg"])
+    def test_reset_caches_called_after_failure(self, backend):
+        """Mock Sink with the .write/.reset_caches/.close spec, prove
+        _write_with_retry behaves identically regardless of which Sink
+        implementation is plugged in."""
+        from millpond.main import _write_with_retry
+
+        sink = MagicMock(spec=["write", "reset_caches", "close"])
+        sink.write.side_effect = [RuntimeError("boom"), None]
+        batch = pa.table({"a": [1]})
+        with patch("millpond.main.time"):
+            _write_with_retry(sink, batch)
+        # reset_caches was invoked between the failed and successful
+        # attempts — both backends rely on this contract.
+        assert sink.reset_caches.call_count == 1
+        assert sink.write.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# 11. Performance smoke contracts (parametrized)
+# ---------------------------------------------------------------------------
+
+
+class TestPerformanceContracts:
+    """Conservative wall-clock bounds — the goal is catching a 100x
+    regression, not a 10% one. These are NOT benchmarks; they are
+    "did something go horribly wrong" smoke tests. Tuned so a healthy
+    laptop or CI runner finishes well under the threshold."""
+
+    def test_first_write_to_empty_catalog_completes_under_10s(self, handle):
+        """Create-table + first append is the slowest path on each
+        backend (catalog round-trips, schema-sample building, partition
+        spec, etc.). 10s is a generous ceiling — production typically
+        sees <1s. If it ever hits the cap, something has gone wrong."""
+        start = time.monotonic()
+        handle.write_fn(_three_row_batch())
+        elapsed = time.monotonic() - start
+        assert elapsed < 10.0, (
+            f"{handle.name} first write took {elapsed:.2f}s, "
+            "expected <10s. Something is wrong with create-table/append."
+        )
+
+    def test_subsequent_write_completes_under_5s(self, handle):
+        """Warm-path append: table exists, schema unchanged, cache hot.
+        Should be much faster than first write. 5s is again a smoke
+        ceiling, not a benchmark target."""
+        handle.write_fn(_three_row_batch())  # warm
+        start = time.monotonic()
+        handle.write_fn(_three_row_batch())
+        elapsed = time.monotonic() - start
+        assert elapsed < 5.0, (
+            f"{handle.name} warm-path write took {elapsed:.2f}s, expected <5s."
+        )
+
+    def test_100_row_batch_writes_under_5s(self, handle):
+        batch = pa.table(
+            {
+                "event": [f"e{i}" for i in range(100)],
+                "team_id": pa.array(list(range(100)), pa.int64()),
+            }
+        )
+        start = time.monotonic()
+        handle.write_fn(batch)
+        elapsed = time.monotonic() - start
+        assert elapsed < 5.0, (
+            f"{handle.name} 100-row write took {elapsed:.2f}s, expected <5s."
+        )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -129,3 +129,164 @@ class TestLoad:
     def test_kafka_consumer_overrides_default_empty(self):
         cfg = load()
         assert cfg.kafka_config_overrides == ()
+
+    def test_destination_defaults_to_ducklake(self):
+        cfg = load()
+        assert cfg.destination == "ducklake"
+        assert cfg.table_label == "events"
+
+    def test_iceberg_fields_none_when_destination_ducklake(self):
+        cfg = load()
+        assert cfg.iceberg_catalog_uri is None
+        assert cfg.iceberg_namespace is None
+        assert cfg.s3_access_key_id is None
+
+
+class TestLoadIcebergDestination:
+    @pytest.fixture(autouse=True)
+    def _env(self, monkeypatch):
+        # Strip any DUCKLAKE_* so a leak doesn't make this test pass by accident.
+        for key in list(__import__("os").environ):
+            if key.startswith("DUCKLAKE_"):
+                monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+        monkeypatch.setenv("KAFKA_TOPIC", "test-topic")
+        monkeypatch.setenv("REPLICA_COUNT", "4")
+        monkeypatch.setenv("POD_NAME", "millpond-events-2")
+        monkeypatch.setenv("MILLPOND_DESTINATION", "iceberg")
+        monkeypatch.setenv("ICEBERG_TABLE", "events")
+        monkeypatch.setenv("ICEBERG_NAMESPACE", "millpond")
+        monkeypatch.setenv("ICEBERG_CATALOG_URI", "http://catalog:8181")
+        monkeypatch.setenv("ICEBERG_WAREHOUSE", "s3://warehouse/")
+        monkeypatch.setenv("MILLPOND_S3_ACCESS_KEY_ID", "akid")
+        monkeypatch.setenv("MILLPOND_S3_SECRET_ACCESS_KEY", "secret")
+        monkeypatch.setenv("MILLPOND_S3_REGION", "us-east-1")
+
+    def test_loads_iceberg(self, monkeypatch):
+        # Use a distinct iceberg_table name from the KAFKA_TOPIC so we can
+        # actually prove dispatch — not just rely on both happening to be
+        # "events". (Prior version of this test was a false-positive.)
+        monkeypatch.setenv("ICEBERG_TABLE", "ice_events")
+        cfg = load()
+        assert cfg.destination == "iceberg"
+        assert cfg.iceberg_table == "ice_events"
+        assert cfg.iceberg_namespace == "millpond"
+        assert cfg.iceberg_catalog_uri == "http://catalog:8181"
+        assert cfg.iceberg_warehouse == "s3://warehouse/"
+        assert cfg.s3_access_key_id == "akid"
+        assert cfg.table_label == "millpond.ice_events"
+
+    def test_default_group_id_uses_iceberg_table(self, monkeypatch):
+        # Distinct table name so the assertion proves we're reading
+        # iceberg_table (not ducklake_table or KAFKA_TOPIC).
+        monkeypatch.setenv("ICEBERG_TABLE", "ice_events")
+        cfg = load()
+        assert cfg.group_id == "millpond-test-topic-ice_events"
+
+    @pytest.mark.parametrize("raw", ["ICEBERG", "Iceberg", "iceberg", "IceBERG"])
+    def test_iceberg_destination_is_case_insensitive(self, raw, monkeypatch):
+        monkeypatch.setenv("MILLPOND_DESTINATION", raw)
+        cfg = load()
+        assert cfg.destination == "iceberg"
+
+    def test_ducklake_fields_none_when_destination_iceberg(self):
+        cfg = load()
+        assert cfg.ducklake_table is None
+        assert cfg.rds_host is None
+        assert cfg.partition_by is None
+
+    def test_stray_ducklake_env_vars_are_ignored(self, monkeypatch):
+        # An operator who flipped MILLPOND_DESTINATION to iceberg may still
+        # have DUCKLAKE_* set from the prior config. Those should be silently
+        # ignored, not validated, not pulled into Config.
+        monkeypatch.setenv("DUCKLAKE_TABLE", "leftover")
+        monkeypatch.setenv("DUCKLAKE_RDS_PASSWORD", "leftover")
+        cfg = load()
+        assert cfg.destination == "iceberg"
+        assert cfg.ducklake_table is None  # ignored, not propagated
+
+    def test_optional_s3_endpoint_and_token(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_S3_ENDPOINT", "http://minio:9000")
+        monkeypatch.setenv("ICEBERG_CATALOG_TOKEN", "bearer-xyz")
+        cfg = load()
+        assert cfg.s3_endpoint == "http://minio:9000"
+        assert cfg.iceberg_catalog_token == "bearer-xyz"
+
+    @pytest.mark.parametrize(
+        "missing_var",
+        [
+            "ICEBERG_CATALOG_URI",
+            "ICEBERG_WAREHOUSE",
+            "ICEBERG_NAMESPACE",
+            "ICEBERG_TABLE",
+            "MILLPOND_S3_ACCESS_KEY_ID",
+            "MILLPOND_S3_SECRET_ACCESS_KEY",
+            "MILLPOND_S3_REGION",
+        ],
+    )
+    def test_missing_iceberg_required_field_raises(self, missing_var, monkeypatch):
+        monkeypatch.delenv(missing_var)
+        with pytest.raises(RuntimeError, match=missing_var):
+            load()
+
+    def test_unsafe_iceberg_table_name_rejected(self, monkeypatch):
+        monkeypatch.setenv("ICEBERG_TABLE", "events; DROP TABLE x")
+        with pytest.raises(RuntimeError, match="unsafe characters"):
+            load()
+
+    def test_unsafe_iceberg_namespace_rejected(self, monkeypatch):
+        monkeypatch.setenv("ICEBERG_NAMESPACE", "evil-ns")
+        with pytest.raises(RuntimeError, match="unsafe characters"):
+            load()
+
+
+class TestLoadDestinationValidation:
+    @pytest.fixture(autouse=True)
+    def _env(self, monkeypatch):
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+        monkeypatch.setenv("KAFKA_TOPIC", "test-topic")
+        monkeypatch.setenv("REPLICA_COUNT", "4")
+        monkeypatch.setenv("POD_NAME", "millpond-events-2")
+        monkeypatch.setenv("DUCKLAKE_TABLE", "events")
+        monkeypatch.setenv("DUCKLAKE_DATA_PATH", "s3://bucket/data")
+        monkeypatch.setenv("DUCKLAKE_RDS_HOST", "host")
+        monkeypatch.setenv("DUCKLAKE_RDS_PASSWORD", "pass")
+        monkeypatch.setenv("DUCKLAKE_CONNECTION", ":memory:")
+
+    def test_unknown_destination_raises(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_DESTINATION", "snowflake")
+        with pytest.raises(RuntimeError, match="MILLPOND_DESTINATION"):
+            load()
+
+    @pytest.mark.parametrize("raw", ["DUCKLAKE", "DuckLake", "ducklake", "DuckLAKE"])
+    def test_ducklake_destination_is_case_insensitive(self, raw, monkeypatch):
+        # `.lower()` in load() accepts any casing operators might helm-template in.
+        monkeypatch.setenv("MILLPOND_DESTINATION", raw)
+        cfg = load()
+        assert cfg.destination == "ducklake"
+
+    def test_destination_whitespace_tolerated(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_DESTINATION", "  ducklake  ")
+        cfg = load()
+        assert cfg.destination == "ducklake"
+
+    def test_destination_empty_string_defaults_to_ducklake(self, monkeypatch):
+        # Common helm-template gotcha: unset variable renders as "" rather
+        # than being absent. Treat empty/whitespace as fall-back to default.
+        monkeypatch.setenv("MILLPOND_DESTINATION", "")
+        cfg = load()
+        assert cfg.destination == "ducklake"
+
+    def test_destination_only_whitespace_defaults_to_ducklake(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_DESTINATION", "   ")
+        cfg = load()
+        assert cfg.destination == "ducklake"
+
+    def test_stray_iceberg_env_vars_ignored_when_destination_ducklake(self, monkeypatch):
+        # Symmetric to the iceberg-side test: stray ICEBERG_* should not
+        # affect a DuckLake deployment.
+        monkeypatch.setenv("ICEBERG_TABLE", "ice_events")
+        monkeypatch.setenv("ICEBERG_NAMESPACE", "millpond")
+        cfg = load()
+        assert cfg.destination == "ducklake"
+        assert cfg.iceberg_table is None

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -4,8 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from confluent_kafka import OFFSET_STORED
 
-from confluent_kafka import OFFSET_STORED
-
+from millpond.config import Config
 from millpond.consumer import (
     _base_kafka_config,
     _maybe_attach_oauth_cb,
@@ -14,7 +13,6 @@ from millpond.consumer import (
     create,
     discover_partition_count,
 )
-from millpond.config import Config
 
 
 class TestComputeAssignment:
@@ -137,6 +135,7 @@ def _make_cfg(**overrides) -> Config:
         group_id="test-group",
         replica_count=4,
         ordinal=1,
+        destination="ducklake",
         ducklake_table="events",
         ducklake_data_path="s3://bucket/data",
         ducklake_connection=":memory:",
@@ -145,9 +144,19 @@ def _make_cfg(**overrides) -> Config:
         rds_database="ducklake",
         rds_username="ducklake",
         rds_password="pass",
+        partition_by=None,
+        iceberg_catalog_uri=None,
+        iceberg_warehouse=None,
+        iceberg_namespace=None,
+        iceberg_table=None,
+        iceberg_table_location=None,
+        iceberg_catalog_token=None,
+        s3_access_key_id=None,
+        s3_secret_access_key=None,
+        s3_region=None,
+        s3_endpoint=None,
         flush_size=100,
         flush_interval_ms=1000,
-        partition_by=None,
         fetch_min_bytes=1,
         fetch_max_wait_ms=500,
         consume_batch_size=1000,
@@ -169,6 +178,20 @@ class TestBaseKafkaConfig:
         cfg = _make_cfg(ordinal=3)
         base = _base_kafka_config(cfg)
         assert base["client.id"] == "millpond-test-topic-events-3"
+
+    def test_includes_client_id_for_iceberg_destination(self):
+        # When the destination is iceberg, table_label is "namespace.table"
+        # rather than the bare ducklake_table. Lock the formatting so a
+        # future cfg refactor doesn't silently change the client.id shape.
+        cfg = _make_cfg(
+            ordinal=2,
+            destination="iceberg",
+            ducklake_table=None,
+            iceberg_namespace="millpond",
+            iceberg_table="ice_events",
+        )
+        base = _base_kafka_config(cfg)
+        assert base["client.id"] == "millpond-test-topic-millpond.ice_events-2"
 
     def test_includes_overrides(self):
         cfg = _make_cfg(kafka_config_overrides=(("security.protocol", "SSL"), ("sasl.mechanisms", "PLAIN")))

--- a/tests/unit/test_ducklake.py
+++ b/tests/unit/test_ducklake.py
@@ -9,9 +9,7 @@ from millpond.ducklake import (
     _escape_libpq,
     _sanitize_setting_value,
     _table_exists,
-    _tables_ensured,
     _validate_partition_expr,
-    reset_table_cache,
 )
 
 
@@ -92,24 +90,14 @@ class TestEscapeLibpq:
         assert _escape_libpq(None) == "''"
 
 
-class TestResetTableCache:
-    def test_reset_clears_ensured_tables(self):
-        _tables_ensured.add("test_table")
-        assert "test_table" in _tables_ensured
-        reset_table_cache()
-        assert len(_tables_ensured) == 0
-
-
-@pytest.fixture(autouse=True)
-def _clear_table_cache():
-    """Ensure table cache is clean before and after each test."""
-    reset_table_cache()
-    yield
-    reset_table_cache()
-
-
 def _sample_batch() -> pa.Table:
     return pa.table({"col_a": [1], "col_b": ["x"]})
+
+
+@pytest.fixture
+def cache() -> set[str]:
+    """A fresh caller-owned ensure cache, one per test."""
+    return set()
 
 
 class TestTableExists:
@@ -125,33 +113,33 @@ class TestTableExists:
 
 
 class TestEnsureTable:
-    def test_skips_if_cached(self):
+    def test_skips_if_cached(self, cache):
         conn = MagicMock()
-        _tables_ensured.add("events")
-        _ensure_table(conn, "events", _sample_batch())
+        cache.add("events")
+        _ensure_table(conn, "events", _sample_batch(), cache)
         conn.execute.assert_not_called()
 
     @patch("millpond.ducklake._table_exists", return_value=True)
-    def test_skips_create_if_table_exists(self, mock_exists):
+    def test_skips_create_if_table_exists(self, mock_exists, cache):
         conn = MagicMock()
-        _ensure_table(conn, "events", _sample_batch())
+        _ensure_table(conn, "events", _sample_batch(), cache)
         conn.execute.assert_not_called()
-        assert "events" in _tables_ensured
+        assert "events" in cache
 
     @patch("millpond.ducklake._table_exists", return_value=False)
-    def test_creates_table_and_caches(self, mock_exists):
+    def test_creates_table_and_caches(self, mock_exists, cache):
         conn = MagicMock()
-        _ensure_table(conn, "events", _sample_batch())
+        _ensure_table(conn, "events", _sample_batch(), cache)
         # Should have called register, execute (CREATE), unregister
         assert conn.execute.call_count >= 1
         create_sql = conn.execute.call_args_list[0][0][0]
         assert "CREATE TABLE IF NOT EXISTS" in create_sql
-        assert "events" in _tables_ensured
+        assert "events" in cache
 
     @patch("millpond.ducklake._table_exists", return_value=False)
-    def test_creates_table_with_partitioning(self, mock_exists):
+    def test_creates_table_with_partitioning(self, mock_exists, cache):
         conn = MagicMock()
-        _ensure_table(conn, "events", _sample_batch(), partition_by="team_id,year(ts)")
+        _ensure_table(conn, "events", _sample_batch(), cache, partition_by="team_id,year(ts)")
         # Find the ALTER PARTITIONED BY call
         alter_calls = [
             call for call in conn.execute.call_args_list if "PARTITIONED BY" in str(call)
@@ -160,7 +148,7 @@ class TestEnsureTable:
         assert "team_id,year(ts)" in str(alter_calls[0])
 
     @patch("millpond.ducklake._table_exists")
-    def test_concurrent_create_recovers(self, mock_exists):
+    def test_concurrent_create_recovers(self, mock_exists, cache):
         """If CREATE fails but another pod created the table, continue."""
         # First call: table doesn't exist. Second call (after error): table exists.
         mock_exists.side_effect = [False, True]
@@ -168,11 +156,11 @@ class TestEnsureTable:
         conn.register = MagicMock()
         conn.unregister = MagicMock()
         conn.execute.side_effect = duckdb.Error("serialization conflict")
-        _ensure_table(conn, "events", _sample_batch())
-        assert "events" in _tables_ensured
+        _ensure_table(conn, "events", _sample_batch(), cache)
+        assert "events" in cache
 
     @patch("millpond.ducklake._table_exists")
-    def test_create_fails_and_table_still_missing_raises(self, mock_exists):
+    def test_create_fails_and_table_still_missing_raises(self, mock_exists, cache):
         """If CREATE fails and table doesn't exist, raise."""
         mock_exists.return_value = False
         conn = MagicMock()
@@ -180,10 +168,10 @@ class TestEnsureTable:
         conn.unregister = MagicMock()
         conn.execute.side_effect = duckdb.Error("connection lost")
         with pytest.raises(RuntimeError, match="Failed to create table"):
-            _ensure_table(conn, "events", _sample_batch())
+            _ensure_table(conn, "events", _sample_batch(), cache)
 
     @patch("millpond.ducklake._table_exists")
-    def test_concurrent_partition_alter_recovers(self, mock_exists):
+    def test_concurrent_partition_alter_recovers(self, mock_exists, cache):
         """If ALTER PARTITIONED BY fails but table exists, continue."""
         mock_exists.side_effect = [False, True]
         conn = MagicMock()
@@ -195,5 +183,5 @@ class TestEnsureTable:
                 raise duckdb.Error("serialization conflict")
 
         conn.execute.side_effect = execute_side_effect
-        _ensure_table(conn, "events", _sample_batch(), partition_by="team_id")
-        assert "events" in _tables_ensured
+        _ensure_table(conn, "events", _sample_batch(), cache, partition_by="team_id")
+        assert "events" in cache

--- a/tests/unit/test_ducklake_maintenance.py
+++ b/tests/unit/test_ducklake_maintenance.py
@@ -1,4 +1,4 @@
-"""Unit tests for tools/maintenance.py.
+"""Unit tests for tools/ducklake_maintenance.py.
 
 Coverage tier A: pure helpers, log message shape, argparse plumbing.
 Coverage tier B: orchestrator retry/dispatch logic with mocked sub-calls.
@@ -12,7 +12,7 @@ import logging
 from unittest.mock import MagicMock, patch
 
 import duckdb
-import maintenance
+import ducklake_maintenance
 import pytest
 
 # ---------------------------------------------------------------------------
@@ -22,51 +22,51 @@ import pytest
 
 class TestSqlStringLiteral:
     def test_plain(self):
-        assert maintenance._sql_string_literal("plain") == "'plain'"
+        assert ducklake_maintenance._sql_string_literal("plain") == "'plain'"
 
     def test_embedded_quote_doubled(self):
-        assert maintenance._sql_string_literal("with'quote") == "'with''quote'"
+        assert ducklake_maintenance._sql_string_literal("with'quote") == "'with''quote'"
 
     def test_already_doubled_quotes_are_escaped_again(self):
         # The helper has no idea whether the input was pre-escaped; doubling
         # is a one-way transform consistent with SQL string-literal rules.
-        assert maintenance._sql_string_literal("two''already") == "'two''''already'"
+        assert ducklake_maintenance._sql_string_literal("two''already") == "'two''''already'"
 
     def test_empty(self):
-        assert maintenance._sql_string_literal("") == "''"
+        assert ducklake_maintenance._sql_string_literal("") == "''"
 
 
 class TestBytesToHuman:
     """Round-trip DuckLake's stored byte-count format back to a units-suffixed form."""
 
     def test_clean_mib(self):
-        assert maintenance._bytes_to_human("67108864") == "64MiB"
-        assert maintenance._bytes_to_human("134217728") == "128MiB"
-        assert maintenance._bytes_to_human("5242880") == "5MiB"
+        assert ducklake_maintenance._bytes_to_human("67108864") == "64MiB"
+        assert ducklake_maintenance._bytes_to_human("134217728") == "128MiB"
+        assert ducklake_maintenance._bytes_to_human("5242880") == "5MiB"
 
     def test_clean_gib(self):
-        assert maintenance._bytes_to_human("1073741824") == "1GiB"
-        assert maintenance._bytes_to_human("2147483648") == "2GiB"
+        assert ducklake_maintenance._bytes_to_human("1073741824") == "1GiB"
+        assert ducklake_maintenance._bytes_to_human("2147483648") == "2GiB"
 
     def test_clean_kib(self):
-        assert maintenance._bytes_to_human("1024") == "1KiB"
-        assert maintenance._bytes_to_human("4096") == "4KiB"
+        assert ducklake_maintenance._bytes_to_human("1024") == "1KiB"
+        assert ducklake_maintenance._bytes_to_human("4096") == "4KiB"
 
     def test_picks_largest_clean_unit(self):
         # 64 MiB = 65536 KiB; the converter picks MiB, not KiB.
-        assert maintenance._bytes_to_human("67108864") == "64MiB"
+        assert ducklake_maintenance._bytes_to_human("67108864") == "64MiB"
 
     def test_non_power_of_1024_returns_none(self):
-        assert maintenance._bytes_to_human("12345678") is None
+        assert ducklake_maintenance._bytes_to_human("12345678") is None
 
     def test_zero_or_negative_returns_none(self):
-        assert maintenance._bytes_to_human("0") is None
-        assert maintenance._bytes_to_human("-1024") is None
+        assert ducklake_maintenance._bytes_to_human("0") is None
+        assert ducklake_maintenance._bytes_to_human("-1024") is None
 
     def test_non_integer_returns_none(self):
-        assert maintenance._bytes_to_human("128MiB") is None
-        assert maintenance._bytes_to_human("") is None
-        assert maintenance._bytes_to_human(None) is None
+        assert ducklake_maintenance._bytes_to_human("128MiB") is None
+        assert ducklake_maintenance._bytes_to_human("") is None
+        assert ducklake_maintenance._bytes_to_human(None) is None
 
 
 class TestLogCleanupThroughput:
@@ -77,7 +77,7 @@ class TestLogCleanupThroughput:
 
     def test_typical(self, caplog):
         with caplog.at_level(logging.INFO, logger="maintenance"):
-            maintenance._log_cleanup_throughput(
+            ducklake_maintenance._log_cleanup_throughput(
                 "cleanup-all", files_processed=50, elapsed_s=10.0, queue_depth_after=950
             )
         msg = caplog.records[0].getMessage()
@@ -92,13 +92,13 @@ class TestLogCleanupThroughput:
 
     def test_zero_elapsed_does_not_divide_by_zero(self, caplog):
         with caplog.at_level(logging.INFO, logger="maintenance"):
-            maintenance._log_cleanup_throughput("cleanup", 0, 0.0, 0)
+            ducklake_maintenance._log_cleanup_throughput("cleanup", 0, 0.0, 0)
         msg = caplog.records[0].getMessage()
         assert "rate_obj_s=0.0" in msg
 
     def test_full_drain(self, caplog):
         with caplog.at_level(logging.INFO, logger="maintenance"):
-            maintenance._log_cleanup_throughput("cleanup-all", 47023, 9405.0, 0)
+            ducklake_maintenance._log_cleanup_throughput("cleanup-all", 47023, 9405.0, 0)
         msg = caplog.records[0].getMessage()
         assert "files_processed=47023" in msg
         assert "rate_obj_s=5.0" in msg
@@ -109,7 +109,7 @@ class TestArgparse:
     """The new subcommands must reach the dispatch with the expected fields."""
 
     def setup_method(self):
-        self.parser = maintenance.build_parser()
+        self.parser = ducklake_maintenance.build_parser()
 
     def test_dedup_deletions_dry_run(self):
         args = self.parser.parse_args(["dedup-deletions", "--dry-run"])
@@ -178,16 +178,16 @@ class TestCleanupAllSafe:
 
     def _patches(self):
         return (
-            patch("maintenance._acquire_advisory_lock"),
-            patch("maintenance.dedup_deletions"),
-            patch("maintenance.heal_orphans"),
-            patch("maintenance.cleanup_all"),
+            patch("ducklake_maintenance._acquire_advisory_lock"),
+            patch("ducklake_maintenance.dedup_deletions"),
+            patch("ducklake_maintenance.heal_orphans"),
+            patch("ducklake_maintenance.cleanup_all"),
         )
 
     def test_succeeds_on_first_attempt(self):
         lock, dedup, heal, cleanup = (p.start() for p in self._patches())
         try:
-            maintenance.cleanup_all_safe(MagicMock(), max_iterations=10)
+            ducklake_maintenance.cleanup_all_safe(MagicMock(), max_iterations=10)
         finally:
             patch.stopall()
         # Lock taken once for the whole orchestration.
@@ -203,7 +203,7 @@ class TestCleanupAllSafe:
         # Second attempt: dedup + heal mop up the fresh orphans, cleanup succeeds.
         cleanup.side_effect = [duckdb.IOException("simulated NoSuchKey"), None]
         try:
-            maintenance.cleanup_all_safe(MagicMock(), max_iterations=10)
+            ducklake_maintenance.cleanup_all_safe(MagicMock(), max_iterations=10)
         finally:
             patch.stopall()
         assert lock.call_count == 1, "lock taken once for the whole orchestration"
@@ -216,7 +216,7 @@ class TestCleanupAllSafe:
         cleanup.side_effect = duckdb.IOException("persistent crash")
         try:
             with pytest.raises(RuntimeError, match="exhausted 3 iterations"):
-                maintenance.cleanup_all_safe(MagicMock(), max_iterations=3)
+                ducklake_maintenance.cleanup_all_safe(MagicMock(), max_iterations=3)
         finally:
             patch.stopall()
         assert dedup.call_count == 3
@@ -229,13 +229,13 @@ class TestFsck:
 
     def test_dry_run_delegates_to_dry_run_subcalls(self):
         with (
-            patch("maintenance.dedup_deletions") as dedup,
-            patch("maintenance.heal_orphans") as heal,
-            patch("maintenance.orphans") as s3_orphans,
-            patch("maintenance.cleanup_all_safe") as orch,
+            patch("ducklake_maintenance.dedup_deletions") as dedup,
+            patch("ducklake_maintenance.heal_orphans") as heal,
+            patch("ducklake_maintenance.orphans") as s3_orphans,
+            patch("ducklake_maintenance.cleanup_all_safe") as orch,
         ):
             conn = MagicMock()
-            maintenance.fsck(conn, dry_run=True, max_iterations=10)
+            ducklake_maintenance.fsck(conn, dry_run=True, max_iterations=10)
         # Dry-run must run heal_orphans so its B1/B3 gates execute.
         dedup.assert_called_once_with(conn, dry_run=True)
         heal.assert_called_once_with(conn, dry_run=True)
@@ -244,13 +244,13 @@ class TestFsck:
 
     def test_real_run_calls_orchestrator_and_s3_sweep(self):
         with (
-            patch("maintenance.dedup_deletions") as dedup,
-            patch("maintenance.heal_orphans") as heal,
-            patch("maintenance.orphans") as s3_orphans,
-            patch("maintenance.cleanup_all_safe") as orch,
+            patch("ducklake_maintenance.dedup_deletions") as dedup,
+            patch("ducklake_maintenance.heal_orphans") as heal,
+            patch("ducklake_maintenance.orphans") as s3_orphans,
+            patch("ducklake_maintenance.cleanup_all_safe") as orch,
         ):
             conn = MagicMock()
-            maintenance.fsck(conn, dry_run=False, max_iterations=7)
+            ducklake_maintenance.fsck(conn, dry_run=False, max_iterations=7)
         # Real path goes through cleanup_all_safe (which itself calls dedup +
         # heal under the lock); it must NOT call heal/dedup directly here, or
         # we'd be running them outside the lock.
@@ -263,13 +263,13 @@ class TestFsck:
         """A real fsck would abort once heal-orphans hits a failed gate; the
         dry-run must surface the same outcome rather than reporting healthy."""
         with (
-            patch("maintenance.dedup_deletions"),
-            patch("maintenance.heal_orphans") as heal,
-            patch("maintenance.orphans"),
+            patch("ducklake_maintenance.dedup_deletions"),
+            patch("ducklake_maintenance.heal_orphans") as heal,
+            patch("ducklake_maintenance.orphans"),
         ):
             heal.side_effect = RuntimeError("safety gate B1 failed: ...")
             with pytest.raises(RuntimeError, match="safety gate B1"):
-                maintenance.fsck(MagicMock(), dry_run=True, max_iterations=10)
+                ducklake_maintenance.fsck(MagicMock(), dry_run=True, max_iterations=10)
 
 
 class TestSetCompactionTuning:
@@ -277,7 +277,7 @@ class TestSetCompactionTuning:
 
     def test_emits_expected_sets(self):
         conn = MagicMock()
-        maintenance._set_compaction_tuning(conn, threads=4, memory_limit="8GB")
+        ducklake_maintenance._set_compaction_tuning(conn, threads=4, memory_limit="8GB")
         executed = [c.args[0] for c in conn.execute.call_args_list]
         assert "SET threads = 4" in executed
         assert "SET memory_limit = '8GB'" in executed
@@ -287,7 +287,7 @@ class TestSetCompactionTuning:
     def test_rejects_injection_in_memory_limit(self):
         conn = MagicMock()
         with pytest.raises(ValueError, match="Illegal character"):
-            maintenance._set_compaction_tuning(conn, threads=2, memory_limit="4GB'; DROP TABLE x; --")
+            ducklake_maintenance._set_compaction_tuning(conn, threads=2, memory_limit="4GB'; DROP TABLE x; --")
         # Sanitization happens before any execute; conn must not have been touched.
         conn.execute.assert_not_called()
 
@@ -314,7 +314,7 @@ class TestScopedTargetFileSize:
         # equals the default — that's a healthy install, not a failure.
         conn = self._conn("134217728")
         with caplog.at_level(logging.WARNING, logger="maintenance"):
-            with maintenance._scoped_target_file_size(conn, "5MiB"):
+            with ducklake_maintenance._scoped_target_file_size(conn, "5MiB"):
                 pass
         warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
         assert warnings == [], "no warning expected on a clean default-value round-trip"
@@ -323,7 +323,7 @@ class TestScopedTargetFileSize:
         # 64 MiB — operator value, not the default.
         conn = self._conn("67108864")
         with caplog.at_level(logging.WARNING, logger="maintenance"):
-            with maintenance._scoped_target_file_size(conn, "5MiB"):
+            with ducklake_maintenance._scoped_target_file_size(conn, "5MiB"):
                 pass
         assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
 
@@ -333,7 +333,7 @@ class TestScopedTargetFileSize:
         # the warning is informative.
         conn = self._conn("12345678")
         with caplog.at_level(logging.WARNING, logger="maintenance"):
-            with maintenance._scoped_target_file_size(conn, "5MiB"):
+            with ducklake_maintenance._scoped_target_file_size(conn, "5MiB"):
                 pass
         warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
         assert len(warnings) == 1
@@ -343,13 +343,13 @@ class TestScopedTargetFileSize:
     def test_no_warning_when_prior_unset(self, caplog):
         conn = self._conn(None)
         with caplog.at_level(logging.WARNING, logger="maintenance"):
-            with maintenance._scoped_target_file_size(conn, "5MiB"):
+            with ducklake_maintenance._scoped_target_file_size(conn, "5MiB"):
                 pass
         assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
 
     def test_restores_to_converted_prior(self):
         conn = self._conn("67108864")
-        with maintenance._scoped_target_file_size(conn, "5MiB"):
+        with ducklake_maintenance._scoped_target_file_size(conn, "5MiB"):
             pass
         # The last execute call should be the restore SET to '64MiB'.
         last_sql = conn.execute.call_args_list[-1].args[0]
@@ -358,10 +358,10 @@ class TestScopedTargetFileSize:
 
     def test_restores_to_default_when_prior_unset(self):
         conn = self._conn(None)
-        with maintenance._scoped_target_file_size(conn, "5MiB"):
+        with ducklake_maintenance._scoped_target_file_size(conn, "5MiB"):
             pass
         last_sql = conn.execute.call_args_list[-1].args[0]
-        assert f"'{maintenance.DEFAULT_TARGET_FILE_SIZE}'" in last_sql
+        assert f"'{ducklake_maintenance.DEFAULT_TARGET_FILE_SIZE}'" in last_sql
 
 
 class TestAcquireAdvisoryLock:
@@ -370,7 +370,7 @@ class TestAcquireAdvisoryLock:
     def test_emits_single_postgres_query_call_with_doubled_quotes(self):
         conn = MagicMock()
         conn.execute.return_value.fetchone.return_value = (True,)
-        maintenance._acquire_advisory_lock(conn)
+        ducklake_maintenance._acquire_advisory_lock(conn)
         sent = conn.execute.call_args_list[0].args[0]
         # Outer single-quote-wrapped literal (postgres_query 2nd arg) and
         # inner single quotes around 'millpond-...' must be doubled to
@@ -382,4 +382,4 @@ class TestAcquireAdvisoryLock:
         conn = MagicMock()
         conn.execute.return_value.fetchone.return_value = (False,)
         with pytest.raises(RuntimeError, match="advisory lock"):
-            maintenance._acquire_advisory_lock(conn)
+            ducklake_maintenance._acquire_advisory_lock(conn)

--- a/tests/unit/test_ducklake_maintenance_macros.py
+++ b/tests/unit/test_ducklake_maintenance_macros.py
@@ -1,4 +1,4 @@
-"""Tier C: SQL macros in tools/maintenance.sql against a stub schema.
+"""Tier C: SQL macros in tools/ducklake_maintenance.sql against a stub schema.
 
 In-process DuckDB with stub catalog tables and a real local-filesystem glob.
 Exercises path-normalization logic where the same physical file may be
@@ -15,12 +15,12 @@ historical entries.
 import re
 
 import duckdb
-import maintenance
+import ducklake_maintenance
 import pytest
 
 
 def _make_stub_lake(con):
-    """Mirror the DuckLake catalog tables maintenance.py / maintenance.sql touch.
+    """Mirror the DuckLake catalog tables ducklake_maintenance.py / ducklake_maintenance.sql touch.
 
     Includes the ``end_snapshot`` column on data_file and delete_file even
     though the existing macro tests don't read it — heal-orphans's safety
@@ -50,7 +50,7 @@ def _seed_queue(con, rows):
 
 
 def _load_macros(con):
-    con.execute(maintenance.MAINTENANCE_SQL_PATH.read_text())
+    con.execute(ducklake_maintenance.MAINTENANCE_SQL_PATH.read_text())
 
 
 @pytest.fixture
@@ -253,7 +253,7 @@ class TestHealOrphansGates:
         _load_macros(lake_con)
         # heal_orphans creates _orphans via find_catalog_orphans(?) then
         # runs B1/B3. dry_run=True returns before the DELETE.
-        maintenance.heal_orphans(lake_con, dry_run=True)
+        ducklake_maintenance.heal_orphans(lake_con, dry_run=True)
 
     def test_b1_passes_when_only_expired_rows_match_queue(self, lake_con, data_dir, monkeypatch):
         # data_file_id=1 was once live (path 'a') but is now expired (snapshot 100).
@@ -326,7 +326,7 @@ class TestHealOrphansGates:
         monkeypatch.setenv("DUCKLAKE_DATA_PATH", str(data_dir) + "/")
         _load_macros(lake_con)
         with pytest.raises(RuntimeError, match="safety gate B1 failed.*still appear as live"):
-            maintenance.heal_orphans(lake_con, dry_run=True)
+            ducklake_maintenance.heal_orphans(lake_con, dry_run=True)
 
 
 class TestB1GateS3Paths:
@@ -352,7 +352,7 @@ class TestB1GateS3Paths:
         # sides and recognize the same file.
         self._populate_orphans(lake_con, [(1, "s3://bucket/lake/data/a.parquet")])
         _seed_data_files(lake_con, [(1, "s3://bucket/lake/data/a.parquet", None)])
-        total_live, would_be_live = maintenance._heal_orphans_b1_counts(lake_con, "s3://bucket/lake/data")
+        total_live, would_be_live = ducklake_maintenance._heal_orphans_b1_counts(lake_con, "s3://bucket/lake/data")
         assert total_live == 1
         assert would_be_live == 1
 
@@ -365,20 +365,20 @@ class TestB1GateS3Paths:
         # the queue stores keys like 'main/events/.../X.parquet'.
         self._populate_orphans(lake_con, [(1, "a.parquet")])
         _seed_data_files(lake_con, [(1, "s3://bucket/lake/data/a.parquet", None)])
-        _, would_be_live = maintenance._heal_orphans_b1_counts(lake_con, "s3://bucket/lake/data")
+        _, would_be_live = ducklake_maintenance._heal_orphans_b1_counts(lake_con, "s3://bucket/lake/data")
         assert would_be_live == 1, "s3 absolute live row must match relative-queue orphan after normalization"
 
     def test_s3_absolute_queue_vs_s3_relative_data_file(self, lake_con):
         # Symmetric: queue absolute, data_file relative.
         self._populate_orphans(lake_con, [(1, "s3://bucket/lake/data/a.parquet")])
         _seed_data_files(lake_con, [(1, "a.parquet", None)])
-        _, would_be_live = maintenance._heal_orphans_b1_counts(lake_con, "s3://bucket/lake/data")
+        _, would_be_live = ducklake_maintenance._heal_orphans_b1_counts(lake_con, "s3://bucket/lake/data")
         assert would_be_live == 1
 
     def test_s3_with_trailing_slash_still_matches(self, lake_con):
         self._populate_orphans(lake_con, [(1, "a.parquet")])
         _seed_data_files(lake_con, [(1, "s3://bucket/lake/data/a.parquet", None)])
-        _, would_be_live = maintenance._heal_orphans_b1_counts(lake_con, "s3://bucket/lake/data/")
+        _, would_be_live = ducklake_maintenance._heal_orphans_b1_counts(lake_con, "s3://bucket/lake/data/")
         assert would_be_live == 1, "trailing-slash data_path on s3:// must not produce double-slash mismatch"
 
     def test_s3_expired_data_file_does_not_block(self, lake_con):
@@ -392,7 +392,7 @@ class TestB1GateS3Paths:
                 (2, "s3://bucket/lake/data/live.parquet", None),  # live, different
             ],
         )
-        total_live, would_be_live = maintenance._heal_orphans_b1_counts(lake_con, "s3://bucket/lake/data")
+        total_live, would_be_live = ducklake_maintenance._heal_orphans_b1_counts(lake_con, "s3://bucket/lake/data")
         assert total_live == 1
         assert would_be_live == 0, "expired s3:// row must not block heal-orphans"
 
@@ -404,14 +404,14 @@ class TestSchemaConsistency:
         ever changes ATTACH_NAME, this test fails loudly — the constraint
         is documented in the .sql header but the assertion is what makes it
         load-bearing."""
-        sql = maintenance.MAINTENANCE_SQL_PATH.read_text()
+        sql = ducklake_maintenance.MAINTENANCE_SQL_PATH.read_text()
         # Strip line comments so we don't catch the cautionary references in
         # the header.
         without_comments = "\n".join(line.split("--", 1)[0] for line in sql.splitlines())
         refs = set(re.findall(r"__ducklake_metadata_\w+", without_comments))
-        unexpected = refs - {maintenance.METADATA_SCHEMA}
+        unexpected = refs - {ducklake_maintenance.METADATA_SCHEMA}
         assert not unexpected, (
-            f"maintenance.sql references {sorted(unexpected)} but METADATA_SCHEMA "
-            f"is {maintenance.METADATA_SCHEMA!r}. If you change ATTACH_NAME in "
-            "maintenance.py, update the schema references in maintenance.sql to match."
+            f"ducklake_maintenance.sql references {sorted(unexpected)} but METADATA_SCHEMA "
+            f"is {ducklake_maintenance.METADATA_SCHEMA!r}. If you change ATTACH_NAME in "
+            "ducklake_maintenance.py, update the schema references in ducklake_maintenance.sql to match."
         )

--- a/tests/unit/test_ducklake_metrics.py
+++ b/tests/unit/test_ducklake_metrics.py
@@ -347,7 +347,7 @@ class TestBuiltinFilesPerBand:
     def test_band_boundaries_inclusive_lower_exclusive_upper(self, conn, registry):
         # Exactly 1 MiB (1048576) must land in 1to5mib, not lt1mib —
         # matches DuckLake's own bin semantics (min inclusive, max
-        # exclusive) so this metric's bands compose with maintenance.py's
+        # exclusive) so this metric's bands compose with ducklake_maintenance.py's
         # tiered compaction.
         _stub_catalog(conn)
         conn.execute(
@@ -629,7 +629,7 @@ class TestSchedulerReconnect:
 
 
 class TestConnectWithBackoff:
-    """maintenance.connect() retries with exponential backoff until success or stop."""
+    """ducklake_maintenance.connect() retries with exponential backoff until success or stop."""
 
     def test_eventually_returns_connection(self, registry, monkeypatch):
         sm = dm._build_self_metrics(registry=registry)
@@ -643,7 +643,7 @@ class TestConnectWithBackoff:
                 raise RuntimeError("transient")
             return sentinel
 
-        monkeypatch.setattr(dm.maintenance, "connect", fake_connect)
+        monkeypatch.setattr(dm.ducklake_maintenance, "connect", fake_connect)
         # Speed test up: Event.wait returns immediately if stop is already
         # set, but here we don't want that. Instead patch the constants so
         # delays are in ms, not seconds.
@@ -667,7 +667,7 @@ class TestConnectWithBackoff:
             stop.set()
             raise RuntimeError("never recovers")
 
-        monkeypatch.setattr(dm.maintenance, "connect", fake_connect)
+        monkeypatch.setattr(dm.ducklake_maintenance, "connect", fake_connect)
         monkeypatch.setattr(dm, "_BACKOFF_INITIAL_SECONDS", 0.001)
 
         assert dm._connect_with_backoff(stop, sm) is None

--- a/tests/unit/test_iceberg.py
+++ b/tests/unit/test_iceberg.py
@@ -1,0 +1,339 @@
+"""Unit tests for millpond/iceberg.py.
+
+Uses PyIceberg's ``SqlCatalog`` against a temp SQLite file as a real
+catalog backend so the tests exercise the actual ``create_table`` /
+``load_table`` / ``Table.append`` paths rather than mocking them. The
+warehouse is a temp directory on the local filesystem — no S3, no
+Docker, no REST fixture.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pyarrow as pa
+import pytest
+from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.partitioning import PartitionSpec
+from pyiceberg.transforms import IdentityTransform
+
+from millpond import iceberg
+
+
+@pytest.fixture
+def catalog(tmp_path):
+    """A SqlCatalog backed by a temp SQLite file with a temp warehouse dir."""
+    cat = SqlCatalog(
+        "test",
+        **{
+            "uri": f"sqlite:///{tmp_path}/cat.db",
+            "warehouse": f"file://{tmp_path}/warehouse",
+        },
+    )
+    yield cat
+
+
+@pytest.fixture
+def cache() -> dict:
+    """Per-test caller-owned ensure cache (formerly module-level `_tables_ensured`)."""
+    return {}
+
+
+def _sample_batch() -> pa.Table:
+    """Three-row sample with a string and an int column — mimics post-JSON-conversion shape."""
+    return pa.table({"event": ["click", "view", "scroll"], "team_id": [1, 2, 3]})
+
+
+# ---------------------------------------------------------------------------
+# _add_metadata_columns / _schema_sample
+# ---------------------------------------------------------------------------
+
+
+class TestAddMetadataColumns:
+    def test_appends_inserted_at_and_partition_cols(self, monkeypatch):
+        # Pin "now" so the derived year/month/day/hour are predictable.
+        fixed = datetime.datetime(2026, 5, 13, 14, 30, 0, tzinfo=datetime.UTC)
+        monkeypatch.setattr(iceberg, "_now_utc_us", lambda: fixed)
+        out = iceberg._add_metadata_columns(_sample_batch())
+
+        # Schema gained _inserted_at + 4 partition cols, in order (appended
+        # to whatever the source schema had — slice the trailing 5 so we
+        # don't depend on _sample_batch()'s column count).
+        assert out.schema.names[-5:] == ["_inserted_at", "year", "month", "day", "hour"]
+
+        # Derived values match the pinned timestamp.
+        assert out.column("year").to_pylist() == [2026, 2026, 2026]
+        assert out.column("month").to_pylist() == [5, 5, 5]
+        assert out.column("day").to_pylist() == [13, 13, 13]
+        assert out.column("hour").to_pylist() == [14, 14, 14]
+
+    def test_partition_cols_are_int32(self):
+        out = iceberg._add_metadata_columns(_sample_batch())
+        for name in iceberg.PARTITION_COLS:
+            assert out.schema.field(name).type == pa.int32(), (
+                f"{name} must be int32 — Iceberg's IdentityTransform on int64 would still work "
+                "but we lock the width so the on-disk layout doesn't depend on PyArrow's "
+                "default return type of pc.year/month/day/hour."
+            )
+
+    def test_inserted_at_is_utc(self):
+        out = iceberg._add_metadata_columns(_sample_batch())
+        ts_type = out.schema.field("_inserted_at").type
+        assert isinstance(ts_type, pa.TimestampType)
+        assert ts_type.tz == "UTC"
+
+    def test_all_rows_share_one_timestamp(self):
+        # A flush must land in exactly one partition, not get split by
+        # the microsecond drift of sequential per-row timestamps.
+        out = iceberg._add_metadata_columns(_sample_batch())
+        ts_values = out.column("_inserted_at").to_pylist()
+        assert len(set(ts_values)) == 1
+
+
+class TestSchemaSample:
+    def test_has_zero_rows_and_correct_columns(self):
+        sample = iceberg._schema_sample(_sample_batch())
+        assert sample.num_rows == 0
+        names = [sample.schema.field(i).name for i in range(sample.num_columns)]
+        # source cols first, then metadata cols in fixed order
+        assert names == ["event", "team_id", "_inserted_at", "year", "month", "day", "hour"]
+
+    def test_metadata_col_dtypes_match_real_writes(self, monkeypatch):
+        # If _schema_sample's dtypes drift from _add_metadata_columns' output,
+        # create_table will declare types that don't match what Table.append
+        # will try to write, and the first real write fails. Lock them.
+        fixed = datetime.datetime(2026, 5, 13, 14, 30, 0, tzinfo=datetime.UTC)
+        monkeypatch.setattr(iceberg, "_now_utc_us", lambda: fixed)
+        sample = iceberg._schema_sample(_sample_batch())
+        real = iceberg._add_metadata_columns(_sample_batch())
+        for name in ("_inserted_at", "year", "month", "day", "hour"):
+            assert sample.schema.field(name).type == real.schema.field(name).type
+
+
+# ---------------------------------------------------------------------------
+# _build_partition_spec
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPartitionSpec:
+    def test_four_identity_fields(self):
+        from pyiceberg.io.pyarrow import _pyarrow_to_schema_without_ids
+        from pyiceberg.schema import assign_fresh_schema_ids
+
+        ice_schema = assign_fresh_schema_ids(
+            _pyarrow_to_schema_without_ids(iceberg._schema_sample(_sample_batch()).schema)
+        )
+        spec = iceberg._build_partition_spec(ice_schema)
+
+        assert isinstance(spec, PartitionSpec)
+        assert len(spec.fields) == 4
+        assert [f.name for f in spec.fields] == list(iceberg.PARTITION_COLS)
+        for f in spec.fields:
+            assert isinstance(f.transform, IdentityTransform)
+
+    def test_partition_field_ids_are_distinct_from_column_ids(self):
+        from pyiceberg.io.pyarrow import _pyarrow_to_schema_without_ids
+        from pyiceberg.schema import assign_fresh_schema_ids
+
+        ice_schema = assign_fresh_schema_ids(
+            _pyarrow_to_schema_without_ids(iceberg._schema_sample(_sample_batch()).schema)
+        )
+        spec = iceberg._build_partition_spec(ice_schema)
+        column_ids = {f.field_id for f in ice_schema.fields}
+        partition_ids = {f.field_id for f in spec.fields}
+        # Iceberg field IDs are catalog-wide unique; partition fields can't
+        # share IDs with columns or we'll get conflicting metadata.
+        assert column_ids.isdisjoint(partition_ids)
+
+
+# ---------------------------------------------------------------------------
+# _ensure_table
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureTable:
+    def test_creates_new_table_with_partition_spec(self, catalog, cache):
+        table = iceberg._ensure_table(catalog, "ns", "events", _sample_batch(), cache)
+        assert table.spec().fields  # has a non-trivial partition spec
+        assert [f.name for f in table.spec().fields] == list(iceberg.PARTITION_COLS)
+
+    def test_caches_subsequent_calls(self, catalog, cache):
+        t1 = iceberg._ensure_table(catalog, "ns", "events", _sample_batch(), cache)
+        t2 = iceberg._ensure_table(catalog, "ns", "events", _sample_batch(), cache)
+        # Same Python object — cache hit, no second load_table round trip.
+        assert t1 is t2
+
+    def test_loads_existing_table(self, catalog, cache):
+        # Pre-create via the real path; then a fresh cache should load,
+        # not create.
+        iceberg._ensure_table(catalog, "ns", "events", _sample_batch(), cache)
+        cache.clear()
+        table = iceberg._ensure_table(catalog, "ns", "events", _sample_batch(), cache)
+        assert table.name() == ("ns", "events")
+
+    def test_falls_back_to_load_when_create_loses_race(self, catalog, cache, monkeypatch):
+        from pyiceberg.exceptions import NoSuchTableError, TableAlreadyExistsError
+
+        # Pre-create via the real path so a real load_table will succeed.
+        iceberg._ensure_table(catalog, "ns", "events", _sample_batch(), cache)
+        cache.clear()
+        # Patch load_table to raise NoSuchTableError once (forcing the
+        # create path) then succeed; patch create_table to raise the
+        # narrow already-exists signal we catch.
+        real_load = catalog.load_table
+
+        def raise_create(*_a, **_kw):
+            raise TableAlreadyExistsError("simulated race")
+
+        load_calls = {"n": 0}
+
+        def load_then_succeed(identifier):
+            load_calls["n"] += 1
+            if load_calls["n"] == 1:
+                raise NoSuchTableError("simulated initial miss")
+            return real_load(identifier)
+
+        monkeypatch.setattr(catalog, "load_table", load_then_succeed)
+        monkeypatch.setattr(catalog, "create_table", raise_create)
+        table = iceberg._ensure_table(catalog, "ns", "events", _sample_batch(), cache)
+        assert table is not None
+        assert load_calls["n"] == 2  # initial miss + fallback after create_table raised
+
+
+# ---------------------------------------------------------------------------
+# write
+# ---------------------------------------------------------------------------
+
+
+class TestWrite:
+    def test_appends_rows_with_metadata_cols(self, catalog, cache, monkeypatch):
+        fixed = datetime.datetime(2026, 5, 13, 14, 30, 0, tzinfo=datetime.UTC)
+        monkeypatch.setattr(iceberg, "_now_utc_us", lambda: fixed)
+
+        iceberg.write(catalog, "ns", "events", _sample_batch(), cache)
+
+        table = catalog.load_table(("ns", "events"))
+        df = table.scan().to_arrow()
+        # Source rows landed, plus the metadata columns we manage.
+        assert df.num_rows == 3
+        assert set(df.column_names) >= {"event", "team_id", "_inserted_at", "year", "month", "day", "hour"}
+        assert df.column("year").to_pylist() == [2026, 2026, 2026]
+        assert df.column("hour").to_pylist() == [14, 14, 14]
+
+    def test_empty_batch_is_noop(self, catalog, cache):
+        from pyiceberg.exceptions import NoSuchTableError
+
+        empty = pa.table({"event": pa.array([], pa.string()), "team_id": pa.array([], pa.int64())})
+        # Per the Sink contract, write() shouldn't be called with len==0; the
+        # backend defensively skips the catalog round trip and does NOT create
+        # the table. (DuckLake takes the opposite path — see Sink protocol docs.)
+        iceberg.write(catalog, "ns", "events", empty, cache)
+        with pytest.raises(NoSuchTableError):
+            catalog.load_table(("ns", "events"))
+
+    def test_multiple_writes_accumulate(self, catalog, cache, monkeypatch):
+        fixed = datetime.datetime(2026, 5, 13, 14, 30, 0, tzinfo=datetime.UTC)
+        monkeypatch.setattr(iceberg, "_now_utc_us", lambda: fixed)
+
+        iceberg.write(catalog, "ns", "events", _sample_batch(), cache)
+        iceberg.write(catalog, "ns", "events", _sample_batch(), cache)
+
+        df = catalog.load_table(("ns", "events")).scan().to_arrow()
+        assert df.num_rows == 6
+
+
+# ---------------------------------------------------------------------------
+# cache lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestRealisticPayloads:
+    """Production batches are not always flat-and-tidy. Cover the shapes
+    that arrow_converter actually produces:
+      * nullable columns with some/all NULL values
+      * mixed-width ints
+      * timestamps both with and without tz
+      * all-null columns (Arrow may yield `null` type when every JSON value is None)
+    """
+
+    def test_nullable_column_with_some_nulls(self, catalog, cache, monkeypatch):
+        fixed = datetime.datetime(2026, 5, 13, 14, 30, 0, tzinfo=datetime.UTC)
+        monkeypatch.setattr(iceberg, "_now_utc_us", lambda: fixed)
+
+        batch = pa.table(
+            {
+                "event": ["click", None, "view"],
+                "team_id": pa.array([1, None, 3], pa.int64()),
+            }
+        )
+        iceberg.write(catalog, "ns", "events", batch, cache)
+        df = catalog.load_table(("ns", "events")).scan().to_arrow()
+        assert df.num_rows == 3
+        # Null preservation: the None entries land as NULL, not coerced.
+        assert df.column("event").to_pylist() == ["click", None, "view"]
+        assert df.column("team_id").to_pylist() == [1, None, 3]
+
+    def test_all_null_int_column(self, catalog, cache, monkeypatch):
+        fixed = datetime.datetime(2026, 5, 13, 14, 30, 0, tzinfo=datetime.UTC)
+        monkeypatch.setattr(iceberg, "_now_utc_us", lambda: fixed)
+
+        batch = pa.table(
+            {
+                "event": ["x", "y"],
+                "score": pa.array([None, None], pa.int64()),  # all-null, typed
+            }
+        )
+        iceberg.write(catalog, "ns", "events", batch, cache)
+        df = catalog.load_table(("ns", "events")).scan().to_arrow()
+        assert df.column("score").to_pylist() == [None, None]
+
+    def test_mixed_int_widths(self, catalog, cache, monkeypatch):
+        fixed = datetime.datetime(2026, 5, 13, 14, 30, 0, tzinfo=datetime.UTC)
+        monkeypatch.setattr(iceberg, "_now_utc_us", lambda: fixed)
+
+        batch = pa.table(
+            {
+                "small": pa.array([1, 2], pa.int16()),
+                "regular": pa.array([10, 20], pa.int32()),
+                "big": pa.array([100, 200], pa.int64()),
+            }
+        )
+        iceberg.write(catalog, "ns", "events", batch, cache)
+        df = catalog.load_table(("ns", "events")).scan().to_arrow()
+        # int16 and int32 widen to int32 on the Iceberg side (IntegerType);
+        # int64 stays LongType. Values land unchanged.
+        assert df.column("small").to_pylist() == [1, 2]
+        assert df.column("regular").to_pylist() == [10, 20]
+        assert df.column("big").to_pylist() == [100, 200]
+
+    def test_timestamp_without_tz_maps_to_timestamp_type(self):
+        # _arrow_to_iceberg distinguishes naive (TimestampType) from
+        # tz-aware (TimestamptzType). Production payloads usually carry tz,
+        # but some sources emit naive — verify both paths.
+        from pyiceberg.types import TimestampType, TimestamptzType
+
+        from millpond.iceberg import _arrow_to_iceberg
+
+        assert isinstance(_arrow_to_iceberg(pa.timestamp("us")), TimestampType)
+        assert isinstance(_arrow_to_iceberg(pa.timestamp("us", tz="UTC")), TimestamptzType)
+
+
+class TestCacheLifecycle:
+    def test_clearing_cache_forces_reload(self, catalog, cache):
+        t1 = iceberg._ensure_table(catalog, "ns", "events", _sample_batch(), cache)
+        cache.clear()
+        t2 = iceberg._ensure_table(catalog, "ns", "events", _sample_batch(), cache)
+        # New Python object after cache reset (load_table returns a fresh
+        # Table instance each call).
+        assert t1 is not t2
+
+    def test_separate_caches_do_not_interfere(self, catalog):
+        # Two independent caches → two independent Table refs even for the
+        # same catalog identifier. Proves caches are caller-owned.
+        cache_a: dict = {}
+        cache_b: dict = {}
+        ta = iceberg._ensure_table(catalog, "ns", "events", _sample_batch(), cache_a)
+        tb = iceberg._ensure_table(catalog, "ns", "events", _sample_batch(), cache_b)
+        assert ta is not tb
+        assert "ns.events" in cache_a
+        assert "ns.events" in cache_b

--- a/tests/unit/test_iceberg_schema.py
+++ b/tests/unit/test_iceberg_schema.py
@@ -1,0 +1,306 @@
+"""Unit tests for the Iceberg SchemaManager (millpond/iceberg.py).
+
+Schema evolution lives inside the iceberg module rather than the shared
+schema.py — that file is DuckLake-specific. Tests here use PyIceberg's
+SqlCatalog against a temp SQLite file so we exercise the real
+update_schema() commit path.
+"""
+
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.types import (
+    BinaryType,
+    BooleanType,
+    DateType,
+    DoubleType,
+    FloatType,
+    IntegerType,
+    LongType,
+    StringType,
+    TimestampType,
+    TimestamptzType,
+)
+
+from millpond import iceberg
+from millpond.iceberg import SchemaManager, _arrow_to_iceberg
+
+
+@pytest.fixture
+def catalog(tmp_path):
+    return SqlCatalog(
+        "test",
+        **{
+            "uri": f"sqlite:///{tmp_path}/cat.db",
+            "warehouse": f"file://{tmp_path}/warehouse",
+        },
+    )
+
+
+def _initial_batch() -> pa.Table:
+    return pa.table({"event": ["click"], "team_id": [1]})
+
+
+def _seed_table(catalog) -> None:
+    """Land an initial table via iceberg._ensure_table so SchemaManager has something to read."""
+    iceberg._ensure_table(catalog, "ns", "events", _initial_batch(), {})
+
+
+# ---------------------------------------------------------------------------
+# _arrow_to_iceberg type mapping
+# ---------------------------------------------------------------------------
+
+
+class TestArrowToIceberg:
+    def test_bool(self):
+        assert isinstance(_arrow_to_iceberg(pa.bool_()), BooleanType)
+
+    def test_int_widths_below_64_to_integer(self):
+        for t in (pa.int8(), pa.int16(), pa.int32(), pa.uint8(), pa.uint16()):
+            assert isinstance(_arrow_to_iceberg(t), IntegerType), f"{t} should map to IntegerType"
+
+    def test_int64_and_uint32_uint64_to_long(self):
+        # uint32 exceeds signed int32 range; widen to LongType to be safe.
+        for t in (pa.int64(), pa.uint32(), pa.uint64()):
+            assert isinstance(_arrow_to_iceberg(t), LongType), f"{t} should map to LongType"
+
+    def test_float32_to_float_float64_to_double(self):
+        assert isinstance(_arrow_to_iceberg(pa.float32()), FloatType)
+        assert isinstance(_arrow_to_iceberg(pa.float64()), DoubleType)
+
+    def test_strings_to_string(self):
+        for t in (pa.string(), pa.large_string(), pa.utf8()):
+            assert isinstance(_arrow_to_iceberg(t), StringType)
+
+    def test_binary_to_binary(self):
+        assert isinstance(_arrow_to_iceberg(pa.binary()), BinaryType)
+        assert isinstance(_arrow_to_iceberg(pa.large_binary()), BinaryType)
+
+    def test_date_to_date(self):
+        assert isinstance(_arrow_to_iceberg(pa.date32()), DateType)
+
+    def test_timestamp_naive_vs_tz_aware(self):
+        assert isinstance(_arrow_to_iceberg(pa.timestamp("us")), TimestampType)
+        assert isinstance(_arrow_to_iceberg(pa.timestamp("us", tz="UTC")), TimestamptzType)
+
+    def test_unknown_falls_back_to_string(self):
+        # duration isn't in our explicit map — fallback prevents a crash on
+        # weird PyArrow types and lands the column as JSON-ish strings.
+        assert isinstance(_arrow_to_iceberg(pa.duration("us")), StringType)
+
+
+# ---------------------------------------------------------------------------
+# SchemaManager.evolve — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestEvolveAddColumns:
+    def test_adds_new_column(self, catalog):
+        _seed_table(catalog)
+        mgr = SchemaManager(catalog, "ns", "events")
+
+        # Add a column the table doesn't have yet.
+        new_schema = pa.schema([("event", pa.string()), ("team_id", pa.int64()), ("user_id", pa.string())])
+        mgr.evolve(new_schema)
+
+        table = catalog.load_table(("ns", "events"))
+        names = {f.name for f in table.schema().fields}
+        assert "user_id" in names
+
+    def test_multiple_new_columns_one_transaction(self, catalog):
+        _seed_table(catalog)
+        mgr = SchemaManager(catalog, "ns", "events")
+
+        new_schema = pa.schema(
+            [
+                ("event", pa.string()),
+                ("team_id", pa.int64()),
+                ("user_id", pa.string()),
+                ("country", pa.string()),
+                ("score", pa.float64()),
+            ]
+        )
+        mgr.evolve(new_schema)
+
+        table = catalog.load_table(("ns", "events"))
+        names = {f.name for f in table.schema().fields}
+        assert {"user_id", "country", "score"} <= names
+
+    def test_idempotent_on_no_change(self, catalog):
+        _seed_table(catalog)
+        mgr = SchemaManager(catalog, "ns", "events")
+
+        # First evolve — already-known columns; should commit nothing.
+        same_schema = pa.schema([("event", pa.string()), ("team_id", pa.int64())])
+        before = catalog.load_table(("ns", "events")).schema()
+        mgr.evolve(same_schema)
+        after = catalog.load_table(("ns", "events")).schema()
+        assert before == after
+
+
+class TestEvolveSkipsReserved:
+    def test_skips_inserted_at_and_partition_cols(self, catalog):
+        _seed_table(catalog)
+        mgr = SchemaManager(catalog, "ns", "events")
+
+        # Batch claims to have _inserted_at + partition cols (which it would,
+        # because they were added by iceberg.write). evolve must not try to
+        # re-add them — they're owned by iceberg.py.
+        with_meta = pa.schema(
+            [
+                ("event", pa.string()),
+                ("team_id", pa.int64()),
+                ("_inserted_at", pa.timestamp("us", tz="UTC")),
+                ("year", pa.int32()),
+                ("month", pa.int32()),
+                ("day", pa.int32()),
+                ("hour", pa.int32()),
+            ]
+        )
+
+        before = catalog.load_table(("ns", "events")).schema()
+        mgr.evolve(with_meta)
+        after = catalog.load_table(("ns", "events")).schema()
+        # No DDL should have fired (table already has _inserted_at + partition
+        # cols from iceberg._ensure_table; everything else in batch is known).
+        assert before == after
+
+
+class TestEvolveSkipsUnsafeNames:
+    def test_unsafe_name_skipped(self, catalog):
+        _seed_table(catalog)
+        mgr = SchemaManager(catalog, "ns", "events")
+
+        # "evil; DROP" would be an injection if the writer just interpolated.
+        # PyIceberg's API doesn't interpolate (this is belt-and-suspenders),
+        # but we keep the safety check at the SchemaManager layer.
+        bad = pa.schema([("event", pa.string()), ("team_id", pa.int64()), ("evil; DROP", pa.string())])
+        mgr.evolve(bad)
+
+        table = catalog.load_table(("ns", "events"))
+        names = {f.name for f in table.schema().fields}
+        assert "evil; DROP" not in names
+
+
+# ---------------------------------------------------------------------------
+# SchemaManager.evolve — uninitialised paths
+# ---------------------------------------------------------------------------
+
+
+class TestEvolveBeforeTableExists:
+    def test_returns_silently_when_table_missing(self, catalog):
+        # No table seeded. evolve() should not raise — iceberg.write will
+        # create the table on the next call; evolve picks it up afterward.
+        mgr = SchemaManager(catalog, "ns", "events")
+        schema = pa.schema([("event", pa.string()), ("team_id", pa.int64())])
+        mgr.evolve(schema)  # must not raise
+
+    def test_picks_up_table_on_next_evolve(self, catalog):
+        mgr = SchemaManager(catalog, "ns", "events")
+
+        # First evolve — table doesn't exist yet, returns silently.
+        mgr.evolve(pa.schema([("event", pa.string())]))
+
+        # iceberg.write creates the table (would happen in the real flow).
+        _seed_table(catalog)
+
+        # Second evolve adds a new column.
+        mgr.evolve(pa.schema([("event", pa.string()), ("team_id", pa.int64()), ("user_id", pa.string())]))
+        names = {f.name for f in catalog.load_table(("ns", "events")).schema().fields}
+        assert "user_id" in names
+
+
+# ---------------------------------------------------------------------------
+# Widening / narrowing
+# ---------------------------------------------------------------------------
+
+
+class TestEvolveWidens:
+    def test_int32_widens_to_long(self, catalog):
+        # Seed with team_id as IntegerType (int64 arrow → LongType, so seed
+        # with int32 to land an IntegerType column).
+        iceberg._ensure_table(
+            catalog, "ns", "events", pa.table({"event": ["x"], "team_id": pa.array([1], pa.int32())}), {}
+        )
+        mgr = SchemaManager(catalog, "ns", "events")
+        mgr.evolve(pa.schema([("event", pa.string()), ("team_id", pa.int32())]))  # initial load
+        # Now arrive with int64 — should widen Integer → Long.
+        committed = mgr.evolve(pa.schema([("event", pa.string()), ("team_id", pa.int64())]))
+        assert committed is True
+        field = next(f for f in catalog.load_table(("ns", "events")).schema().fields if f.name == "team_id")
+        assert isinstance(field.field_type, LongType)
+
+    def test_no_change_returns_false_and_skips_commit(self, catalog):
+        _seed_table(catalog)
+        mgr = SchemaManager(catalog, "ns", "events")
+        # Same schema — no commit, no reload signal.
+        result = mgr.evolve(pa.schema([("event", pa.string()), ("team_id", pa.int64())]))
+        assert result is False
+
+
+class TestEvolveRejectsNarrowing:
+    def test_long_to_int_raises_and_bumps_error_counter(self, catalog):
+        from unittest.mock import patch
+
+        # Seed with team_id as int64 → LongType.
+        _seed_table(catalog)
+        mgr = SchemaManager(catalog, "ns", "events")
+        mgr.evolve(pa.schema([("event", pa.string()), ("team_id", pa.int64())]))  # initialize
+
+        # Iceberg rejects narrowing in update_column. Attempt long → int.
+        from pyiceberg.exceptions import ValidationError
+
+        narrowing = pa.schema([("event", pa.string()), ("team_id", pa.int32())])
+        # PyIceberg 0.11.x raises ValidationError on narrowing. Lock the
+        # specific class so a future change in pyiceberg's exception
+        # hierarchy doesn't silently still "pass" against a broad except.
+        with patch("millpond.iceberg.metrics") as mock_metrics, pytest.raises(ValidationError):
+            mgr.evolve(narrowing)
+        # errors_total{type=schema}.inc() must have fired before the re-raise.
+        mock_metrics.errors_total.labels.assert_any_call(type="schema")
+        # Schema unchanged — narrowing was rejected, not silently applied.
+        field = next(f for f in catalog.load_table(("ns", "events")).schema().fields if f.name == "team_id")
+        assert isinstance(field.field_type, LongType)
+
+    def test_failed_evolve_invalidates_for_next_attempt(self, catalog):
+        from unittest.mock import patch
+
+        _seed_table(catalog)
+        mgr = SchemaManager(catalog, "ns", "events")
+        mgr.evolve(pa.schema([("event", pa.string()), ("team_id", pa.int64())]))
+        assert mgr._initialized
+
+        from pyiceberg.exceptions import ValidationError
+
+        narrowing = pa.schema([("event", pa.string()), ("team_id", pa.int32())])
+        with patch("millpond.iceberg.metrics"), pytest.raises(ValidationError):
+            mgr.evolve(narrowing)
+        # After the failure, the manager must be un-initialized so the next
+        # call re-loads (possibly observing another writer's evolution).
+        assert mgr._initialized is False
+
+
+# ---------------------------------------------------------------------------
+# invalidate
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidate:
+    def test_reload_after_invalidate(self, catalog):
+        _seed_table(catalog)
+        mgr = SchemaManager(catalog, "ns", "events")
+        mgr.evolve(pa.schema([("event", pa.string()), ("team_id", pa.int64())]))  # initializes
+
+        # Add a column via another (simulated) writer — bypassing our manager.
+        table = catalog.load_table(("ns", "events"))
+        with table.update_schema() as us:
+            us.add_column("user_id", StringType())
+
+        # Without invalidate, mgr's cached known-set wouldn't have user_id —
+        # invalidate forces a reload.
+        mgr.invalidate()
+        mgr.evolve(pa.schema([("event", pa.string()), ("team_id", pa.int64()), ("user_id", pa.string())]))
+        names = {f.name for f in catalog.load_table(("ns", "events")).schema().fields}
+        assert "user_id" in names

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,85 +1,127 @@
 from unittest.mock import MagicMock, patch
 
+import duckdb
 import pyarrow as pa
 import pytest
 from confluent_kafka import KafkaException
+from pyiceberg.exceptions import (
+    CommitFailedException,
+    CommitStateUnknownException,
+    ServerError,
+    ServiceUnavailableError,
+)
 
 from millpond.main import _convert_batch, _flush, _write_with_retry
 
 
+def _make_sink() -> MagicMock:
+    """Mock Sink — just needs `write`, `reset_caches`, and `close`."""
+    return MagicMock(spec=["write", "reset_caches", "close"])
+
+
+# Realistic failure modes the broad `except Exception` in _write_with_retry
+# must catch. If somebody narrows that handler later, these parametrizations
+# fail in CI before the regression reaches production. Includes:
+#   - OSError: S3 / network
+#   - duckdb.Error: DuckLake local execution
+#   - CommitFailedException: Iceberg optimistic-concurrency conflict
+#   - CommitStateUnknownException: REST 5xx after commit submission
+#   - ServerError / ServiceUnavailableError: catalog 5xx, transient
+#   - KafkaException: broker disconnect during a write (rare but possible
+#     if the same Kafka client surfaces an error mid-flush)
+#   - RuntimeError: catch-all for backend-internal surprises
+_RETRYABLE_EXCEPTIONS = [
+    OSError("S3 timeout"),
+    duckdb.Error("serialization conflict"),
+    CommitFailedException("optimistic-concurrency clash"),
+    CommitStateUnknownException("REST 5xx after submit"),
+    ServerError("catalog 500"),
+    ServiceUnavailableError("catalog 503"),
+    KafkaException("broker disconnect"),
+    RuntimeError("unexpected"),
+]
+
+
 class TestWriteWithRetry:
     def test_succeeds_first_try(self):
-        db = MagicMock()
-        schema_mgr = MagicMock()
+        sink = _make_sink()
         table = pa.table({"a": [1]})
-        with patch("millpond.main.ducklake") as mock_dl:
-            _write_with_retry(db, "test", table, schema_mgr)
-            assert mock_dl.write.call_count == 1
+        _write_with_retry(sink, table)
+        assert sink.write.call_count == 1
+        sink.reset_caches.assert_not_called()
 
-    def test_retries_on_failure(self):
-        db = MagicMock()
-        schema_mgr = MagicMock()
+    @pytest.mark.parametrize("exc", _RETRYABLE_EXCEPTIONS)
+    def test_retries_on_failure(self, exc):
+        sink = _make_sink()
+        sink.write.side_effect = [exc, None]
         table = pa.table({"a": [1]})
-        with patch("millpond.main.ducklake") as mock_dl, patch("millpond.main.time") as mock_time:
-            mock_dl.write.side_effect = [OSError("S3 timeout"), None]
-            _write_with_retry(db, "test", table, schema_mgr)
-            assert mock_dl.write.call_count == 2
-            mock_time.sleep.assert_called_once_with(1.0)
+        with patch("millpond.main.time") as mock_time:
+            _write_with_retry(sink, table)
+        assert sink.write.call_count == 2
+        mock_time.sleep.assert_called_once_with(1.0)
 
-    def test_raises_after_max_retries(self):
-        db = MagicMock()
-        schema_mgr = MagicMock()
+    @pytest.mark.parametrize(
+        "exc_cls",
+        [
+            OSError,
+            duckdb.Error,
+            CommitFailedException,
+            CommitStateUnknownException,
+            ServerError,
+            ServiceUnavailableError,
+            KafkaException,
+            RuntimeError,
+        ],
+    )
+    def test_raises_after_max_retries(self, exc_cls):
+        sink = _make_sink()
+        sink.write.side_effect = exc_cls("persistent failure")
         table = pa.table({"a": [1]})
-        with patch("millpond.main.ducklake") as mock_dl, patch("millpond.main.time"):
-            mock_dl.write.side_effect = OSError("persistent failure")
-            with pytest.raises(OSError):
-                _write_with_retry(db, "test", table, schema_mgr)
-            assert mock_dl.write.call_count == 3
+        with patch("millpond.main.time"), pytest.raises(exc_cls):
+            _write_with_retry(sink, table)
+        assert sink.write.call_count == 3
 
     def test_exponential_backoff(self):
-        db = MagicMock()
-        schema_mgr = MagicMock()
+        sink = _make_sink()
+        sink.write.side_effect = [OSError(), OSError(), None]
         table = pa.table({"a": [1]})
-        with patch("millpond.main.ducklake") as mock_dl, patch("millpond.main.time") as mock_time:
-            mock_dl.write.side_effect = [OSError(), OSError(), None]
-            _write_with_retry(db, "test", table, schema_mgr)
-            calls = [c.args[0] for c in mock_time.sleep.call_args_list]
-            assert calls == [1.0, 2.0]
+        with patch("millpond.main.time") as mock_time:
+            _write_with_retry(sink, table)
+        calls = [c.args[0] for c in mock_time.sleep.call_args_list]
+        assert calls == [1.0, 2.0]
 
-    def test_invalidates_schema_on_retry(self):
-        db = MagicMock()
-        schema_mgr = MagicMock()
+    @pytest.mark.parametrize("exc", _RETRYABLE_EXCEPTIONS)
+    def test_resets_caches_on_retry(self, exc):
+        sink = _make_sink()
+        sink.write.side_effect = [exc, None]
         table = pa.table({"a": [1]})
-        with patch("millpond.main.ducklake") as mock_dl, patch("millpond.main.time"):
-            mock_dl.write.side_effect = [OSError("schema conflict"), None]
-            _write_with_retry(db, "test", table, schema_mgr)
-            schema_mgr.invalidate.assert_called_once()
+        with patch("millpond.main.time"):
+            _write_with_retry(sink, table)
+        sink.reset_caches.assert_called_once()
 
 
 class TestFlushErrorDistinction:
     """Offset commit failures must be distinguishable from write failures in metrics and logs."""
 
     def _make_flush_args(self):
-        db = MagicMock()
+        sink = _make_sink()
         cfg = MagicMock()
-        cfg.ducklake_table = "test_table"
+        cfg.table_label = "test_table"
         kafka = MagicMock()
         table = pa.table({"a": [1, 2]})
         offsets = {("topic", 0): 42}
-        schema_mgr = MagicMock()
-        return db, cfg, kafka, table, offsets, schema_mgr
+        return sink, cfg, kafka, table, offsets
 
     @patch("millpond.main.time")
     @patch("millpond.main.server")
     @patch("millpond.main.metrics")
-    @patch("millpond.main.ducklake")
-    def test_commit_failure_raises_after_retries(self, mock_dl, mock_metrics, mock_server, mock_time):
+    def test_commit_failure_raises_after_retries(self, mock_metrics, mock_server, mock_time):
         mock_time.monotonic.return_value = 0.0
-        db, cfg, kafka, table, offsets, schema_mgr = self._make_flush_args()
+        sink, cfg, kafka, table, offsets = self._make_flush_args()
         kafka.commit.side_effect = KafkaException("broker unavailable")
 
         with pytest.raises(KafkaException):
-            _flush(db, cfg, kafka, table, 100, 2, offsets, 1.0, schema_mgr)
+            _flush(sink, cfg, kafka, table, 100, 2, offsets, 1.0)
 
         assert kafka.commit.call_count == 3
         # Each failed attempt increments the offset_commit error counter
@@ -91,39 +133,36 @@ class TestFlushErrorDistinction:
     @patch("millpond.main.time")
     @patch("millpond.main.server")
     @patch("millpond.main.metrics")
-    @patch("millpond.main.ducklake")
-    def test_commit_succeeds_after_retry(self, mock_dl, mock_metrics, mock_server, mock_time):
+    def test_commit_succeeds_after_retry(self, mock_metrics, mock_server, mock_time):
         mock_time.monotonic.return_value = 0.0
-        db, cfg, kafka, table, offsets, schema_mgr = self._make_flush_args()
+        sink, cfg, kafka, table, offsets = self._make_flush_args()
         kafka.commit.side_effect = [KafkaException("transient"), None]
 
         # Should not raise — commit succeeds on second attempt
-        _flush(db, cfg, kafka, table, 100, 2, offsets, 1.0, schema_mgr)
+        _flush(sink, cfg, kafka, table, 100, 2, offsets, 1.0)
         assert kafka.commit.call_count == 2
 
     @patch("millpond.main.time")
     @patch("millpond.main.server")
     @patch("millpond.main.metrics")
-    @patch("millpond.main.ducklake")
-    def test_commit_retry_exponential_backoff(self, mock_dl, mock_metrics, mock_server, mock_time):
+    def test_commit_retry_exponential_backoff(self, mock_metrics, mock_server, mock_time):
         mock_time.monotonic.return_value = 0.0
-        db, cfg, kafka, table, offsets, schema_mgr = self._make_flush_args()
+        sink, cfg, kafka, table, offsets = self._make_flush_args()
         kafka.commit.side_effect = [KafkaException("fail"), KafkaException("fail"), None]
 
-        _flush(db, cfg, kafka, table, 100, 2, offsets, 1.0, schema_mgr)
+        _flush(sink, cfg, kafka, table, 100, 2, offsets, 1.0)
         delays = [c.args[0] for c in mock_time.sleep.call_args_list]
         assert delays == [0.5, 1.0]
 
     @patch("millpond.main.time")
     @patch("millpond.main.server")
     @patch("millpond.main.metrics")
-    @patch("millpond.main.ducklake")
-    def test_write_failure_does_not_increment_offset_commit_error(self, mock_dl, mock_metrics, mock_server, mock_time):
-        db, cfg, kafka, table, offsets, schema_mgr = self._make_flush_args()
-        mock_dl.write.side_effect = OSError("S3 timeout")
+    def test_write_failure_does_not_increment_offset_commit_error(self, mock_metrics, mock_server, mock_time):
+        sink, cfg, kafka, table, offsets = self._make_flush_args()
+        sink.write.side_effect = OSError("S3 timeout")
 
         with pytest.raises(OSError):
-            _flush(db, cfg, kafka, table, 100, 2, offsets, 1.0, schema_mgr)
+            _flush(sink, cfg, kafka, table, 100, 2, offsets, 1.0)
 
         # offset_commit error should NOT have been incremented
         commit_calls = [
@@ -133,11 +172,10 @@ class TestFlushErrorDistinction:
 
     @patch("millpond.main.server")
     @patch("millpond.main.metrics")
-    @patch("millpond.main.ducklake")
-    def test_successful_flush_records_write_metrics(self, mock_dl, mock_metrics, mock_server):
-        db, cfg, kafka, table, offsets, schema_mgr = self._make_flush_args()
+    def test_successful_flush_records_write_metrics(self, mock_metrics, mock_server):
+        sink, cfg, kafka, table, offsets = self._make_flush_args()
 
-        _flush(db, cfg, kafka, table, 100, 2, offsets, 1.0, schema_mgr, trigger="size")
+        _flush(sink, cfg, kafka, table, 100, 2, offsets, 1.0, trigger="size")
 
         mock_metrics.records_written_total.inc.assert_called_once_with(2)
         mock_metrics.batches_flushed_total.labels.assert_called_once_with(trigger="size")

--- a/tests/unit/test_pyiceberg_pin.py
+++ b/tests/unit/test_pyiceberg_pin.py
@@ -1,0 +1,53 @@
+"""PyIceberg version-pin canary.
+
+millpond/iceberg.py depends on two private PyIceberg symbols to convert a
+PyArrow schema into an Iceberg ``Schema`` with sequential field IDs:
+
+  * ``pyiceberg.io.pyarrow._pyarrow_to_schema_without_ids``
+  * ``pyiceberg.schema.assign_fresh_schema_ids``
+
+PyIceberg is pre-1.0 and rearranges internals between minor versions. This
+test imports both symbols and asserts the installed PyIceberg version is
+the one this module was last verified against. When the import fails or
+the version moves, treat that as a signal to revisit ``iceberg.py`` —
+either the private API has changed, or it's time to rewrite the schema
+conversion to use only public surface.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import version
+
+import pyiceberg
+
+# Update this constant when revalidating against a new PyIceberg release.
+_VERIFIED_AGAINST = "0.11.1"
+
+
+def test_pyiceberg_version_is_pinned():
+    installed = version("pyiceberg")
+    assert installed == _VERIFIED_AGAINST, (
+        f"PyIceberg {installed} installed, but millpond/iceberg.py was last "
+        f"verified against {_VERIFIED_AGAINST}. Review the private-API imports "
+        f"in millpond/iceberg.py before bumping this constant."
+    )
+    assert pyiceberg.__version__ == _VERIFIED_AGAINST
+
+
+def test_private_symbols_still_importable():
+    # If either import raises, the private path moved and the module
+    # body in millpond/iceberg.py won't load — fail loud now instead of
+    # at startup in production.
+    from pyiceberg.io.pyarrow import _pyarrow_to_schema_without_ids
+    from pyiceberg.schema import assign_fresh_schema_ids
+
+    assert callable(_pyarrow_to_schema_without_ids)
+    assert callable(assign_fresh_schema_ids)
+
+    # Defend against a re-export shim that papers over a real internal move.
+    # If pyiceberg ever moves the implementations and re-exports them from
+    # the old path, the imports above succeed but `__module__` shifts —
+    # catch that here so we revalidate millpond/iceberg.py against the
+    # new location instead of silently coupling to a shim that may go away.
+    assert _pyarrow_to_schema_without_ids.__module__ == "pyiceberg.io.pyarrow"
+    assert assign_fresh_schema_ids.__module__ == "pyiceberg.schema"

--- a/tests/unit/test_sink.py
+++ b/tests/unit/test_sink.py
@@ -1,0 +1,105 @@
+"""Tests for the Sink Protocol and `make_sink` factory.
+
+`make_sink` is the only piece of glue between cfg and the backend modules.
+If somebody adds a third destination string to `Config.destination` without
+extending the factory dispatch, this is where the gap surfaces. Likewise
+if either Sink class drops a required method, the conformance assertions
+here catch it before main.py does at runtime.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from millpond import sink as sink_mod
+
+
+def _cfg(destination: str) -> MagicMock:
+    cfg = MagicMock()
+    cfg.destination = destination
+    # Provide the minimal field set each sink reads in __init__.
+    cfg.ducklake_table = "events"
+    cfg.partition_by = None
+    cfg.iceberg_catalog_uri = "http://catalog:8181"
+    cfg.iceberg_warehouse = "s3://warehouse/"
+    cfg.iceberg_namespace = "millpond"
+    cfg.iceberg_table = "events"
+    cfg.iceberg_table_location = None
+    cfg.iceberg_catalog_token = None
+    cfg.s3_access_key_id = "akid"
+    cfg.s3_secret_access_key = "secret"
+    cfg.s3_region = "us-east-1"
+    cfg.s3_endpoint = None
+    return cfg
+
+
+class TestMakeSinkDispatch:
+    def test_returns_ducklake_sink_for_ducklake(self):
+        # Stub out the heavy `connect()` so we don't need a real DuckDB+Postgres.
+        with patch("millpond.ducklake.connect") as mock_connect, patch(
+            "millpond.ducklake.schema.SchemaManager"
+        ):
+            mock_connect.return_value = MagicMock()
+            from millpond.ducklake import DuckLakeSink
+
+            sink = sink_mod.make_sink(_cfg("ducklake"))
+            assert isinstance(sink, DuckLakeSink)
+
+    def test_returns_iceberg_sink_for_iceberg(self):
+        with patch("millpond.iceberg.connect") as mock_connect, patch(
+            "millpond.iceberg.SchemaManager"
+        ):
+            mock_connect.return_value = MagicMock()
+            from millpond.iceberg import IcebergSink
+
+            sink = sink_mod.make_sink(_cfg("iceberg"))
+            assert isinstance(sink, IcebergSink)
+
+    def test_unknown_destination_raises(self):
+        with pytest.raises(ValueError, match="Unknown destination"):
+            sink_mod.make_sink(_cfg("snowflake"))
+
+
+class TestSinkProtocolConformance:
+    """Each Sink class must expose `write`, `reset_caches`, `close` as callables.
+
+    A duck-typed Protocol doesn't enforce this at type-check time; this test
+    is the runtime backstop against an accidental rename.
+    """
+
+    @pytest.mark.parametrize("class_path", ["millpond.ducklake.DuckLakeSink", "millpond.iceberg.IcebergSink"])
+    def test_required_methods_exist(self, class_path):
+        module_name, class_name = class_path.rsplit(".", 1)
+        module = __import__(module_name, fromlist=[class_name])
+        cls = getattr(module, class_name)
+        for method in ("write", "reset_caches", "close"):
+            assert hasattr(cls, method), f"{class_path} missing {method!r}"
+            assert callable(getattr(cls, method)), f"{class_path}.{method} is not callable"
+
+
+class TestLazyImport:
+    """make_sink must not import the unused backend.
+
+    pyiceberg pulls cryptography/aiohttp/etc. transitively; importing it on
+    a DuckLake-only deployment is ~150ms of cold-start cost for nothing.
+    """
+
+    def test_ducklake_dispatch_does_not_import_iceberg_module(self):
+        # We can't easily un-import a module that's already in sys.modules
+        # from earlier tests in this run. Instead, prove the function body
+        # uses a lazy `from ... import` by source inspection — cheap and
+        # robust to other tests having pre-loaded iceberg.
+        import inspect
+        import re
+
+        src = inspect.getsource(sink_mod.make_sink)
+        # Imports must be inside the function (line-anchored, indented),
+        # not at module top, otherwise the lazy guarantee is gone.
+        assert re.search(r"^[ \t]+from millpond\.iceberg import", src, re.M), (
+            "make_sink must import iceberg lazily (inside the function), not at module top"
+        )
+        assert re.search(r"^[ \t]+from millpond\.ducklake import", src, re.M), (
+            "make_sink must import ducklake lazily (inside the function), not at module top"
+        )

--- a/tests/unit/test_sink_wrappers.py
+++ b/tests/unit/test_sink_wrappers.py
@@ -28,6 +28,13 @@ def _ducklake_cfg(**overrides) -> MagicMock:
     cfg = MagicMock()
     cfg.destination = "ducklake"
     cfg.ducklake_table = "events"
+    cfg.ducklake_connection = ":memory:"
+    cfg.ducklake_data_path = "s3://bucket/data"
+    cfg.rds_host = "localhost"
+    cfg.rds_port = "5432"
+    cfg.rds_database = "ducklake"
+    cfg.rds_username = "ducklake"
+    cfg.rds_password = "pass"
     cfg.partition_by = None
     for k, v in overrides.items():
         setattr(cfg, k, v)
@@ -64,9 +71,27 @@ class TestDuckLakeSinkInit:
             assert sink._partition_by is None
             assert sink._tables_ensured == set()
 
-    def test_missing_ducklake_table_raises_runtimeerror(self):
-        with pytest.raises(RuntimeError, match="ducklake_table"):
-            DuckLakeSink(_ducklake_cfg(ducklake_table=None))
+    @pytest.mark.parametrize(
+        "missing_field",
+        [
+            "ducklake_table",
+            "ducklake_connection",
+            "ducklake_data_path",
+            "rds_host",
+            "rds_port",
+            "rds_database",
+            "rds_username",
+            "rds_password",
+        ],
+    )
+    def test_missing_required_field_raises_runtimeerror(self, missing_field):
+        # Each field connect() touches must be guarded. Without the guard,
+        # a missing rds_* field would surface as a cryptic libpq
+        # "host=None" or similar deep in the stack. Symmetric with the
+        # IcebergSink test below.
+        cfg = _ducklake_cfg(**{missing_field: None})
+        with pytest.raises(RuntimeError, match=missing_field):
+            DuckLakeSink(cfg)
 
     def test_runtimeerror_survives_python_optimize(self):
         # `assert` would silently pass under `python -O`. Confirm the guard

--- a/tests/unit/test_sink_wrappers.py
+++ b/tests/unit/test_sink_wrappers.py
@@ -1,0 +1,169 @@
+"""Tests for the DuckLakeSink and IcebergSink wrapper classes.
+
+The class wrappers are thin — constructor wiring, three delegate methods.
+The module-level helper functions are exercised separately by
+`test_ducklake.py` and `test_iceberg.py`. These tests cover the class
+behaviour that those don't touch:
+
+  * `__init__` validates required cfg fields and constructs an internal
+    `SchemaManager` against the right namespace/table.
+  * `reset_caches` clears the instance cache AND invalidates the schema
+    manager — both delegates, not just one.
+  * `close` releases the connection (DuckLake) or no-ops (Iceberg).
+  * The `cfg.X is None` guards raise `RuntimeError` (not bare `assert`,
+    which `python -O` strips).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from millpond.ducklake import DuckLakeSink
+from millpond.iceberg import IcebergSink
+
+
+def _ducklake_cfg(**overrides) -> MagicMock:
+    cfg = MagicMock()
+    cfg.destination = "ducklake"
+    cfg.ducklake_table = "events"
+    cfg.partition_by = None
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def _iceberg_cfg(**overrides) -> MagicMock:
+    cfg = MagicMock()
+    cfg.destination = "iceberg"
+    cfg.iceberg_catalog_uri = "http://catalog:8181"
+    cfg.iceberg_warehouse = "s3://warehouse/"
+    cfg.iceberg_namespace = "millpond"
+    cfg.iceberg_table = "events"
+    cfg.iceberg_table_location = None
+    cfg.iceberg_catalog_token = None
+    cfg.s3_access_key_id = "akid"
+    cfg.s3_secret_access_key = "secret"
+    cfg.s3_region = "us-east-1"
+    cfg.s3_endpoint = None
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+class TestDuckLakeSinkInit:
+    def test_constructs_schema_manager_with_right_table(self):
+        with patch("millpond.ducklake.connect") as mock_connect, patch(
+            "millpond.ducklake.schema.SchemaManager"
+        ) as mock_sm:
+            mock_connect.return_value = MagicMock(name="conn")
+            sink = DuckLakeSink(_ducklake_cfg())
+            mock_sm.assert_called_once_with(mock_connect.return_value, "events")
+            assert sink._table_name == "events"
+            assert sink._partition_by is None
+            assert sink._tables_ensured == set()
+
+    def test_missing_ducklake_table_raises_runtimeerror(self):
+        with pytest.raises(RuntimeError, match="ducklake_table"):
+            DuckLakeSink(_ducklake_cfg(ducklake_table=None))
+
+    def test_runtimeerror_survives_python_optimize(self):
+        # `assert` would silently pass under `python -O`. Confirm the guard
+        # is an explicit raise by checking the class isn't using `assert`.
+        import inspect
+
+        src = inspect.getsource(DuckLakeSink.__init__)
+        assert "raise RuntimeError" in src
+        assert "assert cfg.ducklake_table" not in src
+
+
+class TestDuckLakeSinkResetCaches:
+    def test_clears_tables_ensured_and_invalidates_schema_mgr(self):
+        with patch("millpond.ducklake.connect") as mock_connect, patch(
+            "millpond.ducklake.schema.SchemaManager"
+        ) as mock_sm:
+            mock_connect.return_value = MagicMock(name="conn")
+            sink = DuckLakeSink(_ducklake_cfg())
+            sink._tables_ensured.add("events")
+            sink.reset_caches()
+            assert sink._tables_ensured == set()
+            mock_sm.return_value.invalidate.assert_called_once()
+
+
+class TestDuckLakeSinkClose:
+    def test_closes_connection(self):
+        with patch("millpond.ducklake.connect") as mock_connect, patch("millpond.ducklake.schema.SchemaManager"):
+            mock_conn = MagicMock(name="conn")
+            mock_connect.return_value = mock_conn
+            sink = DuckLakeSink(_ducklake_cfg())
+            sink.close()
+            mock_conn.close.assert_called_once()
+
+
+class TestIcebergSinkInit:
+    def test_constructs_schema_manager_with_namespace_and_table(self):
+        with patch("millpond.iceberg.connect") as mock_connect, patch(
+            "millpond.iceberg.SchemaManager"
+        ) as mock_sm:
+            mock_connect.return_value = MagicMock(name="catalog")
+            sink = IcebergSink(_iceberg_cfg())
+            mock_sm.assert_called_once_with(mock_connect.return_value, "millpond", "events")
+            assert sink._namespace == "millpond"
+            assert sink._table_name == "events"
+            assert sink._tables_ensured == {}
+
+    def test_passes_optional_token_and_endpoint(self):
+        with patch("millpond.iceberg.connect") as mock_connect, patch("millpond.iceberg.SchemaManager"):
+            mock_connect.return_value = MagicMock()
+            IcebergSink(_iceberg_cfg(iceberg_catalog_token="bearer-xyz", s3_endpoint="http://minio:9000"))
+            kwargs = mock_connect.call_args.kwargs
+            assert kwargs["catalog_token"] == "bearer-xyz"
+            assert kwargs["s3_endpoint"] == "http://minio:9000"
+
+    @pytest.mark.parametrize(
+        "missing_field",
+        [
+            "iceberg_catalog_uri",
+            "iceberg_warehouse",
+            "iceberg_namespace",
+            "iceberg_table",
+            "s3_access_key_id",
+            "s3_secret_access_key",
+            "s3_region",
+        ],
+    )
+    def test_missing_required_field_raises_runtimeerror(self, missing_field):
+        cfg = _iceberg_cfg(**{missing_field: None})
+        with pytest.raises(RuntimeError, match=missing_field):
+            IcebergSink(cfg)
+
+    def test_runtimeerror_survives_python_optimize(self):
+        import inspect
+
+        src = inspect.getsource(IcebergSink.__init__)
+        assert "raise RuntimeError" in src
+        assert "assert cfg.iceberg_catalog_uri" not in src
+
+
+class TestIcebergSinkResetCaches:
+    def test_clears_tables_ensured_and_invalidates_schema_mgr(self):
+        with patch("millpond.iceberg.connect") as mock_connect, patch(
+            "millpond.iceberg.SchemaManager"
+        ) as mock_sm:
+            mock_connect.return_value = MagicMock(name="catalog")
+            sink = IcebergSink(_iceberg_cfg())
+            sink._tables_ensured["millpond.events"] = MagicMock()
+            sink.reset_caches()
+            assert sink._tables_ensured == {}
+            mock_sm.return_value.invalidate.assert_called_once()
+
+
+class TestIcebergSinkClose:
+    def test_close_is_a_noop(self):
+        # PyIceberg REST catalog has no persistent connection. close()
+        # should not raise even though there's nothing to release.
+        with patch("millpond.iceberg.connect") as mock_connect, patch("millpond.iceberg.SchemaManager"):
+            mock_connect.return_value = MagicMock(name="catalog")
+            sink = IcebergSink(_iceberg_cfg())
+            sink.close()  # must not raise

--- a/tools/README.md
+++ b/tools/README.md
@@ -5,17 +5,17 @@ Operational utilities that ship in the millpond Docker image but live outside th
 In the image:
 
 ```
-/app/tools/maintenance.py
-/app/tools/maintenance.sql
+/app/tools/ducklake_maintenance.py
+/app/tools/ducklake_maintenance.sql
 /app/tools/ducklake_metrics.py
 /justfile                        (copy of tools/justfile)
 ```
 
-For local dev, the `MAINTENANCE_SCRIPT`, `MAINTENANCE_SQL`, and `DUCKLAKE_METRICS_SCRIPT` env vars override the in-image paths so `just …` recipes work from a checkout.
+For local dev, the `DUCKLAKE_MAINTENANCE_SCRIPT`, `DUCKLAKE_MAINTENANCE_SQL`, and `DUCKLAKE_METRICS_SCRIPT` env vars override the in-image paths so `just …` recipes work from a checkout.
 
 ---
 
-## maintenance.py
+## ducklake_maintenance.py
 
 Self-contained CLI for DuckLake catalog and storage maintenance. Designed to run as a K8s CronJob reusing the same image and credentials as the main app. Subcommands:
 
@@ -41,9 +41,9 @@ Every `cleanup` / `cleanup-all` (skipped on `--dry-run`) logs a single structure
 
 If `PUSHGATEWAY_URL` is set, the script pushes `maintenance_start_time{operation}` (on start) and `maintenance_duration_seconds{operation, status}` (on completion) to a Prometheus Pushgateway, enabling Grafana annotation queries for maintenance windows.
 
-## maintenance.sql
+## ducklake_maintenance.sql
 
-Executed verbatim at every session start by both `maintenance.py`'s `connect()` and the `just shell` recipe. No templating — `__ducklake_metadata_lake` and friends are written literally so both load paths stay consistent. Defines runtime macros:
+Executed verbatim at every session start by both `ducklake_maintenance.py`'s `connect()` and the `just shell` recipe. No templating — `__ducklake_metadata_lake` and friends are written literally so both load paths stay consistent. Defines runtime macros:
 
 - `count_pending_dups()` — duplicate-row count in the pending-deletion queue
 - `find_catalog_orphans(data_path)` — catalog rows whose S3 key no longer exists, scanned via `glob()` against the live S3 listing
@@ -57,7 +57,7 @@ The header documents the constraints any new recipe must follow:
 
 ## ducklake_metrics.py
 
-Long-running Prometheus-exposition daemon for catalog-side lake-state metrics. Single Python file. Single thread for queries (one DuckDB connection isn't safe for concurrent calls anyway), separate thread for the HTTP server. Reuses `maintenance.connect()`.
+Long-running Prometheus-exposition daemon for catalog-side lake-state metrics. Single Python file. Single thread for queries (one DuckDB connection isn't safe for concurrent calls anyway), separate thread for the HTTP server. Reuses `ducklake_maintenance.connect()`.
 
 Endpoints: `/metrics`, `/-/healthy` (k8s liveness — always 200 while the process answers), `/-/ready` (k8s readiness — 200 after the first successful connect; never gated on individual query completion so slow queries can't block rollout).
 
@@ -82,7 +82,7 @@ Built-in queries (lake-wide; no `table_name` label by design):
 |---|---|---|---|
 | `ducklake_pending_deletes` | — | `total`, `unique_paths`, `dup_rows` | `ducklake_files_scheduled_for_deletion` |
 | `ducklake_files_per_band` | `band` | `count`, `bytes` | `ducklake_data_file` |
-| `ducklake_compaction_candidates` | `tier` | `count` | `ducklake_data_file`; tier buckets match `maintenance.py`'s `TIERS` (`tier1` < 1 MiB, `tier2` [1, 10) MiB, `tier3` [10, 64) MiB, `large` ≥ 64 MiB, plus `total`) |
+| `ducklake_compaction_candidates` | `tier` | `count` | `ducklake_data_file`; tier buckets match `ducklake_maintenance.py`'s `TIERS` (`tier1` < 1 MiB, `tier2` [1, 10) MiB, `tier3` [10, 64) MiB, `large` ≥ 64 MiB, plus `total`) |
 | `ducklake_snapshots` | — | `count`, `oldest_seconds_ago`, `newest_seconds_ago` | `ducklake_snapshot`; CASTs `snapshot_time` (VARCHAR) to TIMESTAMPTZ before time arithmetic |
 | `ducklake_files_per_partition_top20` | `partition` | `count` | Composite partition values joined with `/`; live files without partition_value rows surface as `<none>` |
 | `ducklake_catalog` | `suffix` | `format_version` | `ducklake_metadata` row with `key='version'` and `scope IS NULL`. Numeric `major.minor` (extracted via `regexp_extract`) lands in the gauge value; any trailing tag DuckLake attaches (`-dev1` on main after `MigrateV10`, future `-rcN`/`-betaN` shapes) lands in the `suffix` label. Empty `suffix=""` for clean releases. Polled every 60 minutes — value changes only on a DuckLake upgrade |
@@ -98,7 +98,7 @@ Self-metrics (always on):
 
 Reconnect: connect failures retry with exponential backoff (1s → 60s cap). Once connected, transient query failures only increment the per-query error counter and log; the daemon stays up. After `CONSECUTIVE_FAILURE_THRESHOLD` (default 10) runs in a row across all queries fail, the scheduler raises `_ReconnectNeeded` and the outer loop drops the connection and reconnects via the same backoff. Any successful run resets the streak.
 
-Env vars (in addition to the `DUCKLAKE_*` / `DUCKDB_*` set used by `maintenance.py`):
+Env vars (in addition to the `DUCKLAKE_*` / `DUCKDB_*` set used by `ducklake_maintenance.py`):
 
 | Variable | Default | Notes |
 |---|---|---|
@@ -112,14 +112,14 @@ Recipe wrapper for both maintenance and metrics. Copied to `/justfile` in the im
 
 Groups visible in `just --list`:
 
-- `[interactive]` — `shell` opens a DuckDB session with `lake` and `pg` ATTACHed, S3 SECRET configured, `maintenance.sql` macros loaded
-- `[lifecycle]` — every snapshot/file maintenance subcommand of `maintenance.py`, both `*` and `*-dry-run` variants
+- `[interactive]` — `shell` opens a DuckDB session with `lake` and `pg` ATTACHed, S3 SECRET configured, `ducklake_maintenance.sql` macros loaded
+- `[lifecycle]` — every snapshot/file maintenance subcommand of `ducklake_maintenance.py`, both `*` and `*-dry-run` variants
 - `[compaction]` — tiered compaction recipes plus `compact-probe`
 - `[metrics]` — `ducklake-metrics`, `ducklake-metrics-with-config`, `ducklake-metrics-list`
 
-Path overrides for dev use: `DUCKDB` (binary path), `MAINTENANCE_SCRIPT`, `MAINTENANCE_SQL`, `DUCKLAKE_METRICS_SCRIPT`.
+Path overrides for dev use: `DUCKDB` (binary path), `DUCKLAKE_MAINTENANCE_SCRIPT`, `DUCKLAKE_MAINTENANCE_SQL`, `DUCKLAKE_METRICS_SCRIPT`.
 
-The `_setup` constant mirrors what `maintenance.connect()` does (S3 secret, ATTACH lake + pg, `temp_directory`) so an interactive `just shell` ends up with the same wired-up session as a maintenance subcommand. The two-layer escaping for the Postgres connection string is documented inline.
+The `_setup` constant mirrors what `ducklake_maintenance.connect()` does (S3 secret, ATTACH lake + pg, `temp_directory`) so an interactive `just shell` ends up with the same wired-up session as a maintenance subcommand. The two-layer escaping for the Postgres connection string is documented inline.
 
 ## sizing-calculator.html
 

--- a/tools/ducklake_maintenance.py
+++ b/tools/ducklake_maintenance.py
@@ -76,7 +76,7 @@ METADATA_SCHEMA = f"__ducklake_metadata_{ATTACH_NAME}"
 PG_ATTACH_NAME = "pg"
 
 # Companion SQL file: header conventions plus runtime-loadable macros.
-MAINTENANCE_SQL_PATH = Path(__file__).resolve().parent / "maintenance.sql"
+MAINTENANCE_SQL_PATH = Path(__file__).resolve().parent / "ducklake_maintenance.sql"
 
 # Stable identifier for `pg_try_advisory_lock`. The lock guards mutual
 # exclusion *between maintenance invocations*: it is held by the `pg`
@@ -217,14 +217,14 @@ def connect(debug: bool = False) -> duckdb.DuckDBPyConnection:
     conn.execute(f"ATTACH '{pg_connstr_sql}' AS {PG_ATTACH_NAME} (TYPE postgres)")
 
     if MAINTENANCE_SQL_PATH.exists():
-        # File is executed verbatim by both maintenance.py and the duckdb CLI's
+        # File is executed verbatim by both ducklake_maintenance.py and the duckdb CLI's
         # `.read` meta-command (the `just shell` recipe), so it must contain no
         # templating placeholders — references to `__ducklake_metadata_lake`
         # are written literally to keep both paths consistent.
         conn.execute(MAINTENANCE_SQL_PATH.read_text())
         log.debug("Loaded SQL macros from %s", MAINTENANCE_SQL_PATH)
     else:
-        log.warning("maintenance.sql not found at %s; macros unavailable", MAINTENANCE_SQL_PATH)
+        log.warning("ducklake_maintenance.sql not found at %s; macros unavailable", MAINTENANCE_SQL_PATH)
 
     log.info(
         "Connected: metadata=%s:%s/%s data=%s",

--- a/tools/ducklake_maintenance.sql
+++ b/tools/ducklake_maintenance.sql
@@ -1,6 +1,6 @@
 -- DuckLake catalog maintenance recipes.
 --
--- Loaded at session start by `tools/maintenance.py` (via `conn.execute`) and
+-- Loaded at session start by `tools/ducklake_maintenance.py` (via `conn.execute`) and
 -- by the `shell` recipe in `tools/justfile` (via the duckdb CLI's `.read`
 -- meta-command). Both paths execute the file verbatim, so the file itself
 -- must be valid SQL — no templating, no placeholders.
@@ -9,7 +9,7 @@
 -- -----------
 -- * Schema name. DuckLake stores its catalog tables in
 --   `__ducklake_metadata_<attach_name>`. We attach as `lake` everywhere
---   (the `ATTACH_NAME` constant in `maintenance.py`), so this file
+--   (the `ATTACH_NAME` constant in `ducklake_maintenance.py`), so this file
 --   references `__ducklake_metadata_lake.<table>` directly. If you ever
 --   change the ATTACH alias, the references here must change with it.
 --
@@ -20,7 +20,7 @@
 --   does not expose Postgres system columns to duckdb-side queries. Anything
 --   that touches `ctid` must run via `postgres_execute` / `postgres_query`
 --   against the `pg (TYPE postgres)` ATTACH — see `dedup_deletions` in
---   `maintenance.py` for the working pattern.
+--   `ducklake_maintenance.py` for the working pattern.
 --
 -- * No literal `glob('s3://...')` inside `CREATE MACRO` bodies. DuckDB 1.4
 --   evaluates a literal glob eagerly at macro creation time, which would
@@ -51,7 +51,7 @@ CREATE OR REPLACE TEMP MACRO count_pending_dups() AS (
 --
 -- Pass the lake's bucket-relative root as `data_path` (e.g.
 -- `'s3://bucket/lake/data'` or `'s3://bucket/lake/data/'`);
--- maintenance.py's `find-orphans` subcommand supplies it from
+-- ducklake_maintenance.py's `find-orphans` subcommand supplies it from
 -- `DUCKLAKE_DATA_PATH` for you. We `rtrim(data_path, '/')` everywhere it
 -- appears so an operator-configured trailing slash doesn't produce
 -- `.../data//file.parquet` from the relative-form join (which would

--- a/tools/ducklake_metrics.py
+++ b/tools/ducklake_metrics.py
@@ -8,9 +8,9 @@ compaction-tier candidate counts, pending-deletion queue depth, snapshot
 age). Operators can supply additional queries via a YAML file referenced
 by ``DUCKLAKE_METRICS_CONFIG``.
 
-Reuses ``maintenance.connect()`` so the daemon inherits the same lake +
-postgres ATTACH, S3 secret, and session tunables that maintenance.py runs
-under. Same env vars as the maintenance script:
+Reuses ``ducklake_maintenance.connect()`` so the daemon inherits the same lake +
+postgres ATTACH, S3 secret, and session tunables that ducklake_maintenance.py runs
+under. Same env vars as the ducklake_maintenance script:
   DUCKLAKE_RDS_HOST, DUCKLAKE_RDS_PORT, DUCKLAKE_RDS_DATABASE,
   DUCKLAKE_RDS_USERNAME, DUCKLAKE_RDS_PASSWORD, DUCKLAKE_DATA_PATH,
   DUCKDB_S3_REGION, DUCKDB_S3_ACCESS_KEY_ID, DUCKDB_S3_SECRET_ACCESS_KEY
@@ -39,7 +39,7 @@ from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import duckdb
-import maintenance
+import ducklake_maintenance
 import yaml
 from prometheus_client import (
     CONTENT_TYPE_LATEST,
@@ -56,9 +56,9 @@ log = logging.getLogger("ducklake_metrics")
 # Built-in queries are embedded so the binary is self-contained; they parse
 # through the same loader as user YAML so the two paths can't diverge.
 #
-# SQL refers to the metadata schema by its literal name. maintenance.connect()
+# SQL refers to the metadata schema by its literal name. ducklake_maintenance.connect()
 # always ATTACHes the lake as ``lake``, which fixes the schema as
-# ``__ducklake_metadata_lake`` (per maintenance.py's METADATA_SCHEMA). Built-in
+# ``__ducklake_metadata_lake`` (per ducklake_maintenance.py's METADATA_SCHEMA). Built-in
 # queries hardcode that name; user-supplied queries are passed through verbatim
 # and may reference whatever schema they like.
 BUILTIN_YAML = """
@@ -97,7 +97,7 @@ queries:
       GROUP BY band
 
   - name: ducklake_compaction_candidates
-    help: Live file counts bucketed to match maintenance.py's TIERS spec.
+    help: Live file counts bucketed to match ducklake_maintenance.py's TIERS spec.
     interval_mins: 1
     labels: [tier]
     values: [count]
@@ -484,7 +484,7 @@ def _connect_with_backoff(
     stop: threading.Event,
     self_metrics: SelfMetrics,
 ) -> duckdb.DuckDBPyConnection | None:
-    """Call maintenance.connect() with exponential backoff until it succeeds or stop is set.
+    """Call ducklake_maintenance.connect() with exponential backoff until it succeeds or stop is set.
 
     Returns the new connection on success, or None if the daemon was asked
     to shut down before connect succeeded. ``self_metrics.up`` is held at 0
@@ -496,7 +496,7 @@ def _connect_with_backoff(
     self_metrics.up.set(0)
     while not stop.is_set():
         try:
-            conn = maintenance.connect()
+            conn = ducklake_maintenance.connect()
             log.info("Connected to DuckLake catalog")
             return conn
         except Exception:

--- a/tools/justfile
+++ b/tools/justfile
@@ -1,5 +1,5 @@
 # DuckLake maintenance tasks
-# Delegates to maintenance.py for actual operations.
+# Delegates to ducklake_maintenance.py for actual operations.
 # Requires: DUCKLAKE_RDS_PASSWORD, DUCKDB_S3_ACCESS_KEY_ID, DUCKDB_S3_SECRET_ACCESS_KEY
 
 duckdb := env("DUCKDB", "duckdb")
@@ -21,7 +21,7 @@ data_path := env("DUCKLAKE_DATA_PATH", "")
 # both `SET s3_use_ssl = '<value>'` (a SQL string literal) and into
 # `CREATE OR REPLACE SECRET ... USE_SSL <value>` (an UNQUOTED bool, where
 # even a single quote in the env value would be raw SQL injection). Strict
-# whitelist beats per-context escaping here. maintenance.py applies an
+# whitelist beats per-context escaping here. ducklake_maintenance.py applies an
 # equivalent check via `_sanitize_setting_value`; this is the just-side
 # equivalent.
 _s3_use_ssl_validated := if s3_use_ssl == "true" { "true" } else if s3_use_ssl == "false" { "false" } else { error("DUCKDB_S3_USE_SSL must be 'true' or 'false', got: " + s3_use_ssl) }
@@ -56,7 +56,7 @@ _s3_region_sql := replace(s3_region, "'", "''")
 _s3_endpoint_sql := replace(s3_endpoint, "'", "''")
 _s3_url_style_sql := replace(s3_url_style, "'", "''")
 
-# _setup mirrors what maintenance.py's connect() does so `just shell` ends up
+# _setup mirrors what ducklake_maintenance.py's connect() does so `just shell` ends up
 # with the same wired-up session as a maintenance subcommand:
 #   * temp_directory points at the writable emptyDir in the cron pod (the
 #     image rootfs is read-only, so the duckdb default `.tmp` would crash on
@@ -67,8 +67,8 @@ _s3_url_style_sql := replace(s3_url_style, "'", "''")
 
 _setup := "INSTALL httpfs; INSTALL ducklake; INSTALL postgres; LOAD httpfs; LOAD ducklake; LOAD postgres; SET temp_directory = '/tmp/duckdb_spill'; SET enable_http_logging = false; SET pg_debug_show_queries = false; SET s3_region = '" + _s3_region_sql + "'; SET s3_endpoint = '" + _s3_endpoint_sql + "'; SET s3_access_key_id = '" + _s3_key_sql + "'; SET s3_secret_access_key = '" + _s3_secret_sql + "'; SET s3_use_ssl = " + _s3_use_ssl_validated + "; SET s3_url_style = '" + _s3_url_style_sql + "'; CREATE OR REPLACE SECRET s3 (TYPE s3, PROVIDER config, KEY_ID '" + _s3_key_sql + "', SECRET '" + _s3_secret_sql + "', REGION '" + _s3_region_sql + "', ENDPOINT '" + _s3_endpoint_sql + "', URL_STYLE '" + _s3_url_style_sql + "', USE_SSL " + _s3_use_ssl_validated + "); ATTACH 'postgres:" + _pg_connstr_sql + "' AS lake (TYPE ducklake, DATA_PATH '" + _data_path_sql + "'); ATTACH '" + _pg_connstr_sql + "' AS pg (TYPE postgres); USE lake;"
 
-maintenance := env("MAINTENANCE_SCRIPT", "/app/tools/maintenance.py")
-maintenance_sql := env("MAINTENANCE_SQL", "/app/tools/maintenance.sql")
+ducklake_maintenance := env("DUCKLAKE_MAINTENANCE_SCRIPT", "/app/tools/ducklake_maintenance.py")
+ducklake_maintenance_sql := env("DUCKLAKE_MAINTENANCE_SQL", "/app/tools/ducklake_maintenance.sql")
 ducklake_metrics := env("DUCKLAKE_METRICS_SCRIPT", "/app/tools/ducklake_metrics.py")
 
 default:
@@ -81,7 +81,7 @@ default:
 # Open an interactive DuckDB shell connected to the DuckLake
 [group('interactive')]
 shell:
-    {{ duckdb }} -cmd "{{ _setup }}" -cmd ".read {{ maintenance_sql }}"
+    {{ duckdb }} -cmd "{{ _setup }}" -cmd ".read {{ ducklake_maintenance_sql }}"
 
 # ----------------------------------------------------------------------------
 # snapshot + file lifecycle
@@ -90,92 +90,92 @@ shell:
 # Expire snapshots (dry run)
 [group('lifecycle')]
 expire-dry-run days="7":
-    python {{ maintenance }} expire --days {{ days }} --dry-run
+    python {{ ducklake_maintenance }} expire --days {{ days }} --dry-run
 
 # Expire snapshots
 [group('lifecycle')]
 expire days="7":
-    python {{ maintenance }} expire --days {{ days }}
+    python {{ ducklake_maintenance }} expire --days {{ days }}
 
 # Preview files scheduled for deletion
 [group('lifecycle')]
 cleanup-dry-run days="1":
-    python {{ maintenance }} cleanup --days {{ days }} --dry-run
+    python {{ ducklake_maintenance }} cleanup --days {{ days }} --dry-run
 
 # Delete files scheduled for deletion
 [group('lifecycle')]
 cleanup days="1":
-    python {{ maintenance }} cleanup --days {{ days }}
+    python {{ ducklake_maintenance }} cleanup --days {{ days }}
 
 # Delete all files scheduled for deletion regardless of age
 [group('lifecycle')]
 cleanup-all:
-    python {{ maintenance }} cleanup-all
+    python {{ ducklake_maintenance }} cleanup-all
 
 # Preview duplicate rows in the pending-deletion queue (workaround for DuckLake bug c5)
 [group('lifecycle')]
 dedup-deletions-dry-run:
-    python {{ maintenance }} dedup-deletions --dry-run
+    python {{ ducklake_maintenance }} dedup-deletions --dry-run
 
 # Drop duplicate rows from the pending-deletion queue (workaround for DuckLake bug c5)
 [group('lifecycle')]
 dedup-deletions:
-    python {{ maintenance }} dedup-deletions
+    python {{ ducklake_maintenance }} dedup-deletions
 
 # List catalog rows whose S3 key no longer exists (catalog-side orphans)
 [group('lifecycle')]
 find-orphans:
-    python {{ maintenance }} find-orphans
+    python {{ ducklake_maintenance }} find-orphans
 
 # Preview heal-orphans (run safety gates, skip the DELETE)
 [group('lifecycle')]
 heal-orphans-dry-run:
-    python {{ maintenance }} heal-orphans --dry-run
+    python {{ ducklake_maintenance }} heal-orphans --dry-run
 
 # Delete catalog rows whose S3 key no longer exists (gated B1/B3 safety checks)
 [group('lifecycle')]
 heal-orphans:
-    python {{ maintenance }} heal-orphans
+    python {{ ducklake_maintenance }} heal-orphans
 
 # Loop dedup + heal-orphans + cleanup-all until cleanup-all exits clean
 [group('lifecycle')]
 cleanup-all-safe max_iterations="10":
-    python {{ maintenance }} cleanup-all-safe --max-iterations {{ max_iterations }}
+    python {{ ducklake_maintenance }} cleanup-all-safe --max-iterations {{ max_iterations }}
 
 # Preview fsck (cleanup-all-safe + S3-orphan sweep, dry-run)
 [group('lifecycle')]
 fsck-dry-run:
-    python {{ maintenance }} fsck --dry-run
+    python {{ ducklake_maintenance }} fsck --dry-run
 
 # Bring the lake catalog to a known-good state end-to-end
 [group('lifecycle')]
 fsck max_iterations="10":
-    python {{ maintenance }} fsck --max-iterations {{ max_iterations }}
+    python {{ ducklake_maintenance }} fsck --max-iterations {{ max_iterations }}
 
 # Preview orphaned files
 [group('lifecycle')]
 orphans-dry-run:
-    python {{ maintenance }} orphans --dry-run
+    python {{ ducklake_maintenance }} orphans --dry-run
 
 # Delete orphaned files
 [group('lifecycle')]
 orphans:
-    python {{ maintenance }} orphans
+    python {{ ducklake_maintenance }} orphans
 
 # Full maintenance: expire snapshots + cleanup files
 [group('lifecycle')]
 maintain days="7":
-    python {{ maintenance }} maintain --days {{ days }}
+    python {{ ducklake_maintenance }} maintain --days {{ days }}
 
 # Full maintenance dry run
 [group('lifecycle')]
 maintain-dry-run days="7":
-    python {{ maintenance }} maintain --days {{ days }} --dry-run
+    python {{ ducklake_maintenance }} maintain --days {{ days }} --dry-run
 
 # Run CHECKPOINT (integrated merge + expire + cleanup)
 [group('lifecycle')]
 checkpoint:
-    python {{ maintenance }} checkpoint
+    python {{ ducklake_maintenance }} checkpoint
 
 # ----------------------------------------------------------------------------
 # tiered compaction
@@ -184,34 +184,34 @@ checkpoint:
 # Probe: merge up to a few adjacent files in one table (no target_file_size change)
 [group('compaction')]
 compact-probe table="events" max_compacted_files="2":
-    python {{ maintenance }} compact-probe --table "{{ table }}" --max-compacted-files {{ max_compacted_files }}
+    python {{ ducklake_maintenance }} compact-probe --table "{{ table }}" --max-compacted-files {{ max_compacted_files }}
 
 # Tier 0 -> Tier 1: merge files < 1 MiB into ~5 MiB files
 [group('compaction')]
 compact-to-tier-1 table="":
-    python {{ maintenance }} compact --tier 1 --table "{{ table }}"
+    python {{ ducklake_maintenance }} compact --tier 1 --table "{{ table }}"
 
 [group('compaction')]
 compact-to-tier-1-dry-run table="":
-    python {{ maintenance }} compact --tier 1 --table "{{ table }}" --dry-run
+    python {{ ducklake_maintenance }} compact --tier 1 --table "{{ table }}" --dry-run
 
 # Tier 1 -> Tier 2: merge files in [1 MiB, 10 MiB) into ~32 MiB files
 [group('compaction')]
 compact-to-tier-2 table="":
-    python {{ maintenance }} compact --tier 2 --table "{{ table }}"
+    python {{ ducklake_maintenance }} compact --tier 2 --table "{{ table }}"
 
 [group('compaction')]
 compact-to-tier-2-dry-run table="":
-    python {{ maintenance }} compact --tier 2 --table "{{ table }}" --dry-run
+    python {{ ducklake_maintenance }} compact --tier 2 --table "{{ table }}" --dry-run
 
 # Tier 2 -> Tier 3: merge files in [10 MiB, 64 MiB) into ~128 MiB files
 [group('compaction')]
 compact-to-tier-3 table="":
-    python {{ maintenance }} compact --tier 3 --table "{{ table }}"
+    python {{ ducklake_maintenance }} compact --tier 3 --table "{{ table }}"
 
 [group('compaction')]
 compact-to-tier-3-dry-run table="":
-    python {{ maintenance }} compact --tier 3 --table "{{ table }}" --dry-run
+    python {{ ducklake_maintenance }} compact --tier 3 --table "{{ table }}" --dry-run
 
 # Run all tiered compactions sequentially (tier 1 -> 2 -> 3)
 [group('compaction')]

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,15 @@ constraints = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "aws-msk-iam-sasl-signer-python"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -48,6 +57,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/8e/cdb34c8ca71216d214e049ada2148ee08bcda12b1ac72af3a720dea300ff/botocore-1.42.78.tar.gz", hash = "sha256:61cbd49728e23f68cfd945406ab40044d49abed143362f7ffa4a4f4bd4311791", size = 15023592, upload-time = "2026-03-27T19:27:57.122Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/72/94bba1a375d45c685b00e051b56142359547837086a83861d76f6aec26f4/botocore-1.42.78-py3-none-any.whl", hash = "sha256:038ab63c7f898e8b5db58cb6a45e4da56c31dd984e7e995839a3540c735564ea", size = 14701729, upload-time = "2026-03-27T19:27:54.05Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "6.2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/91/d9ae9a66b01102a18cd16db0cf4cd54187ffe10f0865cc80071a4104fbb3/cachetools-6.2.6.tar.gz", hash = "sha256:16c33e1f276b9a9c0b49ab5782d901e3ad3de0dd6da9bf9bcd29ac5672f2f9e6", size = 32363, upload-time = "2026-01-27T20:32:59.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/45/f458fa2c388e79dd9d8b9b0c99f1d31b568f27388f2fdba7bb66bbc0c6ed/cachetools-6.2.6-py3-none-any.whl", hash = "sha256:8c9717235b3c651603fff0076db52d6acbfd1b338b8ed50256092f7ce9c85bda", size = 11668, upload-time = "2026-01-27T20:32:58.527Z" },
 ]
 
 [[package]]
@@ -220,6 +238,54 @@ wheels = [
 ]
 
 [[package]]
+name = "fsspec"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cb/baa584cb00532126ffe12d9787db0a60c5a4f55c27bfe2666df5d4c30a32/greenlet-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:83ed9f27f1680b50e89f40f6df348a290ea234b249a4003d366663a12eab94f2", size = 235615, upload-time = "2026-04-27T12:21:38.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -247,6 +313,27 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "millpond"
 source = { editable = "." }
 dependencies = [
@@ -255,6 +342,7 @@ dependencies = [
     { name = "orjson" },
     { name = "prometheus-client" },
     { name = "pyarrow" },
+    { name = "pyiceberg", extra = ["pyarrow"] },
     { name = "pytz" },
     { name = "pyyaml" },
 ]
@@ -268,6 +356,7 @@ msk-iam = [
 dev = [
     { name = "pytest" },
     { name = "ruff" },
+    { name = "sqlalchemy" },
     { name = "testcontainers" },
 ]
 
@@ -279,6 +368,7 @@ requires-dist = [
     { name = "orjson", specifier = ">=3.10" },
     { name = "prometheus-client", specifier = ">=0.21" },
     { name = "pyarrow", specifier = ">=18.0" },
+    { name = "pyiceberg", extras = ["pyarrow"], specifier = "==0.11.1" },
     { name = "pytz", specifier = ">=2024.1" },
     { name = "pyyaml", specifier = ">=6.0.3" },
 ]
@@ -288,7 +378,90 @@ provides-extras = ["msk-iam"]
 dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "ruff", specifier = ">=0.8" },
+    { name = "sqlalchemy", specifier = ">=2.0.49" },
     { name = "testcontainers", specifier = ">=4.14.2" },
+]
+
+[[package]]
+name = "mmh3"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/1a/edb23803a168f070ded7a3014c6d706f63b90c84ccc024f89d794a3b7a6d/mmh3-5.2.1.tar.gz", hash = "sha256:bbea5b775f0ac84945191fb83f845a6fd9a21a03ea7f2e187defac7e401616ad", size = 33775, upload-time = "2026-03-05T15:55:57.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/94/bc5c3b573b40a328c4d141c20e399039ada95e5e2a661df3425c5165fd84/mmh3-5.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0cc21533878e5586b80d74c281d7f8da7932bc8ace50b8d5f6dbf7e3935f63f1", size = 56087, upload-time = "2026-03-05T15:54:21.92Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/80/64a02cc3e95c3af0aaa2590849d9ed24a9f14bb93537addde688e039b7c3/mmh3-5.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4eda76074cfca2787c8cf1bec603eaebdddd8b061ad5502f85cddae998d54f00", size = 40500, upload-time = "2026-03-05T15:54:22.953Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/72/e6d6602ce18adf4ddcd0e48f2e13590cc92a536199e52109f46f259d3c46/mmh3-5.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:eee884572b06bbe8a2b54f424dbd996139442cf83c76478e1ec162512e0dd2c7", size = 40034, upload-time = "2026-03-05T15:54:23.943Z" },
+    { url = "https://files.pythonhosted.org/packages/59/c2/bf4537a8e58e21886ef16477041238cab5095c836496e19fafc34b7445d2/mmh3-5.2.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0d0b7e803191db5f714d264044e06189c8ccd3219e936cc184f07106bd17fd7b", size = 97292, upload-time = "2026-03-05T15:54:25.335Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e2/51ed62063b44d10b06d975ac87af287729eeb5e3ed9772f7584a17983e90/mmh3-5.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e6c219e375f6341d0959af814296372d265a8ca1af63825f65e2e87c618f006", size = 103274, upload-time = "2026-03-05T15:54:26.44Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ce/12a7524dca59eec92e5b31fdb13ede1e98eda277cf2b786cf73bfbc24e81/mmh3-5.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26fb5b9c3946bf7f1daed7b37e0c03898a6f062149127570f8ede346390a0825", size = 106158, upload-time = "2026-03-05T15:54:28.578Z" },
+    { url = "https://files.pythonhosted.org/packages/86/1f/d3ba6dd322d01ab5d44c46c8f0c38ab6bbbf9b5e20e666dfc05bf4a23604/mmh3-5.2.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3c38d142c706201db5b2345166eeef1e7740e3e2422b470b8ba5c8727a9b4c7a", size = 113005, upload-time = "2026-03-05T15:54:29.767Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/a9/15d6b6f913294ea41b44d901741298e3718e1cb89ee626b3694625826a43/mmh3-5.2.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50885073e2909251d4718634a191c49ae5f527e5e1736d738e365c3e8be8f22b", size = 120744, upload-time = "2026-03-05T15:54:30.931Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b3/70b73923fd0284c439860ff5c871b20210dfdbe9a6b9dd0ee6496d77f174/mmh3-5.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b3f99e1756fc48ad507b95e5d86f2fb21b3d495012ff13e6592ebac14033f166", size = 99111, upload-time = "2026-03-05T15:54:32.353Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/38/99f7f75cd27d10d8b899a1caafb9d531f3903e4d54d572220e3d8ac35e89/mmh3-5.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62815d2c67f2dd1be76a253d88af4e1da19aeaa1820146dec52cf8bee2958b16", size = 98623, upload-time = "2026-03-05T15:54:33.801Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/68/6e292c0853e204c44d2f03ea5f090be3317a0e2d9417ecb62c9eb27687df/mmh3-5.2.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8f767ba0911602ddef289404e33835a61168314ebd3c729833db2ed685824211", size = 106437, upload-time = "2026-03-05T15:54:35.177Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/fedd7284c459cfb58721d461fcf5607a4c1f5d9ab195d113d51d10164d16/mmh3-5.2.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:67e41a497bac88cc1de96eeba56eeb933c39d54bc227352f8455aa87c4ca4000", size = 110002, upload-time = "2026-03-05T15:54:36.673Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ac/ca8e0c19a34f5b71390171d2ff0b9f7f187550d66801a731bb68925126a4/mmh3-5.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3d74a03fb57757ece25aa4b3c1c60157a1cece37a020542785f942e2f827eed5", size = 97507, upload-time = "2026-03-05T15:54:37.804Z" },
+    { url = "https://files.pythonhosted.org/packages/df/94/6ebb9094cfc7ac5e7950776b9d13a66bb4a34f83814f32ba2abc9494fc68/mmh3-5.2.1-cp312-cp312-win32.whl", hash = "sha256:7374d6e3ef72afe49697ecd683f3da12f4fc06af2d75433d0580c6746d2fa025", size = 40773, upload-time = "2026-03-05T15:54:40.077Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/cd3527198cf159495966551c84a5f36805a10ac17b294f41f67b83f6a4d6/mmh3-5.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:3a9fed49c6ce4ed7e73f13182760c65c816da006debe67f37635580dfb0fae00", size = 41560, upload-time = "2026-03-05T15:54:41.148Z" },
+    { url = "https://files.pythonhosted.org/packages/15/96/6fe5ebd0f970a076e3ed5512871ce7569447b962e96c125528a2f9724470/mmh3-5.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:bbfcb95d9a744e6e2827dfc66ad10e1020e0cac255eb7f85652832d5a264c2fc", size = 39313, upload-time = "2026-03-05T15:54:42.171Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a5/9daa0508a1569a54130f6198d5462a92deda870043624aa3ea72721aa765/mmh3-5.2.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:723b2681ed4cc07d3401bbea9c201ad4f2a4ca6ba8cddaff6789f715dd2b391e", size = 40832, upload-time = "2026-03-05T15:54:43.212Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/6b/3230c6d80c1f4b766dedf280a92c2241e99f87c1504ff74205ec8cebe451/mmh3-5.2.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:3619473a0e0d329fd4aec8075628f8f616be2da41605300696206d6f36920c3d", size = 41964, upload-time = "2026-03-05T15:54:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/62/fb/648bfddb74a872004b6ee751551bfdda783fe6d70d2e9723bad84dbe5311/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:e48d4dbe0f88e53081da605ae68644e5182752803bbc2beb228cca7f1c4454d6", size = 39114, upload-time = "2026-03-05T15:54:45.205Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c2/ab7901f87af438468b496728d11264cb397b3574d41506e71b92128e0373/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a482ac121de6973897c92c2f31defc6bafb11c83825109275cffce54bb64933f", size = 39819, upload-time = "2026-03-05T15:54:46.509Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/ed/6f88dda0df67de1612f2e130ffea34cf84aaee5bff5b0aff4dbff2babe34/mmh3-5.2.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:17fbb47f0885ace8327ce1235d0416dc86a211dcd8cc1e703f41523be32cfec8", size = 40330, upload-time = "2026-03-05T15:54:47.864Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/66/7516d23f53cdf90f43fce24ab80c28f45e6851d78b46bef8c02084edf583/mmh3-5.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d51fde50a77f81330523562e3c2734ffdca9c4c9e9d355478117905e1cfe16c6", size = 56078, upload-time = "2026-03-05T15:54:48.9Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/34/4d152fdf4a91a132cb226b671f11c6b796eada9ab78080fb5ce1e95adaab/mmh3-5.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:19bbd3b841174ae6ed588536ab5e1b1fe83d046e668602c20266547298d939a9", size = 40498, upload-time = "2026-03-05T15:54:49.942Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/4c/8e3af1b6d85a299767ec97bd923f12b06267089c1472c27c1696870d1175/mmh3-5.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be77c402d5e882b6fbacfd90823f13da8e0a69658405a39a569c6b58fdb17b03", size = 40033, upload-time = "2026-03-05T15:54:50.994Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f2/966ea560e32578d453c9e9db53d602cbb1d0da27317e232afa7c38ceba11/mmh3-5.2.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fd96476f04db5ceba1cfa0f21228f67c1f7402296f0e73fee3513aa680ad237b", size = 97320, upload-time = "2026-03-05T15:54:52.072Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/0d/2c5f9893b38aeb6b034d1a44ecd55a010148054f6a516abe53b5e4057297/mmh3-5.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:707151644085dd0f20fe4f4b573d28e5130c4aaa5f587e95b60989c5926653b5", size = 103299, upload-time = "2026-03-05T15:54:53.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fc/2ebaef4a4d4376f89761274dc274035ffd96006ab496b4ee5af9b08f21a9/mmh3-5.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3737303ca9ea0f7cb83028781148fcda4f1dac7821db0c47672971dabcf63593", size = 106222, upload-time = "2026-03-05T15:54:55.092Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/ea7ffe126d0ba0406622602a2d05e1e1a6841cc92fc322eb576c95b27fad/mmh3-5.2.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2778fed822d7db23ac5008b181441af0c869455b2e7d001f4019636ac31b6fe4", size = 113048, upload-time = "2026-03-05T15:54:56.305Z" },
+    { url = "https://files.pythonhosted.org/packages/85/57/9447032edf93a64aa9bef4d9aa596400b1756f40411890f77a284f6293ca/mmh3-5.2.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d57dea657357230cc780e13920d7fa7db059d58fe721c80020f94476da4ca0a1", size = 120742, upload-time = "2026-03-05T15:54:57.453Z" },
+    { url = "https://files.pythonhosted.org/packages/53/82/a86cc87cc88c92e9e1a598fee509f0409435b57879a6129bf3b3e40513c7/mmh3-5.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:169e0d178cb59314456ab30772429a802b25d13227088085b0d49b9fe1533104", size = 99132, upload-time = "2026-03-05T15:54:58.583Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f7/6b16eb1b40ee89bb740698735574536bc20d6cdafc65ae702ea235578e05/mmh3-5.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7e4e1f580033335c6f76d1e0d6b56baf009d1a64d6a4816347e4271ba951f46d", size = 98686, upload-time = "2026-03-05T15:55:00.078Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/88/a601e9f32ad1410f438a6d0544298ea621f989bd34a0731a7190f7dec799/mmh3-5.2.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:2bd9f19f7f1fcebd74e830f4af0f28adad4975d40d80620be19ffb2b2af56c9f", size = 106479, upload-time = "2026-03-05T15:55:01.532Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/ce29ae3dfc4feec4007a437a1b7435fb9507532a25147602cd5b52be86db/mmh3-5.2.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:c88653877aeb514c089d1b3d473451677b8b9a6d1497dbddf1ae7934518b06d2", size = 110030, upload-time = "2026-03-05T15:55:02.934Z" },
+    { url = "https://files.pythonhosted.org/packages/13/30/ae444ef2ff87c805d525da4fa63d27cda4fe8a48e77003a036b8461cfd5c/mmh3-5.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fceef7fe67c81e1585198215e42ad3fdba3a25644beda8fbdaf85f4d7b93175a", size = 97536, upload-time = "2026-03-05T15:55:04.135Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f9/dc3787ee5c813cc27fe79f45ad4500d9b5437f23a7402435cc34e07c7718/mmh3-5.2.1-cp313-cp313-win32.whl", hash = "sha256:54b64fb2433bc71488e7a449603bf8bd31fbcf9cb56fbe1eb6d459e90b86c37b", size = 40769, upload-time = "2026-03-05T15:55:05.277Z" },
+    { url = "https://files.pythonhosted.org/packages/43/67/850e0b5a1e97799822ebfc4ca0e8c6ece3ed8baf7dcdf64de817dfdda2ca/mmh3-5.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:cae6383181f1e345317742d2ddd88f9e7d2682fa4c9432e3a74e47d92dce0229", size = 41563, upload-time = "2026-03-05T15:55:06.283Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/cc/98c90b28e1da5458e19fbfaf4adb5289208d3bfccd45dd14eab216a2f0bb/mmh3-5.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:022aa1a528604e6c83d0a7705fdef0b5355d897a9e0fa3a8d26709ceaa06965d", size = 39310, upload-time = "2026-03-05T15:55:07.323Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b4/65bc1fb2bb7f83e91c30865023b1847cf89a5f237165575e8c83aa536584/mmh3-5.2.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:d771f085fcdf4035786adfb1d8db026df1eb4b41dac1c3d070d1e49512843227", size = 40794, upload-time = "2026-03-05T15:55:09.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/86/7168b3d83be8eb553897b1fac9da8bbb06568e5cfe555ffc329ebb46f59d/mmh3-5.2.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:7f196cd7910d71e9d9860da0ff7a77f64d22c1ad931f1dd18559a06e03109fc0", size = 41923, upload-time = "2026-03-05T15:55:10.924Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9b/b653ab611c9060ce8ff0ba25c0226757755725e789292f3ca138a58082cd/mmh3-5.2.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b1f12bd684887a0a5d55e6363ca87056f361e45451105012d329b86ec19dbe0b", size = 39131, upload-time = "2026-03-05T15:55:11.961Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b4/5a2e0d34ab4d33543f01121e832395ea510132ea8e52cdf63926d9d81754/mmh3-5.2.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:d106493a60dcb4aef35a0fac85105e150a11cf8bc2b0d388f5a33272d756c966", size = 39825, upload-time = "2026-03-05T15:55:13.013Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/69/81699a8f39a3f8d368bec6443435c0c392df0d200ad915bf0d222b588e03/mmh3-5.2.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:44983e45310ee5b9f73397350251cdf6e63a466406a105f1d16cb5baa659270b", size = 40344, upload-time = "2026-03-05T15:55:14.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b3/71c8c775807606e8fd8acc5c69016e1caf3200d50b50b6dd4b40ce10b76c/mmh3-5.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:368625fb01666655985391dbad3860dc0ba7c0d6b9125819f3121ee7292b4ac8", size = 56291, upload-time = "2026-03-05T15:55:15.137Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/75/2c24517d4b2ce9e4917362d24f274d3d541346af764430249ddcc4cb3a08/mmh3-5.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:72d1cc63bcc91e14933f77d51b3df899d6a07d184ec515ea7f56bff659e124d7", size = 40575, upload-time = "2026-03-05T15:55:16.518Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b9/e4a360164365ac9f07a25f0f7928e3a66eb9ecc989384060747aa170e6aa/mmh3-5.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e8b4b5580280b9265af3e0409974fb79c64cf7523632d03fbf11df18f8b0181e", size = 40052, upload-time = "2026-03-05T15:55:17.735Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ca/120d92223a7546131bbbc31c9174168ee7a73b1366f5463ffe69d9e691fe/mmh3-5.2.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4cbbde66f1183db040daede83dd86c06d663c5bb2af6de1142b7c8c37923dd74", size = 97311, upload-time = "2026-03-05T15:55:18.959Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/71/c1a60c1652b8813ef9de6d289784847355417ee0f2980bca002fe87f4ae5/mmh3-5.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8ff038d52ef6aa0f309feeba00c5095c9118d0abf787e8e8454d6048db2037fc", size = 103279, upload-time = "2026-03-05T15:55:20.448Z" },
+    { url = "https://files.pythonhosted.org/packages/48/29/ad97f4be1509cdcb28ae32c15593ce7c415db47ace37f8fad35b493faa9a/mmh3-5.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4130d0b9ce5fad6af07421b1aecc7e079519f70d6c05729ab871794eded8617", size = 106290, upload-time = "2026-03-05T15:55:21.6Z" },
+    { url = "https://files.pythonhosted.org/packages/77/29/1f86d22e281bd8827ba373600a4a8b0c0eae5ca6aa55b9a8c26d2a34decc/mmh3-5.2.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6e0bfe77d238308839699944164b96a2eeccaf55f2af400f54dc20669d8d5f2", size = 113116, upload-time = "2026-03-05T15:55:22.826Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7c/339971ea7ed4c12d98f421f13db3ea576a9114082ccb59d2d1a0f00ccac1/mmh3-5.2.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f963eafc0a77a6c0562397da004f5876a9bcf7265a7bcc3205e29636bc4a1312", size = 120740, upload-time = "2026-03-05T15:55:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/3c7c4bdb8e926bb3c972d1e2907d77960c1c4b250b41e8366cf20c6e4373/mmh3-5.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:92883836caf50d5255be03d988d75bc93e3f86ba247b7ca137347c323f731deb", size = 99143, upload-time = "2026-03-05T15:55:25.456Z" },
+    { url = "https://files.pythonhosted.org/packages/df/0a/33dd8706e732458c8375eae63c981292de07a406bad4ec03e5269654aa2c/mmh3-5.2.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:57b52603e89355ff318025dd55158f6e71396c0f1f609d548e9ea9c94cc6ce0a", size = 98703, upload-time = "2026-03-05T15:55:26.723Z" },
+    { url = "https://files.pythonhosted.org/packages/51/04/76bbce05df76cbc3d396f13b2ea5b1578ef02b6a5187e132c6c33f99d596/mmh3-5.2.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f40a95186a72fa0b67d15fef0f157bfcda00b4f59c8a07cbe5530d41ac35d105", size = 106484, upload-time = "2026-03-05T15:55:28.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8f/c6e204a2c70b719c1f62ffd9da27aef2dddcba875ea9c31ca0e87b975a46/mmh3-5.2.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:58370d05d033ee97224c81263af123dea3d931025030fd34b61227a768a8858a", size = 110012, upload-time = "2026-03-05T15:55:29.532Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/37/7181efd8e39db386c1ebc3e6b7d1f702a09d7c1197a6f2742ed6b5c16597/mmh3-5.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7be6dfb49e48fd0a7d91ff758a2b51336f1cd21f9d44b20f6801f072bd080cdd", size = 97508, upload-time = "2026-03-05T15:55:31.01Z" },
+    { url = "https://files.pythonhosted.org/packages/42/0f/afa7ca2615fd85e1469474bb860e381443d0b868c083b62b41cb1d7ca32f/mmh3-5.2.1-cp314-cp314-win32.whl", hash = "sha256:54fe8518abe06a4c3852754bfd498b30cc58e667f376c513eac89a244ce781a4", size = 41387, upload-time = "2026-03-05T15:55:32.403Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0d/46d42a260ee1357db3d486e6c7a692e303c017968e14865e00efa10d09fc/mmh3-5.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:3f796b535008708846044c43302719c6956f39ca2d93f2edda5319e79a29efbb", size = 42101, upload-time = "2026-03-05T15:55:33.646Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/7b/848a8378059d96501a41159fca90d6a99e89736b0afbe8e8edffeac8c74b/mmh3-5.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:cd471ede0d802dd936b6fab28188302b2d497f68436025857ca72cd3810423fe", size = 39836, upload-time = "2026-03-05T15:55:35.026Z" },
+    { url = "https://files.pythonhosted.org/packages/27/61/1dabea76c011ba8547c25d30c91c0ec22544487a8750997a27a0c9e1180b/mmh3-5.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5174a697ce042fa77c407e05efe41e03aa56dae9ec67388055820fb48cf4c3ba", size = 57727, upload-time = "2026-03-05T15:55:36.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/32/731185950d1cf2d5e28979cc8593016ba1619a295faba10dda664a4931b5/mmh3-5.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0a3984146e414684a6be2862d84fcb1035f4984851cb81b26d933bab6119bf00", size = 41308, upload-time = "2026-03-05T15:55:37.254Z" },
+    { url = "https://files.pythonhosted.org/packages/76/aa/66c76801c24b8c9418b4edde9b5e57c75e72c94e29c48f707e3962534f18/mmh3-5.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bd6e7d363aa93bd3421b30b6af97064daf47bc96005bddba67c5ffbc6df426b8", size = 40758, upload-time = "2026-03-05T15:55:38.61Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/bb/79a1f638a02f0ae389f706d13891e2fbf7d8c0a22ecde67ba828951bb60a/mmh3-5.2.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:113f78e7463a36dbbcea05bfe688efd7fa759d0f0c56e73c974d60dcfec3dfcc", size = 109670, upload-time = "2026-03-05T15:55:40.13Z" },
+    { url = "https://files.pythonhosted.org/packages/26/94/8cd0e187a288985bcfc79bf5144d1d712df9dee74365f59d26e3a1865be6/mmh3-5.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7e8ec5f606e0809426d2440e0683509fb605a8820a21ebd120dcdba61b74ef7f", size = 117399, upload-time = "2026-03-05T15:55:42.076Z" },
+    { url = "https://files.pythonhosted.org/packages/42/94/dfea6059bd5c5beda565f58a4096e43f4858fb6d2862806b8bbd12cbb284/mmh3-5.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22b0f9971ec4e07e8223f2beebe96a6cfc779d940b6f27d26604040dd74d3a44", size = 120386, upload-time = "2026-03-05T15:55:43.481Z" },
+    { url = "https://files.pythonhosted.org/packages/47/cb/f9c45e62aaa67220179f487772461d891bb582bb2f9783c944832c60efd9/mmh3-5.2.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:85ffc9920ffc39c5eee1e3ac9100c913a0973996fbad5111f939bbda49204bb7", size = 125924, upload-time = "2026-03-05T15:55:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/fe54a4a7c11bc9f623dfc1707decd034245602b076dfc1dcc771a4163170/mmh3-5.2.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7aec798c2b01aaa65a55f1124f3405804184373abb318a3091325aece235f67c", size = 135280, upload-time = "2026-03-05T15:55:45.866Z" },
+    { url = "https://files.pythonhosted.org/packages/97/67/fe7e9e9c143daddd210cd22aef89cbc425d58ecf238d2b7d9eb0da974105/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55dbbd8ffbc40d1697d5e2d0375b08599dae8746b0b08dea05eee4ce81648fac", size = 110050, upload-time = "2026-03-05T15:55:47.074Z" },
+    { url = "https://files.pythonhosted.org/packages/43/c4/6d4b09fcbef80794de447c9378e39eefc047156b290fa3dd2d5257ca8227/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:6c85c38a279ca9295a69b9b088a2e48aa49737bb1b34e6a9dc6297c110e8d912", size = 111158, upload-time = "2026-03-05T15:55:48.239Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a6/ca51c864bdb30524beb055a6d8826db3906af0834ec8c41d097a6e8573d5/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:6290289fa5fb4c70fd7f72016e03633d60388185483ff3b162912c81205ae2cf", size = 116890, upload-time = "2026-03-05T15:55:49.405Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/04/5a1fe2e2ad843d03e89af25238cbc4f6840a8bb6c4329a98ab694c71deda/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:4fc6cd65dc4d2fdb2625e288939a3566e36127a84811a4913f02f3d5931da52d", size = 123121, upload-time = "2026-03-05T15:55:50.61Z" },
+    { url = "https://files.pythonhosted.org/packages/af/4d/3c820c6f4897afd25905270a9f2330a23f77a207ea7356f7aadace7273c0/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:623f938f6a039536cc02b7582a07a080f13fdfd48f87e63201d92d7e34d09a18", size = 110187, upload-time = "2026-03-05T15:55:52.143Z" },
+    { url = "https://files.pythonhosted.org/packages/21/54/1d71cd143752361c0aebef16ad3f55926a6faf7b112d355745c1f8a25f7f/mmh3-5.2.1-cp314-cp314t-win32.whl", hash = "sha256:29bc3973676ae334412efdd367fcd11d036b7be3efc1ce2407ef8676dabfeb82", size = 41934, upload-time = "2026-03-05T15:55:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e4/63a2a88f31d93dea03947cccc2a076946857e799ea4f7acdecbf43b324aa/mmh3-5.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:28cfab66577000b9505a0d068c731aee7ca85cd26d4d63881fab17857e0fe1fb", size = 43036, upload-time = "2026-03-05T15:55:55.252Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0f/59204bf136d1201f8d7884cfbaf7498c5b4674e87a4c693f9bde63741ce1/mmh3-5.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:dfd51b4c56b673dfbc43d7d27ef857dd91124801e2806c69bb45585ce0fa019b", size = 40391, upload-time = "2026-03-05T15:55:56.697Z" },
 ]
 
 [[package]]
@@ -415,12 +588,222 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyiceberg"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "click" },
+    { name = "fsspec" },
+    { name = "mmh3" },
+    { name = "pydantic" },
+    { name = "pyparsing" },
+    { name = "pyroaring" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "strictyaml" },
+    { name = "tenacity" },
+    { name = "zstandard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f0/7616676603fdbd05ab97816337a9b31be08a5f9e1ffd636260812b217e0f/pyiceberg-0.11.1.tar.gz", hash = "sha256:366fe0d5a74e3cf1d4e7cbf3c49e308da60e7835ea268667be9185388f05d7a5", size = 1076075, upload-time = "2026-03-03T00:10:27.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/84/a140466b7e0841207e6b77042e03d4ab3a4f9d47e00f0bbbcc5420792bbb/pyiceberg-0.11.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cd423b8ee2f75fc9db09158875abe5e2c952a26ae5e521c3265ab2f9d3511ddf", size = 532981, upload-time = "2026-03-03T00:10:08.906Z" },
+    { url = "https://files.pythonhosted.org/packages/17/10/6bedd784010f707680ffd0606d4d11394cf915f4f9f54ae16e8007e00ad4/pyiceberg-0.11.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e273242cdca56029af694d7ce18075d47a74d034326d663ff6dd2655a6f44825", size = 533188, upload-time = "2026-03-03T00:10:10.086Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a3/79db617c3cffc963efa8a332707079d3f22fd58067b31a208d358dd89b39/pyiceberg-0.11.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b347d3cc8510f8fbe191956fcda7da372ebb3302789acefca08e352345959003", size = 729546, upload-time = "2026-03-03T00:10:11.413Z" },
+    { url = "https://files.pythonhosted.org/packages/06/64/acc11d230c33817bced80d9d947bb49e7bb3a429d76d906523e3df86faf8/pyiceberg-0.11.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bba3a35b4648694783aeae5b77c235a57191c8b1b375c8602b03ae56a6cf4fe7", size = 730263, upload-time = "2026-03-03T00:10:13.283Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/1a/fb067d5150c7309fbf5dd126c648a6afed6259e7bc924ba3c65d0f87a333/pyiceberg-0.11.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0f958cbca18d05846e3081dfff8575e73d45595441d659847479656dc76f91d", size = 724064, upload-time = "2026-03-03T00:10:14.55Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/71/103fdba5b144d55f3bb07347893737cc1d8fd71308108a77b7817c92c544/pyiceberg-0.11.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8c62636a1e9d8a1fc74ffb70383939b9cd93f2c9ee8e12015a50dd75c98a989e", size = 727239, upload-time = "2026-03-03T00:10:16.204Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c3/4db64429304c58c039f8e842cd37a9a1c472f596c2868ed2a5d2907b17ed/pyiceberg-0.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:1d6b6f0c1e7dd8357f1ba56524bfc870d04ad3c00979db291784a7145497ad3b", size = 531309, upload-time = "2026-03-03T00:10:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4c/a122d80d98cb6125d87024681263406433f0c25c699d503f5633521e6809/pyiceberg-0.11.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b7ec5db19feab98a31fcd5caccf4a9a4e83f96933d1ca393ba7aea665710c2bb", size = 532644, upload-time = "2026-03-03T00:10:18.574Z" },
+    { url = "https://files.pythonhosted.org/packages/10/94/9a8fa5fc580e6dccd34bbbf51e7658cd7b49540e2458783addeff5e22a91/pyiceberg-0.11.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cec0616d2ba6e7dda6327089a2f34ec723aa9ac2c389857ef0b83f65fb135dd6", size = 532787, upload-time = "2026-03-03T00:10:19.656Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ab/ab7c88828bc17d77dbbc5a765419dfec2135629e1d74cdd0762cd38ad867/pyiceberg-0.11.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ddb360da76c62c7c23ec3da40e1af48e6712a563905fea2d1a8911ff7a3b6c4d", size = 722202, upload-time = "2026-03-03T00:10:21.012Z" },
+    { url = "https://files.pythonhosted.org/packages/df/38/079cf1c0bf86da315472a926eec0dba10135f43374a2e267336eb98d8c76/pyiceberg-0.11.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d8790f420ebc484236017edba59182cf2a21bd3e4224a0bd0760a9c7268e96a", size = 724037, upload-time = "2026-03-03T00:10:22.176Z" },
+    { url = "https://files.pythonhosted.org/packages/08/6b/08eaef477debb110438d943ef3f5985096f660ccb735d6344701cbd075a9/pyiceberg-0.11.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ae27ba4d37925d5b2cff192acaa70c8bb114d632bbc527cc91fea0370702b866", size = 716035, upload-time = "2026-03-03T00:10:23.789Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/59/7671d6a630ab1d85c6e7ca8ddf438dc63a0b0dd183bc4be69bf25c0fa5f6/pyiceberg-0.11.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:db66a4e0fdfbf4090631d59c3f65e960d9a5561e9259f6f3993cbe91e396837e", size = 720887, upload-time = "2026-03-03T00:10:24.824Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/2b/5c8ad37807efaedb14b20f01f36462684468c80da5b74f4018fb4c1804b5/pyiceberg-0.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:eb3a0a3e630ee89758eb96b39b456f4697732351fb0c080e9498ea578f9b71f9", size = 530923, upload-time = "2026-03-03T00:10:26.196Z" },
+]
+
+[package.optional-dependencies]
+pyarrow = [
+    { name = "pyarrow" },
+    { name = "pyiceberg-core" },
+]
+
+[[package]]
+name = "pyiceberg-core"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/a0/0bcedbbe901484aacb6c605505f8574fd65954826e592fdb163e1cfb09f2/pyiceberg_core-0.8.0.tar.gz", hash = "sha256:59021ca5bc7ca95f2b06fb0730280fb3f60ed898060bcd874c156d093853b5f3", size = 618882, upload-time = "2026-01-20T00:50:40.076Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/e0/9a8fa537d29d34e3265682056d6517b926975107b5b1af6057d1713557d6/pyiceberg_core-0.8.0-cp310-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d60c75a741a1d9199277a9e50fc3adbc84ab286a881f9b1f721fa120e7197912", size = 24733948, upload-time = "2026-01-20T00:50:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/3e/f5522c1e9c20c3e89bfd76b2f54ba38e57389e5a2872233e49e60a131e04/pyiceberg_core-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1d71e566b2d56141760ff8734667eede5a5d60963dfbcdce80c2dd3cf2edb39d", size = 11682041, upload-time = "2026-01-20T00:50:22.843Z" },
+    { url = "https://files.pythonhosted.org/packages/95/4b/f799e5c7a2b2ede75514e64901503358a7a134ca1ea217fd86535af533b6/pyiceberg_core-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82782d1b974200c5526d069391ba2bc235a868b5d0d6ac17ca406df735ab89a3", size = 13835428, upload-time = "2026-01-20T00:50:25.021Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ff/2dbd6f7c99a2f782f908be2cc997371de45cc1df61abeeff1fc0165c05b6/pyiceberg_core-0.8.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0e14b2aea26293ba5878c398adc880fff0f1ce5d989e00d4b1a930c143541114", size = 14580807, upload-time = "2026-01-20T00:50:27.158Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/13/176c2b00a9b804af79d8b697ba1a2525f4390e959be777076972071ca069/pyiceberg_core-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:a5726cc62f9ac2582a0d5dde92e4140b711b5e29ec0c6c636d6d2782d984031b", size = 13354110, upload-time = "2026-01-20T00:50:29.785Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyroaring"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/46/a50510d080f8cb089303ec0f7cd80736b2949ca3d148f48f1cc90c49e345/pyroaring-1.1.0.tar.gz", hash = "sha256:f02e4021397ae02a139defdc6813b9942ab163de90affddd4ce4efbac299f619", size = 200298, upload-time = "2026-04-24T21:29:25.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/e9/d8dcccfdac1657e6a53b6ade0c0c71d59244316810c82537a5d634f8b7fd/pyroaring-1.1.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:fdf484d26016e0c016f23f2b635d2899daec034565fdcc062ed6b10f3b26a3f4", size = 334166, upload-time = "2026-04-24T21:28:07.184Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/16/70f8268c9bac4f6d91a82df254332edfa07020fe02e97c6d3d0295ee4db3/pyroaring-1.1.0-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:e9c2b9aa8decdcf40ed8f4c887092c20a272f8c32215c3fee65e9db92ecf418e", size = 711970, upload-time = "2026-04-24T21:28:08.929Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a6/0b88a8a8e4ffdd0bf53765c3ea17ce3b747f7de42b1f10d5c50a13ba3ecc/pyroaring-1.1.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:5eb031237e9d39cbdfc9276facacdd88e27aefb58940bd8b56b878dfd38d6022", size = 385825, upload-time = "2026-04-24T21:28:10.077Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a7/f06a899b896bb74a031201fbba707abf23e2485f44ead28d2e91977ee204/pyroaring-1.1.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:66aa6a321fbc598f26d5e66050a7f145c2253f3fe5737b589841ff0cbe5cb177", size = 2000799, upload-time = "2026-04-24T21:28:11.276Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/16/b13e0727ef5c91c84ac5d9b5c4af43cb3f28d8822d96d44aa4aeefc10b37/pyroaring-1.1.0-cp312-cp312-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8cff06d18c9a30f8547a92757078aa345db1ba5b22e3082a05f64e50b384e27a", size = 1843405, upload-time = "2026-04-24T21:28:12.394Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/4b/ff77d6eb4747c65aba49d345318059f1ccfbd206bbcd34686cea819187e9/pyroaring-1.1.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:043dbbaa905f7288c515ac06a96b67a3763f35e9ae06f0c0278c0d9964d16760", size = 2224307, upload-time = "2026-04-24T21:28:13.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d1/9b4e2175a9bd07592ef1c6f4692ba0cfe3abd54f33ebd574aa2b2ab88c2c/pyroaring-1.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:71fec09bd42f8c33ac3b762cd00c5db842eb583ffd0e361739ce1c17ad078a6a", size = 2902586, upload-time = "2026-04-24T21:28:15.485Z" },
+    { url = "https://files.pythonhosted.org/packages/67/24/904952d6bfe2e4946f361958157774230cb1ac171d306e2460620274c58a/pyroaring-1.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c9f30ca28b991a920b446ed3ee19c7ecafcc49c46db592abf89cf239a7bb45f4", size = 2741581, upload-time = "2026-04-24T21:28:17.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f5/8ad5605870fbdcb568f0b847e1fea24adea15e07c90231fb62f339c08b14/pyroaring-1.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:67650460c65bdd7b4f5078d9c955aa38f64627d02cb48f9cfb24eae84bca2aba", size = 3182906, upload-time = "2026-04-24T21:28:18.435Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5d/264414a1b1bea72b2a7756e2b1dca709e5c695b0cd332a8f90c297ae3b33/pyroaring-1.1.0-cp312-cp312-win32.whl", hash = "sha256:61a8eabee99104ca197b6e7cce05dc4f27f503be52881800cd370eb5a5152d3f", size = 211231, upload-time = "2026-04-24T21:28:20.414Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/39/dd3341e235a3794c613ea32bd35618a88ff2ae067dbe9dd7c382c8c146d2/pyroaring-1.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:51ebe5e6f48e3dc9df91a4cb62137ef72e1469acd6f37479abd9991f6d945cc9", size = 263337, upload-time = "2026-04-24T21:28:21.371Z" },
+    { url = "https://files.pythonhosted.org/packages/12/5d/bb8e93dd7412180c621086ed46014a0f09f9a71d9370ce8cf607c5a2cf00/pyroaring-1.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:9882a204178cc8c915e0ce30abb4bdd1668e383c571b06649d5ed272d9625877", size = 216727, upload-time = "2026-04-24T21:28:22.536Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/75/1d39ecb04e6cd96d191eb8884864355051df80928dd5096a9dea43fbf63b/pyroaring-1.1.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:72f68a16b00b35481d9b3bfe897ecd8a1f7da69efd92ba5b17347ca11c21cb0d", size = 333363, upload-time = "2026-04-24T21:28:23.838Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3e/65cd0871e86d11c5c5cfd0f5abb0ca80eb2b6b5dbe5a2433f315a9ebd90c/pyroaring-1.1.0-cp313-cp313-macosx_14_0_universal2.whl", hash = "sha256:4c443e9f942b6089efe8c9b264576e9d116f90be28a315679375bba2d8a915d6", size = 710573, upload-time = "2026-04-24T21:28:24.884Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a2/f8f23515f41414332e60cd86e4957e2a6838070b2ad5fe25e80f136de635/pyroaring-1.1.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:3beb40eb1220d1ce4fb3661bb019e9a21857e5bb294fe8c1c5016aeb6e82318c", size = 384880, upload-time = "2026-04-24T21:28:25.864Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/5b/82dc44b5074a1ff62e702d12611272d1711a60d5518dab23f94e1f7a9b3d/pyroaring-1.1.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f1f56004e8f1c1489bf279c25f1fa4764252cd9af5fb35675774268a4a615ba", size = 1999529, upload-time = "2026-04-24T21:28:26.859Z" },
+    { url = "https://files.pythonhosted.org/packages/11/40/b07bac8cdc4b709a05f5c55bb52d4f684e5ea1fadfa0b6d9decf477a9d2a/pyroaring-1.1.0-cp313-cp313-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:13660386ea8905ee4d42c21a6275463e2dc7d31e0b5d65eec210aa7043ad96f4", size = 1842927, upload-time = "2026-04-24T21:28:28.056Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/60/c4b511965802dfc77978a9e16f2813f47fb3083db1822019ba1bb169c685/pyroaring-1.1.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0dfb6cf50fd8898179e460e699a6b8326ca508c627d083f7bf62f769fe1717d5", size = 2199538, upload-time = "2026-04-24T21:28:29.425Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/12/38f6b50b3f3f41a8b752d3e9efcf105b18eb2c66811831059f25613734ac/pyroaring-1.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:81ebbc0c880c8a10f13118632e5c0d59159ceada8b651bba18f2e6dc70efdeda", size = 2896904, upload-time = "2026-04-24T21:28:30.67Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/b6/b5436e4b93c6bf2bd3dd6ccb88cbdc64b12084151a43e2f5c94be50eb710/pyroaring-1.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:370d191b0d1b32bbd99452ef5f0485f22fcc4bf7404d33b821d0ce2459951152", size = 2733819, upload-time = "2026-04-24T21:28:31.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/8f/f392f268de9607a5c7a95aaed6b9c8a81f00c14d85c33855e9f492095478/pyroaring-1.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8b3bfad0ae3ef0e67b40c193863dce8b7d79de545dadbe53c19acc3ace38f66", size = 3161730, upload-time = "2026-04-24T21:28:33.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/a1/03250fd4834b6a5c13e6600bca47ea20fda579f80bce3551d4985185d164/pyroaring-1.1.0-cp313-cp313-win32.whl", hash = "sha256:eead129046822cb0fd47c78740b81bdaffd0515c0bb0306a2318acf0f0540b58", size = 211194, upload-time = "2026-04-24T21:28:35.001Z" },
+    { url = "https://files.pythonhosted.org/packages/70/63/d9b307462cddc82fe94a67d6810e5c802818690e131ba690c1de674d8558/pyroaring-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:90ab2f00c09eed5bd986a80c8641e2dc10e7aca1a2d892d89a44b396e39c08ea", size = 263110, upload-time = "2026-04-24T21:28:35.976Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4a/aa6e9833a6ba9a630efdbec8783b63da6602f763b37a5b5fbc01d73a1af1/pyroaring-1.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:51dd2490a64ad4ed53c4fb58ef1ee3f84f6cbd97cdb47abd9065c9f714ab72ef", size = 216546, upload-time = "2026-04-24T21:28:37.065Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ab/2260fd567a2d5d957393b932ea940dc31146bd509c88164c1b786eee7836/pyroaring-1.1.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:5e337f8c5b3c2e0c27da83fc2cb702684a47eee907a960cfee964fcb5344515b", size = 335093, upload-time = "2026-04-24T21:28:38.325Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6c/df82a832ff3760c7c7653b80d030fb43b18eb88bfa604e7de3e84457286e/pyroaring-1.1.0-cp314-cp314-macosx_14_0_universal2.whl", hash = "sha256:53acecba8f898e96b84d4139356e30719c70358177e270055901d3ec1cb0e34c", size = 712387, upload-time = "2026-04-24T21:28:39.404Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b9/a94d6b2d7a1be2fa5009ecfc345bacb2ee0b536020aeb23e92c6bb7e70f2/pyroaring-1.1.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:986efb3aec7655d69c14db2309a2072dbf181bdb906091fede83ad18e316cdaf", size = 385413, upload-time = "2026-04-24T21:28:40.563Z" },
+    { url = "https://files.pythonhosted.org/packages/60/6a/3658eadbe28a5a2093c27857dd21441f1ea1cede2ddbe367df76e3018859/pyroaring-1.1.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92643c9dd303de8960c3dbed93a28b8d87da5ed0a7776568979f379d7bc8a885", size = 1995135, upload-time = "2026-04-24T21:28:41.931Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e2/4706ec770790d3433520eb0ea98fc662ccb1533164fd00b01f3413c3425c/pyroaring-1.1.0-cp314-cp314-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6a1d4c59d5b23c01d62f86d57ceefd0c0977de0425aafa7069f2d70563fed3b8", size = 1833652, upload-time = "2026-04-24T21:28:43.381Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/38/b8b861738e49fd4c4a54bebe257dced603999365629b4e10cb85fac940b0/pyroaring-1.1.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8ac1bc26223befbca986551521f37f4c1670dfe26fccb2f0fc2775e75be99c1", size = 2188218, upload-time = "2026-04-24T21:28:44.487Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8c/96afa9b5f509a5c607deaf30538edb3bdf026447a864cfe3f2c3d7484875/pyroaring-1.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b490f2d22df30affbfdcbe4f7896f321edb72a8dc0cbe5f38adec3de5b947c25", size = 2898243, upload-time = "2026-04-24T21:28:45.9Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/86f8720525250fe742fc77ea5c2a2074a1ea830efe84a79112ce6fe113d3/pyroaring-1.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:56a67794188275f8897a8f1fa64d6313c48241bebbdef38833063e7281b29ef8", size = 2715091, upload-time = "2026-04-24T21:28:47.721Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/21/29e8f58c8af2ce016904a7e6aa61be675945224971cd70f3f698e584a23f/pyroaring-1.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9d9f196007f0b15ea19c21732faacaea83cbf5946b6db4949b3b98cf871c93f0", size = 3149470, upload-time = "2026-04-24T21:28:48.918Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/e1/f67ef1c9de461a80707a2f2981320b1b30632720bac426a9bfd51e4744b6/pyroaring-1.1.0-cp314-cp314-win32.whl", hash = "sha256:abc0f0ce22464864fea208315d25e999e45cb5ee646ac1ca11d314a6a51dbe4a", size = 216552, upload-time = "2026-04-24T21:28:50.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/83/a8d9fee17e6eedf2a2281b2aabcdde86930408486381ec48d1f7d3404521/pyroaring-1.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:532ae6bb1d3431d9956ef07589dd5c8dd918301a83d937c7dc6e511b1364d76a", size = 270712, upload-time = "2026-04-24T21:28:51.817Z" },
+    { url = "https://files.pythonhosted.org/packages/42/50/ab2bf3fe45e4c2952690d657321a8470558f92cf93cb197fe5d31f7110d2/pyroaring-1.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:d2706a89242a347be20805147d58a38f4f4d8f6846228c4ee8dfd3587113719c", size = 224783, upload-time = "2026-04-24T21:28:53.183Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0c/9eb48ac698280170f184045814b7bd44829af37c1c6de79a4d7b5ea0c8b8/pyroaring-1.1.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:39eff7dd06c163c22d0a9f9fd72d27e671457bea8cdb71215382a10512539e1d", size = 345689, upload-time = "2026-04-24T21:28:54.494Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/61/66b18f8ed17e70f88a410dcfac21e5964c2ad01bd4d6a25024a87522c8a9/pyroaring-1.1.0-cp314-cp314t-macosx_14_0_universal2.whl", hash = "sha256:562fa04bbfd41144d1276ed79505007557c161371450d68a1d71fc83dc01d083", size = 732373, upload-time = "2026-04-24T21:28:55.525Z" },
+    { url = "https://files.pythonhosted.org/packages/04/7a/976482874ea5e4476f9dd84e7d0274e480446b1b6ab45dfe301281814b3b/pyroaring-1.1.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:591e2ed4d60443dafd9075c1f72e9aaf359ccf5120e32a8c340c2b2ae3da45e7", size = 392985, upload-time = "2026-04-24T21:28:56.629Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/22/1eed09ff3aa792865dd52ef447cbe52dbc5901ed88bf1cf4513f7220150e/pyroaring-1.1.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:381eda673442c389993f8b0db2dbf5d02ea8ea9aac6ba736f64cc1ffb6c96885", size = 2045479, upload-time = "2026-04-24T21:28:58.008Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/de43464f9b28c445868e4bc8f0e6c6dcd51103bd9a757e3dcd9af25a4a69/pyroaring-1.1.0-cp314-cp314t-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d9127feb5356ba3a92bdffa04c1bf6bcbc8d436369f78badf441018c3029dd63", size = 1853013, upload-time = "2026-04-24T21:28:59.265Z" },
+    { url = "https://files.pythonhosted.org/packages/03/17/29b128a580ec43905fb766b934e7dcb1095059e99e38e941edf50152207b/pyroaring-1.1.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:650db21c10f42ff2b09ef02c10a779a3d59d0c7512552f3844738b30adbcb8a5", size = 2222628, upload-time = "2026-04-24T21:29:00.792Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/d8/bb7d69978a5fcac95da48bedb114554d8345b50b77f042e8cd2a8277bb4b/pyroaring-1.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a5fbcb86e44f1c0c9c052917eee67a04cbac9de7392fb4bc77c140ff4a7e471", size = 2931231, upload-time = "2026-04-24T21:29:02.275Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/12/d44d144352a4586544313a97b2576f8f8673b98c02ae7fed77d38751cc1f/pyroaring-1.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:0f1d76ef29034017eb2cceebd5fa0504d6ced218ce6432f99da5adecbe038269", size = 2729546, upload-time = "2026-04-24T21:29:03.414Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f9/0d01c6ba01c0d01609fddb1d46138a7ae95b7db386bac4afb0ff082d5c0e/pyroaring-1.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:19d0c81c865d63791fe20e5b38733b66f4f962e677ae7e8b3d3c4947ac6e752f", size = 3177123, upload-time = "2026-04-24T21:29:04.619Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6d/f991526fdef3cf7739f6db0cdf12b157e840e0ddd4a7e1c2a477da9072d6/pyroaring-1.1.0-cp314-cp314t-win32.whl", hash = "sha256:1fc112b9a9890f89cc645a16604783ed7fa25299f149b0ef7b45a5e2e3c1f31f", size = 241484, upload-time = "2026-04-24T21:29:06.114Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/6e/fb9876940acb50df355a473c087b9924e7b3368070403683941653b6fabc/pyroaring-1.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d92a0f4c7e6bb7deeafac68c79c92ef9340895fe825cf1a31078443753ab6756", size = 304537, upload-time = "2026-04-24T21:29:07.312Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/e0/39afe4bddbed6276c54e35e310aa345fbeb00f8890e96e7f48cdc2be9c66/pyroaring-1.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:99c42fe1449acfbf130da65e66b4d5b2726aba4497be359bae7672e38a15fc62", size = 234615, upload-time = "2026-04-24T21:29:08.751Z" },
 ]
 
 [[package]]
@@ -547,6 +930,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.7"
 source = { registry = "https://pypi.org/simple" }
@@ -593,6 +989,73 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/b3/2de412451330756aaaa72d27131db6dde23995efe62c941184e15242a5fa/sqlalchemy-2.0.49-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbccb45260e4ff1b7db0be80a9025bb1e6698bdb808b83fff0000f7a90b2c0b", size = 2157681, upload-time = "2026-04-03T16:53:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/50/84/b2a56e2105bd11ebf9f0b93abddd748e1a78d592819099359aa98134a8bf/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb37f15714ec2652d574f021d479e78cd4eb9d04396dca36568fdfffb3487982", size = 3338976, upload-time = "2026-04-03T17:07:40Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/65fcae2ed62f84ab72cf89536c7c3217a156e71a2c111b1305ab6f0690e2/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bb9ec6436a820a4c006aad1ac351f12de2f2dbdaad171692ee457a02429b672", size = 3351937, upload-time = "2026-04-03T17:12:23.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/2f/6fd118563572a7fe475925742eb6b3443b2250e346a0cc27d8d408e73773/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8d6efc136f44a7e8bc8088507eaabbb8c2b55b3dbb63fe102c690da0ddebe55e", size = 3281646, upload-time = "2026-04-03T17:07:41.949Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d7/410f4a007c65275b9cf82354adb4bb8ba587b176d0a6ee99caa16fe638f8/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e06e617e3d4fd9e51d385dfe45b077a41e9d1b033a7702551e3278ac597dc750", size = 3316695, upload-time = "2026-04-03T17:12:25.642Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/95/81f594aa60ded13273a844539041ccf1e66c5a7bed0a8e27810a3b52d522/sqlalchemy-2.0.49-cp312-cp312-win32.whl", hash = "sha256:83101a6930332b87653886c01d1ee7e294b1fe46a07dd9a2d2b4f91bcc88eec0", size = 2117483, upload-time = "2026-04-03T17:05:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9e/fd90114059175cac64e4fafa9bf3ac20584384d66de40793ae2e2f26f3bb/sqlalchemy-2.0.49-cp312-cp312-win_amd64.whl", hash = "sha256:618a308215b6cececb6240b9abde545e3acdabac7ae3e1d4e666896bf5ba44b4", size = 2144494, upload-time = "2026-04-03T17:05:42.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/81/81755f50eb2478eaf2049728491d4ea4f416c1eb013338682173259efa09/sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120", size = 2154547, upload-time = "2026-04-03T16:53:08.64Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bc/3494270da80811d08bcfa247404292428c4fe16294932bce5593f215cad9/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2", size = 3280782, upload-time = "2026-04-03T17:07:43.508Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3", size = 3297156, upload-time = "2026-04-03T17:12:27.697Z" },
+    { url = "https://files.pythonhosted.org/packages/88/50/a6af0ff9dc954b43a65ca9b5367334e45d99684c90a3d3413fc19a02d43c/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7", size = 3228832, upload-time = "2026-04-03T17:07:45.38Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d1/5f6bdad8de0bf546fc74370939621396515e0cdb9067402d6ba1b8afbe9a/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33", size = 3267000, upload-time = "2026-04-03T17:12:29.657Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/30/ad62227b4a9819a5e1c6abff77c0f614fa7c9326e5a3bdbee90f7139382b/sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b", size = 2115641, upload-time = "2026-04-03T17:05:43.989Z" },
+    { url = "https://files.pythonhosted.org/packages/17/3a/7215b1b7d6d49dc9a87211be44562077f5f04f9bb5a59552c1c8e2d98173/sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148", size = 2141498, upload-time = "2026-04-03T17:05:45.7Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4b/52a0cb2687a9cd1648252bb257be5a1ba2c2ded20ba695c65756a55a15a4/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518", size = 3560807, upload-time = "2026-04-03T16:58:31.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d8/fda95459204877eed0458550d6c7c64c98cc50c2d8d618026737de9ed41a/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d", size = 3527481, upload-time = "2026-04-03T17:06:00.155Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0a/2aac8b78ac6487240cf7afef8f203ca783e8796002dc0cf65c4ee99ff8bb/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0", size = 3468565, upload-time = "2026-04-03T16:58:33.414Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/ce71cfa82c50a373fd2148b3c870be05027155ce791dc9a5dcf439790b8b/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08", size = 3477769, upload-time = "2026-04-03T17:06:02.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e8/0a9f5c1f7c6f9ca480319bf57c2d7423f08d31445974167a27d14483c948/sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d", size = 2143319, upload-time = "2026-04-03T17:02:04.328Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/51/fb5240729fbec73006e137c4f7a7918ffd583ab08921e6ff81a999d6517a/sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba", size = 2175104, upload-time = "2026-04-03T17:02:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356, upload-time = "2026-04-03T16:53:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486, upload-time = "2026-04-03T17:07:46.9Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479, upload-time = "2026-04-03T17:12:32.226Z" },
+    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269, upload-time = "2026-04-03T17:07:48.678Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260, upload-time = "2026-04-03T17:12:34.381Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463, upload-time = "2026-04-03T17:05:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204, upload-time = "2026-04-03T17:05:48.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474, upload-time = "2026-04-03T16:58:35.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567, upload-time = "2026-04-03T17:06:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282, upload-time = "2026-04-03T16:58:37.131Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406, upload-time = "2026-04-03T17:06:07.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+]
+
+[[package]]
+name = "strictyaml"
+version = "1.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/08/efd28d49162ce89c2ad61a88bd80e11fb77bc9f6c145402589112d38f8af/strictyaml-1.7.3.tar.gz", hash = "sha256:22f854a5fcab42b5ddba8030a0e4be51ca89af0267961c8d6cfa86395586c407", size = 115206, upload-time = "2023-03-10T12:50:27.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/7c/a81ef5ef10978dd073a854e0fa93b5d8021d0594b639cc8f6453c3c78a1d/strictyaml-1.7.3-py3-none-any.whl", hash = "sha256:fb5c8a4edb43bebb765959e420f9b3978d7f1af88c80606c03fb420888f5d1c7", size = 123917, upload-time = "2023-03-10T12:50:17.242Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
 name = "testcontainers"
 version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
@@ -615,6 +1078,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]
@@ -688,4 +1163,61 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
     { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
     { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
 ]


### PR DESCRIPTION
## Summary

Adds Apache Iceberg as a second destination, selectable at startup via `MILLPOND_DESTINATION` (default `ducklake`, backwards-compatible with all existing deployments). A pod writes to exactly one destination for its lifetime — no per-batch routing.

The abstraction is a thin Protocol (`millpond/sink.py`): `write(batch)`, `reset_caches()`, `close()`. `main.py` only sees the Protocol; each backend lives in its own module. `make_sink(cfg)` dispatches with lazy imports so a single-backend deployment doesn't pay the other backend's import cost (~150ms cold-start).

Builds on the prove-out from #56. That branch is superseded by this one — same core Iceberg implementation, but extended to keep DuckLake working in parallel rather than replacing it.

## Per-backend behavior

|  | DuckLake | Iceberg |
|---|---|---|
| Catalog | Postgres (via DuckDB ducklake extension) | REST catalog (Polaris, Tabular, AWS Glue REST, etc.) |
| Partition spec | Caller-supplied via `DUCKLAKE_PARTITION_BY` | Hardcoded identity transforms on derived `year`/`month`/`day`/`hour` int32 columns; Hive-style layout on S3 |
| Schema evolution | Per-statement DDL; `SchemaManager` swallows per-column failures and continues the flush | Single `update_schema()` transaction; `SchemaManager` re-raises on commit failure so the write-retry loop drives recovery |
| `_inserted_at` | DuckDB `NOW()` at INSERT (per-row, microsecond drift possible) | Python `datetime.now(UTC)` once per batch (all rows share one timestamp) |
| Maintenance tooling | `tools/ducklake_maintenance.py` CronJob + `tools/ducklake_metrics.py` daemon | Not bundled — use your catalog's native compaction/expiry |

The deliberate swallow-vs-raise asymmetry between schema managers is documented in `AGENT.md` with the technical reason (DuckLake DDL is per-statement, Iceberg is transactional).

## Cross-backend contract

`tests/unit/test_backend_equivalence.py` (~80 tests) locks the contract going forward: same Arrow batch through both Sinks, parametrized round-trip + null + pathological-value + reserved-name coverage, schema-evolution metric parity, and conservative performance smoke contracts. Two strict xfails surface pre-existing DuckLake type-mapping defects (float16, date32 — string-keyed dict miss in `_ARROW_TO_DUCKDB`); visible, not fixed in this PR.

The reserved-column-collision check is uniform across backends: both raise `ValueError("Source schema column(s) [...] collide with X-reserved metadata column names...")` at the Sink boundary before any backend-specific work. DuckLake reserves `year/month/day/hour` defensively (even though it doesn't produce them itself) so a deployment-time switch can't suddenly start rejecting batches.

## Notable design calls

* **Sink instance state, not module-level.** Each Sink owns its own `_tables_ensured` cache and `SchemaManager` — no module-level globals. Module helpers take the cache as a required parameter. Eliminates the cross-test-pollution risk and makes the lifecycle obvious.
* **Empty-batch contract on the Protocol.** Callers must not invoke `write()` with a zero-row batch; `main.py` gates on `pending_records > 0`. Backends diverge defensively (DuckLake creates eagerly; Iceberg short-circuits) but the gate ensures neither path runs in steady state.
* **`pa.null()` filtered at `arrow_converter`.** Defensive — `_build_schema`'s `pa.string()` fallback prevents `pa.null()` from appearing in normal use, but the filter keeps the Sink contract uniform if anything ever slips through.
* **`assert` → `if/raise` in Sink constructors.** Survives `python -O`.
* **Guarded shutdown in `main.py`.** `sink`/`kafka`/`http` initialized to `None` before the `try`; closes individually guarded. A partial-startup failure no longer NameErrors.
* **`tools/maintenance.{py,sql}` → `ducklake_maintenance.{py,sql}`.** Plus renamed test files. These ops are DuckLake-only; the prefix makes that explicit.
* **PyIceberg pinned exactly** (`==0.11.1`). The implementation uses two private symbols (`_pyarrow_to_schema_without_ids`, `assign_fresh_schema_ids`) to build a partition spec with sequential field IDs. `tests/unit/test_pyiceberg_pin.py` is the canary — version + module-path assertions fail loudly on any pyiceberg upgrade.

## Documentation

`README.md` and `AGENT.md` restructured to introduce both destinations, split configuration tables by-destination, document the Sink protocol + shared helpers, and explain the swallow-vs-raise asymmetry. `justfile`/`tools/README.md` headers updated. The dev `docker-compose.yaml` stack remains DuckLake-only; for Iceberg local dev, `tests/integration/compose.yaml` (MinIO + tabulario/iceberg-rest) is the documented entry point.

## Test plan

- [x] `uv run pytest tests/unit/` — 471 passed, 2 strict xfailed (the DuckLake type-mapping defects)
- [x] `uv run pytest tests/integration/` — 19 passed (DuckLake in-memory + Iceberg testcontainers stack)
- [x] `uv run ruff check millpond/ tests/ tools/` — clean
- [x] `uv run ruff format --check millpond/` — clean
- [ ] Deploy a canary pod against each destination in a prove-out environment