### PR TITLE
Add Iceberg coverage to integration + e2e suites and run both in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,3 +50,37 @@ jobs:
 
     - name: Build Docker image
       run: docker build --build-arg MILLPOND_VERSION=0.0.0.dev0 -t millpond .
+
+  integration:
+    # Integration suite: MinIO + iceberg-rest via testcontainers. No Kafka,
+    # no millpond container — drives the library directly. ~10s runtime.
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+    - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+
+    - name: Integration tests
+      run: uv run pytest tests/integration -v
+
+  e2e:
+    # E2E suites: full docker-compose stacks for both destinations.
+    # Each builds the millpond image, brings up Kafka/MinIO/(Postgres|iceberg-rest),
+    # runs the producer, and verifies records land. ~1 minute per stack.
+    runs-on: ubuntu-latest
+    needs: check
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - { name: ducklake, path: tests/e2e/test_e2e.py }
+          - { name: iceberg,  path: tests/e2e/test_e2e_iceberg.py }
+    name: e2e (${{ matrix.suite.name }})
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+    - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+
+    - name: E2E tests
+      run: uv run pytest ${{ matrix.suite.path }} -v -s

--- a/AGENT.md
+++ b/AGENT.md
@@ -5,12 +5,15 @@
 Always run before pushing:
 
 ```bash
-just lint       # ruff check
-just fmt-check  # ruff format --check
-just test       # unit tests
+just lint              # ruff check
+just fmt-check         # ruff format --check
+just test              # unit tests
+just test-integration  # MinIO + iceberg-rest via testcontainers (~10s)
+just test-e2e          # full DuckLake stack (~1m)
+just test-e2e-iceberg  # full Iceberg stack (~1m)
 ```
 
-All three must pass. Do not push with lint or test failures.
+All must pass. Do not push with any lint, test, integration, or e2e failures — CI runs all of these on every push and PR (`.github/workflows/ci.yaml`), and the integration/e2e jobs are gating. Catch failures locally rather than on the runner.
 
 For changes to Kafka client code or config handling, also verify with SSL Kafka:
 

--- a/README.md
+++ b/README.md
@@ -461,6 +461,16 @@ Related issues:
 - [aws-msk-iam-auth #143](https://github.com/aws/aws-msk-iam-auth/issues/143) — re-authentication fails with OAUTHBEARER
 - [aws-msk-iam-auth #176](https://github.com/aws/aws-msk-iam-auth/issues/176) — second re-authentication fails with default credentials
 
+## Next steps
+
+### Iceberg multi-writer commit contention
+
+The Iceberg sink can't currently sustain two pods committing to the same table at typical flush cadence. PyIceberg's REST commit attaches a branch-snapshot requirement (`expected id != actual id`); when a second writer commits between when we loaded the table and when we send the commit, the catalog rejects with `CommitFailedException: branch main has changed`. `_write_with_retry` in `main.py` invalidates caches and retries up to 3 times with exponential backoff (1s, 2s, 4s), but under sustained dual-writer load with `FLUSH_INTERVAL_MS=5000`, the retries collide with the *next* round of commits and exhaust the budget — the pod exits.
+
+This is why `docker-compose.iceberg.yaml` runs a single millpond pod while `docker-compose.yaml` (DuckLake) runs two. The DuckLake path serialises writes through Postgres-backed catalog locks; Iceberg's optimistic concurrency control needs more retry headroom and jittered backoff to avoid retry-storms, or the writers need partition-aware table layouts so they aren't contending on the same snapshot.
+
+Surfaced by the e2e suite when first wired up — see `tests/e2e/test_e2e_iceberg.py` and the comment in `docker-compose.iceberg.yaml`.
+
 ## Note
 This project should absolutely be called TableFowl, but that would be an [SEO](https://www.confluent.io/product/tableflow/) and linguistic palaver.
 

--- a/docker-compose.iceberg.yaml
+++ b/docker-compose.iceberg.yaml
@@ -39,12 +39,14 @@ services:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
     command: server /data --console-address ":9001"
-    # Ephemeral host port — the e2e test resolves it via
-    # `DockerCompose.get_service_host_and_port` to read parquet files back
-    # through pyiceberg's S3 client. Avoids hardcoded host ports so this
-    # stack can coexist with docker-compose.yaml.
+    # Ephemeral host port bound to loopback only — the e2e test resolves it
+    # via `DockerCompose.get_service_host_and_port` to read parquet files
+    # back through pyiceberg's S3 client. Avoids hardcoded host ports so
+    # this stack can coexist with docker-compose.yaml. The `127.0.0.1::`
+    # prefix (double colon = ephemeral host port) keeps the binding off
+    # non-loopback interfaces, per the trailofbits semgrep rule.
     ports:
-      - "9000"
+      - "127.0.0.1::9000"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 2s
@@ -77,8 +79,9 @@ services:
       CATALOG_IO__IMPL: org.apache.iceberg.aws.s3.S3FileIO
       CATALOG_S3_ENDPOINT: http://minio:9000
       CATALOG_S3_PATH__STYLE__ACCESS: "true"
+    # Loopback-only ephemeral host port — see comment on minio.ports.
     ports:
-      - "8181"
+      - "127.0.0.1::8181"
 
   # --- Topic Setup ---
 

--- a/docker-compose.iceberg.yaml
+++ b/docker-compose.iceberg.yaml
@@ -1,0 +1,169 @@
+# E2E stack for the Iceberg destination. Mirrors docker-compose.yaml but
+# swaps the DuckLake/Postgres pair for an Iceberg REST catalog over MinIO.
+# Kafka + producer are identical to the DuckLake stack so the only thing
+# under test is the sink dispatch + Iceberg write path.
+#
+# Run via `just test-e2e-iceberg`, or stand it up by hand:
+#     docker compose -f docker-compose.iceberg.yaml up --build
+#
+# Note: this compose does not bind host ports for Kafka/Postgres/MinIO so
+# it can coexist on a developer machine alongside docker-compose.yaml
+# without port collisions. The e2e test reaches the iceberg-rest catalog
+# via testcontainers' ephemeral port mapping.
+
+services:
+  # --- Infrastructure ---
+
+  kafka:
+    image: apache/kafka:3.9.0
+    hostname: kafka
+    volumes:
+      - ./test/kafka-server.properties:/opt/kafka/config/kraft/server.properties:ro
+    environment:
+      CLUSTER_ID: millpond-local-dev-cluster-001
+    command: >
+      bash -c "
+      /opt/kafka/bin/kafka-storage.sh format -t $$CLUSTER_ID -c /opt/kafka/config/kraft/server.properties --ignore-formatted &&
+      /opt/kafka/bin/kafka-server-start.sh /opt/kafka/config/kraft/server.properties
+      "
+    healthcheck:
+      test: /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server kafka:9094
+      interval: 5s
+      timeout: 10s
+      retries: 10
+
+  minio:
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    hostname: minio
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    # Ephemeral host port — the e2e test resolves it via
+    # `DockerCompose.get_service_host_and_port` to read parquet files back
+    # through pyiceberg's S3 client. Avoids hardcoded host ports so this
+    # stack can coexist with docker-compose.yaml.
+    ports:
+      - "9000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+
+  minio-init:
+    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minioadmin minioadmin;
+      mc mb -p local/warehouse;
+      "
+
+  # Iceberg REST catalog (image pinned by digest — see tests/integration/compose.yaml
+  # for rationale: upstream only publishes :latest).
+  iceberg-rest:
+    image: tabulario/iceberg-rest@sha256:3b7d31bdfec626b68e97531c9778a1b9119659e456fe28545a49f6aa6a9ce472
+    depends_on:
+      minio-init:
+        condition: service_completed_successfully
+    environment:
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      AWS_REGION: us-east-1
+      CATALOG_WAREHOUSE: s3://warehouse/
+      CATALOG_IO__IMPL: org.apache.iceberg.aws.s3.S3FileIO
+      CATALOG_S3_ENDPOINT: http://minio:9000
+      CATALOG_S3_PATH__STYLE__ACCESS: "true"
+    ports:
+      - "8181"
+
+  # --- Topic Setup ---
+
+  kafka-init:
+    image: apache/kafka:3.9.0
+    depends_on:
+      kafka:
+        condition: service_healthy
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9094 --create --if-not-exists --topic test-events --partitions 8 --replication-factor 1 &&
+        echo "Waiting for consumer group coordinator..." &&
+        for i in $(seq 1 20); do
+          /opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server kafka:9094 --group millpond-test-events-events --describe >/dev/null 2>&1 && echo "Coordinator ready." && break
+          echo "  attempt $i/20..."
+          sleep 1
+        done
+
+  # --- Producer: writes sample JSON to Kafka ---
+
+  producer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        MILLPOND_VERSION: "0.0.0.dev0"
+    depends_on:
+      kafka-init:
+        condition: service_completed_successfully
+    entrypoint: python
+    command: /app/test/producer.py
+    deploy:
+      replicas: ${PRODUCER_REPLICAS:-2}
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9094
+      KAFKA_TOPIC: test-events
+      KAFKA_PARTITION_COUNT: 8
+      RECORDS_PER_SECOND: 1000
+      TOTAL_RECORDS: -1
+    healthcheck:
+      test: ["CMD-SHELL", "true"]  # producer has no HTTP server; override Dockerfile HEALTHCHECK
+      interval: 10s
+    volumes:
+      - ./test:/app/test:ro
+
+  # --- Millpond Consumer (Iceberg destination) ---
+  #
+  # Single pod for now. Two pods committing to the same Iceberg table every
+  # FLUSH_INTERVAL_MS collide on the catalog's branch-snapshot requirement
+  # more often than _write_with_retry's 3-attempt budget can absorb; that's
+  # a real issue with the IcebergSink under multi-writer load but out of
+  # scope for the test coverage patch. The DuckLake e2e uses two pods.
+
+  millpond-0:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        MILLPOND_VERSION: "0.0.0.dev0"
+    depends_on:
+      kafka-init:
+        condition: service_completed_successfully
+      minio-init:
+        condition: service_completed_successfully
+      iceberg-rest:
+        condition: service_started
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9094
+      KAFKA_TOPIC: test-events
+      REPLICA_COUNT: 1
+      POD_NAME: millpond-test-0
+      FLUSH_SIZE: 5000
+      FLUSH_INTERVAL_MS: 5000
+      MILLPOND_DESTINATION: iceberg
+      ICEBERG_CATALOG_URI: http://iceberg-rest:8181
+      ICEBERG_WAREHOUSE: s3://warehouse/
+      ICEBERG_NAMESPACE: millpond
+      ICEBERG_TABLE: events
+      MILLPOND_S3_ACCESS_KEY_ID: minioadmin
+      MILLPOND_S3_SECRET_ACCESS_KEY: minioadmin
+      MILLPOND_S3_REGION: us-east-1
+      MILLPOND_S3_ENDPOINT: http://minio:9000

--- a/justfile
+++ b/justfile
@@ -53,10 +53,15 @@ test:
 test-integration:
     uv run python -m pytest tests/integration
 
-# Run E2E test (brings up docker-compose stack automatically)
+# Run E2E test against the DuckLake stack (docker-compose.yaml).
 [group('test')]
 test-e2e:
-    uv run python -m pytest tests/e2e -v -s
+    uv run python -m pytest tests/e2e/test_e2e.py -v -s
+
+# Run E2E test against the Iceberg stack (docker-compose.iceberg.yaml).
+[group('test')]
+test-e2e-iceberg:
+    uv run python -m pytest tests/e2e/test_e2e_iceberg.py -v -s
 
 # Full CI check
 [group('test')]

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -30,6 +30,12 @@ def compose():
 def conn(compose):
     """DuckDB connection to the local DuckLake instance."""
     c = duckdb.connect()
+    # INSTALL is idempotent — required on fresh DuckDB user dirs (e.g. CI
+    # runners). Local dev machines usually have these from prior LOADs so
+    # this used to seem to work without INSTALL; CI exposed the gap.
+    c.execute("INSTALL httpfs")
+    c.execute("INSTALL ducklake")
+    c.execute("INSTALL postgres")
     c.execute("LOAD httpfs")
     c.execute("LOAD ducklake")
     c.execute("LOAD postgres")

--- a/tests/e2e/test_e2e_iceberg.py
+++ b/tests/e2e/test_e2e_iceberg.py
@@ -1,0 +1,145 @@
+"""E2E test for the full docker-compose stack with the Iceberg destination.
+
+Brings up Kafka, MinIO, iceberg-rest, producer, and Millpond (configured with
+MILLPOND_DESTINATION=iceberg) via testcontainers, then verifies records flow
+through to the Iceberg table via the REST catalog.
+
+Mirrors tests/e2e/test_e2e.py, swapping the DuckLake reader for pyiceberg.
+
+Usage:
+    just test-e2e-iceberg
+    uv run python -m pytest tests/e2e/test_e2e_iceberg.py -v -s
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+from testcontainers.compose import DockerCompose
+
+from millpond import iceberg as millpond_iceberg
+
+COMPOSE_DIR = str(Path(__file__).resolve().parents[2])
+COMPOSE_FILE = "docker-compose.iceberg.yaml"
+
+NAMESPACE = "millpond"
+TABLE_NAME = "events"
+
+
+@pytest.fixture(scope="module")
+def compose():
+    """Bring up the full Iceberg stack, yield, then tear down."""
+    with DockerCompose(COMPOSE_DIR, compose_file_name=COMPOSE_FILE, build=True) as c:
+        rest_host, rest_port = c.get_service_host_and_port("iceberg-rest", 8181)
+        minio_host, minio_port = c.get_service_host_and_port("minio", 9000)
+        catalog_uri = f"http://{rest_host}:{rest_port}"
+        minio_endpoint = f"http://{minio_host}:{minio_port}"
+        yield catalog_uri, minio_endpoint
+
+
+@pytest.fixture(scope="module")
+def catalog(compose):
+    """PyIceberg REST catalog client pointed at the compose stack."""
+    catalog_uri, minio_endpoint = compose
+    cat = millpond_iceberg.connect(
+        catalog_uri=catalog_uri,
+        warehouse="s3://warehouse/",
+        s3_access_key_id="minioadmin",
+        s3_secret_access_key="minioadmin",
+        s3_region="us-east-1",
+        s3_endpoint=minio_endpoint,
+    )
+    yield cat
+
+
+def _get_count(catalog) -> int:
+    """Return row count, or 0 if the table doesn't exist yet."""
+    from pyiceberg.exceptions import NoSuchTableError
+
+    try:
+        table = catalog.load_table((NAMESPACE, TABLE_NAME))
+        return table.scan().to_arrow().num_rows
+    except NoSuchTableError:
+        return 0
+
+
+def _get_columns(catalog) -> set[str]:
+    from pyiceberg.exceptions import NoSuchTableError
+
+    try:
+        table = catalog.load_table((NAMESPACE, TABLE_NAME))
+        return {f.name for f in table.schema().fields}
+    except NoSuchTableError:
+        return set()
+
+
+def _wait_for_records(catalog, timeout: int = 120) -> int:
+    deadline = time.monotonic() + timeout
+    while True:
+        count = _get_count(catalog)
+        if count > 0:
+            return count
+        if time.monotonic() > deadline:
+            pytest.fail(f"No records appeared in Iceberg table within {timeout}s")
+        time.sleep(2)
+
+
+def _wait_for_count_increase(catalog, baseline: int, timeout: int = 60) -> int:
+    deadline = time.monotonic() + timeout
+    while True:
+        count = _get_count(catalog)
+        if count > baseline:
+            return count
+        if time.monotonic() > deadline:
+            pytest.fail(f"Count did not increase beyond {baseline} within {timeout}s")
+        time.sleep(2)
+
+
+@pytest.fixture(scope="module")
+def initial_count(catalog):
+    """Wait for records once, shared across all tests."""
+    return _wait_for_records(catalog, timeout=120)
+
+
+@pytest.mark.e2e
+class TestE2EIceberg:
+    def test_records_ingested(self, initial_count):
+        """Records should appear in the Iceberg table after the stack starts."""
+        assert initial_count > 0
+
+    def test_ingestion_ongoing(self, catalog, initial_count):
+        """Record count should increase over time as the producer keeps writing."""
+        count2 = _wait_for_count_increase(catalog, initial_count)
+        assert count2 > initial_count
+
+    def test_expected_columns(self, catalog, initial_count):
+        """Table should have the producer columns plus Iceberg's `_inserted_at`
+        and the four partition columns."""
+        columns = _get_columns(catalog)
+        expected = {
+            # Producer top-level fields
+            "uuid", "event", "team_id", "distinct_id", "timestamp",
+            # IcebergSink-injected metadata
+            "_inserted_at", "year", "month", "day", "hour",
+        }
+        missing = expected - columns
+        assert not missing, f"Missing columns: {missing}"
+
+    def test_data_integrity(self, catalog, initial_count):
+        """Core fields should not be null in a sample."""
+        table = catalog.load_table((NAMESPACE, TABLE_NAME))
+        sample = table.scan(limit=10).to_arrow()
+        assert sample.num_rows > 0
+        for col in ("uuid", "event", "team_id"):
+            assert sample.column(col).null_count == 0, f"unexpected nulls in {col}"
+
+    def test_partition_layout_is_hive_style(self, catalog, initial_count):
+        """Data file paths should include year=/month=/day=/hour= segments."""
+        table = catalog.load_table((NAMESPACE, TABLE_NAME))
+        files = list(table.scan().plan_files())
+        assert files, "expected at least one data file after ingestion"
+        file_path = files[0].file.file_path
+        for segment in ("year=", "month=", "day=", "hour="):
+            assert segment in file_path, f"{segment} missing from {file_path}"

--- a/tests/integration/test_iceberg_integration.py
+++ b/tests/integration/test_iceberg_integration.py
@@ -21,6 +21,8 @@ import pytest
 from testcontainers.compose import DockerCompose
 
 from millpond import iceberg
+from millpond.config import Config
+from millpond.iceberg import IcebergSink
 
 
 def _wait_for_http(url: str, timeout: float = 60.0) -> None:
@@ -80,6 +82,49 @@ def _connect(catalog_uri: str, minio_endpoint: str):
         s3_secret_access_key="minioadmin",
         s3_region="us-east-1",
         s3_endpoint=minio_endpoint,
+    )
+
+
+def _make_iceberg_cfg(catalog_uri: str, minio_endpoint: str, table_name: str) -> Config:
+    """Build a Config that targets the integration-test catalog/MinIO.
+
+    Mirrors the env-var contract enforced by ``config.load()`` so the
+    Sink-protocol path is exercised end-to-end. DuckLake fields stay None.
+    """
+    return Config(
+        bootstrap_servers="unused:9092",
+        topic="unused",
+        group_id="unused",
+        replica_count=1,
+        ordinal=0,
+        destination="iceberg",
+        ducklake_table=None,
+        ducklake_data_path=None,
+        ducklake_connection=None,
+        rds_host=None,
+        rds_port=None,
+        rds_database=None,
+        rds_username=None,
+        rds_password=None,
+        partition_by=None,
+        iceberg_catalog_uri=catalog_uri,
+        iceberg_warehouse="s3://warehouse/",
+        iceberg_namespace="millpond",
+        iceberg_table=table_name,
+        iceberg_table_location=None,
+        iceberg_catalog_token=None,
+        s3_access_key_id="minioadmin",
+        s3_secret_access_key="minioadmin",
+        s3_region="us-east-1",
+        s3_endpoint=minio_endpoint,
+        flush_size=1,
+        flush_interval_ms=1,
+        fetch_min_bytes=1,
+        fetch_max_wait_ms=1,
+        consume_batch_size=1,
+        stats_interval_ms=1,
+        broker_source="",
+        kafka_config_overrides=(),
     )
 
 
@@ -144,3 +189,72 @@ class TestIcebergIntegration:
         # Path should look like: s3://warehouse/.../year=YYYY/month=MM/day=DD/hour=HH/<uuid>.parquet
         for segment in ("year=", "month=", "day=", "hour="):
             assert segment in file_path, f"{segment} missing from data file path: {file_path}"
+
+
+@pytest.mark.integration
+class TestIcebergSinkIntegration:
+    """Exercise the `IcebergSink` protocol object — the entry point main.py uses.
+
+    `TestIcebergIntegration` above covers the library functions; this class
+    covers the Sink wrapper: construction from a Config, `write()` round-trip,
+    schema evolution across writes, and `reset_caches()` after a forced
+    invalidation. Same compose stack, different surface.
+    """
+
+    def test_sink_constructs_and_round_trips(self, stack):
+        catalog_uri, minio_endpoint = stack
+        cfg = _make_iceberg_cfg(catalog_uri, minio_endpoint, "sink_round_trip")
+        sink = IcebergSink(cfg)
+
+        batch = pa.table({"event": ["click", "view"], "team_id": [10, 20]})
+        sink.write(batch)
+
+        # Re-read via the same catalog to confirm the commit landed.
+        catalog = _connect(catalog_uri, minio_endpoint)
+        rows = catalog.load_table(("millpond", "sink_round_trip")).scan().to_arrow()
+        assert rows.num_rows == 2
+        assert sorted(rows.column("event").to_pylist()) == ["click", "view"]
+        sink.close()
+
+    def test_sink_evolves_schema_across_writes(self, stack):
+        """First batch has {event, team_id}; second adds `distinct_id`.
+
+        The Sink's internal SchemaManager should pick up the new column on
+        the second write and `update_schema` the table accordingly.
+        """
+        catalog_uri, minio_endpoint = stack
+        cfg = _make_iceberg_cfg(catalog_uri, minio_endpoint, "sink_evolve")
+        sink = IcebergSink(cfg)
+
+        sink.write(pa.table({"event": ["a"], "team_id": [1]}))
+        sink.write(pa.table({"event": ["b"], "team_id": [2], "distinct_id": ["d-2"]}))
+
+        catalog = _connect(catalog_uri, minio_endpoint)
+        rows = catalog.load_table(("millpond", "sink_evolve")).scan().to_arrow()
+        assert rows.num_rows == 2
+        assert "distinct_id" in rows.column_names
+        # First row's distinct_id was unset at write time → null after evolution.
+        d = dict(zip(rows.column("event").to_pylist(), rows.column("distinct_id").to_pylist(), strict=True))
+        assert d["a"] is None
+        assert d["b"] == "d-2"
+        sink.close()
+
+    def test_sink_reset_caches_recovers_after_invalidation(self, stack):
+        """`reset_caches()` is what main.py calls after a write failure.
+
+        Verifies post-reset writes continue to succeed against the same table
+        (cache rebuilt from the catalog).
+        """
+        catalog_uri, minio_endpoint = stack
+        cfg = _make_iceberg_cfg(catalog_uri, minio_endpoint, "sink_reset")
+        sink = IcebergSink(cfg)
+
+        sink.write(pa.table({"event": ["pre"], "team_id": [1]}))
+        sink.reset_caches()
+        sink.write(pa.table({"event": ["post"], "team_id": [2]}))
+
+        catalog = _connect(catalog_uri, minio_endpoint)
+        rows = catalog.load_table(("millpond", "sink_reset")).scan().to_arrow()
+        assert rows.num_rows == 2
+        assert sorted(rows.column("event").to_pylist()) == ["post", "pre"]
+        sink.close()


### PR DESCRIPTION
## Summary

PR #59 added an Iceberg sink but the test suites that would exercise it were not extended. CI also explicitly skipped both integration and e2e (\`pytest -m \"not integration and not e2e\"\`), so even the existing DuckLake e2e never ran on a runner. This PR fixes both gaps.

### What's covered now

| Layer | Before | After |
|---|---|---|
| \`tests/integration/test_iceberg_integration.py\` | drove \`millpond.iceberg.connect/write\` directly | adds \`TestIcebergSinkIntegration\` — constructs \`IcebergSink(cfg)\` from a real \`Config\` and exercises connect/write/schema-evolution/reset_caches |
| \`tests/e2e/\` | DuckLake only | + \`test_e2e_iceberg.py\` against \`docker-compose.iceberg.yaml\` (Kafka + MinIO + iceberg-rest + producer + millpond pod); reads back via pyiceberg, verifies ingestion/columns/partition layout |
| \`docker-compose.iceberg.yaml\` | n/a | new — mirrors the DuckLake stack with Iceberg env vars and ephemeral host ports so it coexists with the DuckLake compose |
| \`justfile\` | one \`test-e2e\` recipe | split into \`test-e2e\` (DuckLake) + \`test-e2e-iceberg\` |
| \`.github/workflows/ci.yaml\` | unit only | + \`integration\` job, + \`e2e\` matrix (ducklake, iceberg) — gating on every push and PR |

### Caught a real bug

Wiring up the Iceberg e2e surfaced multi-writer commit contention: two pods committing to the same Iceberg table at \`FLUSH_INTERVAL_MS=5000\` collide on PyIceberg's branch-snapshot requirement (\`CommitFailedException: branch main has changed\`) more often than \`_write_with_retry\`'s 3-attempt budget can absorb. The Iceberg compose runs a single pod for now; the DuckLake compose still uses two (its commits serialise through Postgres-backed catalog locks). Documented under \"Next steps\" in the README. Fixing requires more retry headroom with jitter, or partition-aware layouts so writers aren't contending on the same snapshot.

### Pre-push checklist

\`AGENT.md\` now lists \`test-integration\`, \`test-e2e\`, and \`test-e2e-iceberg\` alongside lint/format/unit. All run locally in <2 minutes total.

## Test plan

- [ ] CI: \`check\` job (unit + lint + format) passes
- [ ] CI: \`integration\` job passes
- [ ] CI: \`e2e (ducklake)\` matrix leg passes
- [ ] CI: \`e2e (iceberg)\` matrix leg passes
- [ ] CI: \`build\` job passes
- [ ] Locally: \`just test-integration\` → 6/6 (~8s)
- [ ] Locally: \`just test-e2e\` → 4/4 (~54s)
- [ ] Locally: \`just test-e2e-iceberg\` → 5/5 (~52s)