### PR TITLE
Stress-test Lakekeeper concurrent commits + writeup of expected production behaviour

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       run: uv run ruff check millpond/
 
     - name: Unit tests
-      run: uv run pytest -m "not integration and not e2e"
+      run: uv run pytest -m "not integration and not e2e and not stress"
 
   dependency-review:
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -63,6 +63,12 @@ test-e2e:
 test-e2e-iceberg:
     uv run python -m pytest tests/e2e/test_e2e_iceberg.py -v -s
 
+# Stress-test Lakekeeper under concurrent commits (manual; not in CI).
+# Brings up tests/stress/compose.lakekeeper.yaml, sweeps writer counts.
+[group('test')]
+stress-lakekeeper:
+    uv run python -m pytest tests/stress/test_lakekeeper_concurrent.py -v -s -m stress
+
 # Full CI check
 [group('test')]
 ci: fmt-check lint test

--- a/millpond/iceberg.py
+++ b/millpond/iceberg.py
@@ -99,6 +99,13 @@ def connect(
         "s3.access-key-id": s3_access_key_id,
         "s3.secret-access-key": s3_secret_access_key,
         "s3.region": s3_region,
+        # Pin the FileIO implementation. Without this, some catalog
+        # implementations (Lakekeeper) return responses that lead PyIceberg
+        # to route writes through `FsspecFileIO`, which depends on `s3fs`
+        # — not a dependency we want to carry. PyArrowFileIO uses PyArrow's
+        # S3 client, which is already pulled in transitively and respects
+        # the `s3.access-key-id` / `s3.endpoint` properties above.
+        "py-io-impl": "pyiceberg.io.pyarrow.PyArrowFileIO",
     }
     if catalog_token:
         props["token"] = catalog_token

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,14 @@ select = ["E", "F", "I", "UP"]
 markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
     "e2e: marks tests as E2E tests requiring docker-compose stack",
+    "stress: characterisation tests that drive a docker-compose stack under contention (manual, not run in CI)",
 ]
 pythonpath = ["tools"]
+testpaths = ["tests"]
+# Keep collection scoped to `tests/` only — the repo also contains a
+# cloned `lakekeeper/` source tree for cross-reference, and its own
+# tests/ import deps (pydantic_settings, etc.) we don't carry.
+norecursedirs = ["lakekeeper", ".venv", "node_modules"]
 
 [tool.uv]
 constraint-dependencies = [

--- a/tests/stress/FINDINGS.md
+++ b/tests/stress/FINDINGS.md
@@ -1,0 +1,240 @@
+# Lakekeeper concurrent-commit characterisation
+
+Empirical measurements of Lakekeeper's behaviour under N concurrent Iceberg
+table commits, with cross-reference to production load shapes and the
+structural floors imposed by the Iceberg spec.
+
+## TL;DR — expected production behaviour
+
+Projecting today's `IcebergSink.write()` path against Lakekeeper, using observed
+per-pod cadence (~11 s/flush, ~0.09 commits/s/pod) and measured catalog latency
+(p50 ~100 ms, p95 ~400 ms):
+
+| N pods writing one table | Retry-exhaustion rate (3 attempts, p95-anchored) | Operational characterisation |
+|------:|----:|---|
+|   2 |  ~0.03% | invisible |
+|   8 |  ~1.6%  | minor noise |
+|  16 |  ~8.5%  | edge of viability |
+|  **32**  |  **~33%**   | **~1 in 3 flushes ends in pod restart + Kafka offset replay + downstream duplicates** |
+|  64 | ~73%   | pods restart more often than they ingest |
+| 128 | ~97% + catalog saturates at the structural ~5–10 commits/s/table ceiling |  |
+
+The cliff sits at **N ≈ 16 (p95) to N ≈ 64 (p50)**. Current production load is over the p95 cliff. Using p50 instead moves the cliff right by ~4× but doesn't change the curve shape.
+
+Two structural facts that bound any version of this:
+
+- **Catalog choice doesn't change the shape.** The same optimistic-concurrency model holds across Lakekeeper, tabulario/iceberg-rest, Glue, and any current Iceberg REST catalog. Switching implementations changes the latency constants, not the 1/N contention curve we measured.
+- **Three S3 PUTs per commit are irreducible.** Each Iceberg commit writes a new manifest, manifest list, and metadata.json. This bounds *any* Iceberg catalog at roughly 5–10 commits/s/table independent of vendor, language, or hardware tier.
+
+Rest of the document derives these numbers and details the structural facts.
+
+## What was measured
+
+- Catalog: Lakekeeper `quay.io/lakekeeper/catalog:latest-main`, Postgres 17 backend, MinIO storage
+- Topology: catalog, Postgres, MinIO, and N writer processes all on the same docker bridge network (matches production deployment shape)
+- Workload: 100 rows × 50 batches per writer against a single shared Iceberg table, fresh table per writer-count run
+- Retries: **disabled** in the driver — we characterise raw catalog behaviour, not what Millpond's `_write_with_retry` would absorb
+- Driver process model: `multiprocessing.spawn`, one `IcebergSink` per writer process (separate pyiceberg catalog clients)
+- Test harness: `tests/stress/test_lakekeeper_concurrent.py` (host) + `tests/stress/stress_driver.py` (in-network driver). Reproduce with `just stress-lakekeeper`.
+
+## Raw measurements
+
+| N writers | success | conflict | error | p50 ms | p95 ms | p99 ms |
+|----------:|--------:|---------:|------:|-------:|-------:|-------:|
+|  2 |  53.0% |  47.0% | 0 |  82 | 194 | 302 |
+|  4 |  26.5% |  73.5% | 0 | 103 | 229 | 336 |
+|  8 |  13.0% |  87.0% | 0 | 114 | 187 | 264 |
+| 16 |   6.6% |  93.4% | 0 |  98 | 138 | 162 |
+| 32 |   4.6% |  95.4% | 0 | 190 | 407 | 539 |
+
+Per-attempt success rate scales as ~1/N — the signature of naive optimistic concurrency under uniform-arrival concurrent commits. The p50 commit latency holds around 100ms; p95 climbs into the 200–400ms band under contention. Zero non-conflict errors at every N — the stack is healthy, the contention is the only thing failing requests.
+
+### Two regimes (worst case vs production cadence)
+
+The stress test is deliberately a **worst-case characterisation**: writers fire commits as fast as possible, with no flush-cadence pacing. In that regime, per-pod commit rate is bounded by `1 / commit_latency` ≈ 10 commits/sec; fleet rate is N × 10/s; collisions are near-certain at any meaningful N. The 53% success at N=2 isn't a production prediction — it's the answer to "if both writers commit constantly, how often does one win?"
+
+Production behaviour is set by **flush cadence**, not by catalog speed. A pod can't commit faster than it can fill its `FLUSH_SIZE` buffer or reach `FLUSH_INTERVAL_MS`. So the collision math projects very differently when the input rate is rate-limited by data inflow:
+
+- Stress test: `rate ≈ 1 / commit_latency` → `collision ≈ 1 - exp(-N × ~10)` ≈ "always"
+- Production: `rate ≈ N / per_pod_flush_cadence` → `collision ≈ 1 - exp(-N × commit_latency / cadence)`
+
+Both numbers are valid; they answer different questions. The test tells you the *shape* of the contention curve; the production parameters tell you where you sit on that curve.
+
+## Catalog concurrency model
+
+Inspection of Lakekeeper's commit handler — `crates/lakekeeper/src/implementations/postgres/tabular/table/commit.rs` — shows the catalog uses Postgres-level optimistic concurrency:
+
+```sql
+UPDATE tabular
+   SET metadata_location = $new
+ WHERE warehouse_id = $w AND tabular_id = $t
+   AND metadata_location IS NOT DISTINCT FROM $old
+```
+
+If another writer has advanced `metadata_location` between when this commit loaded the parent snapshot and when it issued the UPDATE, the UPDATE matches zero rows. Lakekeeper detects this in `verify_commit_completeness` and returns HTTP 409 with type `ConcurrentUpdateError`.
+
+This is the same algorithmic contract as `tabulario/iceberg-rest`. The implementations differ in detection mechanism (Postgres `UPDATE … WHERE` vs in-JVM snapshot-id check) and in the latency constants, not in concurrency semantics. There is no server-side queueing of non-conflicting appends in current Lakekeeper.
+
+## Structural floor on commit latency
+
+Per the Iceberg spec, every commit to a table produces:
+
+1. A new **manifest file** (entries for the data files being added in this commit)
+2. A new **manifest list** (references the new manifest + the previous snapshot's manifests)
+3. A new **metadata.json** (snapshot history + current snapshot pointer + schemas + partition specs)
+
+The catalog must write all three to S3 before flipping the metadata pointer. That's **three S3 PUTs per commit** as an irreducible cost under fast-append (see below) — true of Lakekeeper, true of tabulario, true of Glue, true of any future Iceberg catalog. At typical S3 small-object PUT latency (50–150ms each), the floor on commit latency is roughly 150–450ms, with parallelism potentially overlapping some.
+
+The implied ceiling on sustained single-table commit rate is therefore **~5–10 commits/sec/table**, against any Iceberg catalog implementation. Above that, requests queue server-side or contend client-side.
+
+### Fast-append vs merge-append
+
+PyIceberg's `Table.append()` resolves to a fast-append snapshot producer by default (`pyiceberg/table/__init__.py:441`; `MANIFEST_MERGE_ENABLED_DEFAULT = False`). The current `IcebergSink.write()` path inherits this without setting any table property, so **every commit is a fast-append**.
+
+The two variants differ in what gets read/written per commit:
+
+| Step | Fast-append (current) | Merge-append |
+|---|---|---|
+| Reads existing manifests at commit time | none (referenced by URL only) | reads merge-candidates ≤ `commit.manifest.min-count-to-merge` (default 100) |
+| Manifest writes per commit | 1 (the new one) | 1 + any merged outputs |
+| Manifest list writes per commit | 1 | 1 |
+| metadata.json writes per commit | 1 | 1 |
+| Manifest count growth per commit | +1 | 0 or net negative |
+
+Fast-append minimises per-commit S3 work; merge-append is more expensive at write time but keeps manifest count bounded. Java Iceberg defaults to merge-append; PyIceberg defaults to fast-append.
+
+The trade-off shows up read-side: the manifest list grows by one entry per commit, and readers planning a scan must list/open all of them. This is what makes `Table.rewrite_manifests()` compaction operationally important for any deployment that commits frequently — the more so on fast-append.
+
+### Metadata size growth
+
+Metadata file sizes — and therefore the floor latency — grow over time as the table accumulates snapshot history and manifests-since-last-compaction. PyIceberg exposes the maintenance primitives:
+
+- `Table.expire_snapshots()` — drop old snapshot entries from metadata.json
+- `Table.rewrite_manifests()` — compact many small manifests into fewer large ones
+- `Table.delete_orphan_files()` — sweep parquet files no live snapshot references
+
+The DuckLake analog is `tools/ducklake_maintenance.py`; no Iceberg counterpart exists in this repo today.
+
+## Production-scale interpretation
+
+Representative observed load for one Millpond pod on a large topic, aggregated over ~19,000 flushes:
+
+| Per-pod metric | Value |
+|---|---|
+| Mean flush cadence (`elapsed` per flush) | ~11 s |
+| Min / max flush cadence | 1.9 s / 37.1 s |
+| Mean write phase (`write`, S3 PUT bundled with current catalog commit) | ~3.3 s |
+| Records per flush | ~29 k |
+| Bytes per flush | ~256 MB |
+| Per-pod commit rate | ~0.09 commits/s |
+| Per-pod data throughput | ~23 MB/s |
+
+Per-pod flush is S3-bound (the parquet PUT dominates the `write` phase), not catalog-bound. Doubling the pod count would roughly halve buffer-fill time per pod → fleet commit rate stays in the same band. Multiple Millpond deployments share one catalog → catalog-side contention compounds across tables.
+
+Projecting onto the contention curve. Fleet rate per table = N × 0.09/s, against the measured p95 commit latency of 400 ms; collision probability per attempt = `1 - exp(-rate × latency)`; post-retry exhaustion probability under the current 3-attempt deterministic-backoff budget approximated as the third power of the per-attempt rate (true with independent attempts; underestimates correlated retries):
+
+| N pods | Fleet rate (×/s) | rate × p95 latency | Per-attempt collision | After 3 retries |
+|------:|------:|------:|------:|------:|
+|   2 | 0.18 | 0.07 |  ~7% |  ~0.03% |
+|   4 | 0.36 | 0.14 | ~13% |  ~0.3% |
+|   8 | 0.73 | 0.29 | ~25% |  ~1.6% |
+|  16 | 1.45 | 0.58 | ~44% |  ~8.5% |
+|  32 | 2.91 | 1.16 | ~69% |  ~33% |
+|  64 | 5.81 | 2.32 | ~90% |  ~73% |
+| 128 | 11.6 | 4.65 | ~99% |  ~97% |
+
+The scaling cliff is around N ≈ 16: below that, retry headroom absorbs contention; above that, retry exhaustion starts forcing pod restarts (re-processing Kafka offsets → downstream duplicates) at a rate that scales rapidly with N.
+
+Using p50 (100 ms) instead of p95 in the same projection moves the cliff right by roughly a factor of 4 — N ≈ 64 instead of N ≈ 16 — but the curve shape is the same.
+
+The implied **single-table commit-rate ceiling of ~5–10/s** from the structural floor section means that as N grows beyond ~50, the catalog itself becomes the bottleneck and the per-pod commit cadence stretches regardless of how much data is buffered.
+
+## Iceberg vs DuckLake atomicity
+
+The current `IcebergSink.write()` calls PyIceberg's `Table.append(batch)`, which is a two-step operation:
+
+1. PyArrow writes the parquet file to S3 (under the table's location)
+2. PyIceberg issues a `POST` to the catalog committing a new snapshot that references the file by URL
+
+The catalog never copies or scans the parquet bytes — it stores the URL and per-file statistics extracted from the parquet footer. This is **register, not materialize**.
+
+| Phase | DuckLake | Iceberg `append()` | Iceberg `add_files()` |
+|---|---|---|---|
+| Data lands on S3 | inside Postgres transaction | step 1 (PyArrow) | step 1 (PyArrow), can be batched independently |
+| Catalog records it | same transaction | step 2 (POST) | step 2 (POST) |
+| Orphan possible between phases? | no | yes (one parquet) | yes (K parquet) |
+| Kafka offset committed? | only after INSERT returns | only after `append()` returns | only after `add_files()` returns |
+| Cleanup tool | `tools/ducklake_maintenance.py` | none in repo (PyIceberg `delete_orphan_files()`) | same |
+
+End-to-end progress semantics — Kafka offsets advance only after the lake-side write returns success — are preserved in all three modes. What changes between DuckLake and Iceberg is the possibility of S3 files that exist but were never registered (from retries on commit conflict, or from a pod crash between PyArrow's PUT and the catalog POST). Today's `_write_with_retry` already produces one orphan per failed attempt, since each `Table.append()` writes a fresh parquet (new UUID) before issuing the commit.
+
+## `add_files` batching
+
+PyIceberg's `Table.add_files(file_paths=[...])` registers pre-existing S3 parquet files with the table without re-writing them. Implementation (`pyiceberg/io/pyarrow.py:parquet_file_to_data_file`):
+
+```
+add_files([paths]) →
+  for path in paths:
+    pq.read_metadata(stream)   ← reads parquet footer only (~tens of KB)
+    extract stats from footer  ← row count, col min/max, null counts
+    build DataFile (in-memory)
+  commit ONE snapshot containing N DataFiles
+```
+
+No data scan — the footer already carries the statistics Iceberg's manifest entries need. Per-file cost is one S3 GET-Range on the footer, a few ms.
+
+Implication for the rate math: a pod that buffers K parquet files locally on S3 before issuing a single `add_files()` call pays one commit per K files. The fleet commit rate drops by K× at the same data throughput.
+
+| K (files per commit) | Per-pod commit cadence at current data rate | Fleet rate (32 pods) | Per-attempt collision at p50 100ms | Per-attempt collision at p95 400ms |
+|---:|---:|---:|---:|---:|
+|  1 (today) |  13s | 2.46/s | ~22% | ~63% |
+|  5 |  65s | 0.49/s |  ~5% | ~18% |
+| 10 | 130s | 0.25/s | ~2.5% |  ~9% |
+| 20 | 260s | 0.12/s | ~1.2% |  ~5% |
+
+`check_duplicate_files=False` should be passed when the writer knows the files are fresh — the default triggers a `data_files` scan over the live snapshot to verify the paths aren't already referenced, which scales with table size.
+
+Partition discovery in `add_files` derives each file's partition tuple from the column min/max in the parquet footer. This only works cleanly if a parquet file's rows are **single-partition** (all rows share the same `year/month/day/hour`). Today's `IcebergSink._add_metadata_columns` stamps a single `_inserted_at` per batch, so per-flush files are single-partition by construction; the invariant must be preserved if files are batched.
+
+## Levers
+
+| Lever | Effect on commit rate | Effect on latency floor | Atomicity | Cost |
+|---|---|---|---|---|
+| Larger `FLUSH_SIZE` / `FLUSH_INTERVAL_MS` | Linear reduction in commit rate | None | Preserved | Larger buffer memory; longer visibility lag |
+| `add_files(K files per commit)` | K× reduction in commit rate | None | Preserved (Kafka offsets gated on `add_files` return) | K orphans per failed commit instead of 1; deferred visibility |
+| Jittered retry backoff in `_write_with_retry` | None | None | Preserved | Reduces retry-storm probability under contention |
+| `expire_snapshots` + `rewrite_manifests` cron | None | Keeps floor near ~2 S3 PUTs minimum | Preserved | New maintenance job to deploy/monitor |
+| Upstream Lakekeeper patch: server-side merge of non-conflicting appends | None (still 5–10/s/table ceiling) | None (still two S3 PUTs) | Preserved | Open-source contribution work; outside this repo |
+| Table sharding (per-ordinal or per-namespace) | Multiplies ceiling by shard count | None | Preserved per shard | Readers must UNION or use a logical view |
+| Single-committer fanout (separate service consumes file-ready notifications) | Eliminates client-side contention | None | Kafka offset commit decouples from catalog commit — visibility lag, separate operational signal | New service; introduces inter-component coordination |
+| Catalog switch to one with native server-side commit queuing | Depends on impl | Depends on impl | Preserved | Operational lift |
+
+## Code changes already on this branch
+
+To make Millpond work with Lakekeeper at all (independent of any architectural decision), `millpond/iceberg.py` was changed to pin PyIceberg's FileIO:
+
+```python
+"py-io-impl": "pyiceberg.io.pyarrow.PyArrowFileIO",
+```
+
+Without this, Lakekeeper's storage-profile response routes PyIceberg through `FsspecFileIO`, which depends on the `s3fs` package (not currently a Millpond dependency). The pin forces PyArrow's S3 client, which already ships with PyIceberg's `[pyarrow]` extra.
+
+The warehouse config used in the stress compose disables `remote-signing-enabled` for the same reason: Lakekeeper's default S3V4 remote-signer triggers the fsspec routing. Production warehouses created via the management API will need the same setting unless `s3fs` is added as a runtime dep.
+
+## Caveats on the measurements
+
+1. **Local laptop.** Lakekeeper, Postgres, MinIO, and all writers share one machine's CPU and a docker bridge network. Production likely sees lower commit latency from a dedicated Postgres, possibly higher from cross-AZ networking. Net direction unknown until measured in a target environment.
+2. **Synthetic arrival pattern.** Writers commit as fast as possible (no flush-interval pacing). Real Millpond's `FLUSH_SIZE` / `FLUSH_INTERVAL_MS` produce a more bursty steady state; the 1/N law from this test is an upper bound on contention probability under uniform arrival.
+3. **No schema evolution.** All workers share one fixed schema. Concurrent schema changes are a separate commit class with their own contention story; not characterised here.
+4. **Single table.** Catalog-side contention across multiple concurrently-written tables (shared Postgres, shared S3 metadata-write bandwidth) is not captured by these runs.
+5. **One Lakekeeper version.** `quay.io/lakekeeper/catalog:latest-main` at the commit pinned during this work. Upstream changes to commit handling would invalidate the latency constants.
+
+## Reproducibility
+
+```
+just stress-lakekeeper                              # runs the full N=2…32 sweep
+cat tests/stress/summary.json                       # machine-readable last-run results
+docker compose -f tests/stress/compose.lakekeeper.yaml --profile driver down -v
+```
+
+Adjust `STRESS_WRITER_COUNTS`, `STRESS_COMMITS_PER_WRITER`, `STRESS_ROWS_PER_COMMIT` in `tests/stress/compose.lakekeeper.yaml` to extend the sweep.

--- a/tests/stress/compose.lakekeeper.yaml
+++ b/tests/stress/compose.lakekeeper.yaml
@@ -1,0 +1,173 @@
+# Stress-test stack for characterising Lakekeeper's concurrent-commit
+# behaviour. Postgres + MinIO + Lakekeeper, with the catalog bootstrap
+# and warehouse creation baked into init containers so the Python driver
+# can start hammering as soon as `lakekeeper-init` exits.
+#
+# No Kafka, no millpond container — the test drives IcebergSink directly
+# from N processes. What's being measured is the catalog's behaviour
+# under N concurrent appends, not the full pipeline.
+#
+# Modelled on lakekeeper/examples/minimal/docker-compose.yaml. Stripped
+# of Jupyter / Trino / Starrocks and renamed services to avoid clashing
+# with other compose stacks on the same dev machine.
+
+services:
+  lakekeeper-db:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -p 5432 -d postgres"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    tmpfs:
+      - /var/lib/postgresql/data
+
+  lakekeeper-minio:
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z
+    environment:
+      MINIO_ROOT_USER: minio-root-user
+      MINIO_ROOT_PASSWORD: minio-root-password
+    command: ["server", "--console-address", ":9001", "/data"]
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    # Loopback-only ephemeral port — pyiceberg's S3 client in the test
+    # process resolves this through testcontainers to read data files.
+    ports:
+      - "127.0.0.1::9000"
+
+  lakekeeper-createbuckets:
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z
+    depends_on:
+      lakekeeper-minio:
+        condition: service_healthy
+    restart: "no"
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://lakekeeper-minio:9000 minio-root-user minio-root-password;
+      mc mb --ignore-existing local/warehouse;
+      "
+
+  lakekeeper-migrate:
+    image: quay.io/lakekeeper/catalog:latest-main
+    environment:
+      LAKEKEEPER__PG_ENCRYPTION_KEY: not-secret-for-test
+      LAKEKEEPER__PG_DATABASE_URL_READ: postgresql://postgres:postgres@lakekeeper-db:5432/postgres
+      LAKEKEEPER__PG_DATABASE_URL_WRITE: postgresql://postgres:postgres@lakekeeper-db:5432/postgres
+      RUST_LOG: info
+    restart: "no"
+    command: ["migrate"]
+    depends_on:
+      lakekeeper-db:
+        condition: service_healthy
+
+  lakekeeper:
+    image: quay.io/lakekeeper/catalog:latest-main
+    environment:
+      LAKEKEEPER__PG_ENCRYPTION_KEY: not-secret-for-test
+      LAKEKEEPER__PG_DATABASE_URL_READ: postgresql://postgres:postgres@lakekeeper-db:5432/postgres
+      LAKEKEEPER__PG_DATABASE_URL_WRITE: postgresql://postgres:postgres@lakekeeper-db:5432/postgres
+      RUST_LOG: info
+    command: ["serve"]
+    healthcheck:
+      test: ["CMD", "/home/nonroot/lakekeeper", "healthcheck"]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+      start_period: 5s
+    depends_on:
+      lakekeeper-migrate:
+        condition: service_completed_successfully
+      lakekeeper-db:
+        condition: service_healthy
+      lakekeeper-minio:
+        condition: service_healthy
+      lakekeeper-createbuckets:
+        condition: service_completed_successfully
+    ports:
+      - "127.0.0.1::8181"
+
+  # Accept ToU + initialise the catalog. Made idempotent because
+  # `docker compose run` re-creates init containers across invocations
+  # (the host test brings up the stack once, then runs the driver, which
+  # triggers another dependency resolution); the second bootstrap POST
+  # would otherwise 409 and trip exit 22 from curl -f.
+  lakekeeper-bootstrap:
+    image: curlimages/curl
+    depends_on:
+      lakekeeper:
+        condition: service_healthy
+    restart: "no"
+    entrypoint: ["sh", "-c"]
+    command:
+      - |
+        code=$$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+          http://lakekeeper:8181/management/v1/bootstrap \
+          -H "Content-Type: application/json" \
+          --data '{"accept-terms-of-use": true}')
+        echo "bootstrap returned $$code"
+        # 2xx = first-time success; 4xx = already bootstrapped (idempotent).
+        case "$$code" in 2*|4*) exit 0 ;; *) exit 1 ;; esac
+
+  # In-network driver. Uses the millpond Dockerfile so it has the same
+  # iceberg.py / IcebergSink the binary uses. Runs the stress sweep, writes
+  # JSON reports to a bind-mounted /results directory the host reads back.
+  # Profile-gated so plain `docker compose up` doesn't start it.
+  stress-driver:
+    profiles: ["driver"]
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+      args:
+        MILLPOND_VERSION: "0.0.0.dev0"
+    depends_on:
+      lakekeeper:
+        condition: service_healthy
+      lakekeeper-warehouse:
+        condition: service_completed_successfully
+    entrypoint: ["python", "/app/tests/stress/stress_driver.py"]
+    environment:
+      LK_CATALOG_URI: http://lakekeeper:8181/catalog
+      LK_MINIO_ENDPOINT: http://lakekeeper-minio:9000
+      LK_WAREHOUSE: stress
+      LK_NAMESPACE: stress_ns
+      STRESS_WRITER_COUNTS: "2,4,8,16,32"
+      STRESS_COMMITS_PER_WRITER: "50"
+      STRESS_ROWS_PER_COMMIT: "100"
+    volumes:
+      # Mount the driver into the image so we don't have to rebuild on edits.
+      - ./stress_driver.py:/app/tests/stress/stress_driver.py:ro
+
+  # Create the warehouse the stress test will write into. The
+  # storage-profile / storage-credential fields point at the in-stack
+  # MinIO; pyiceberg's S3 client receives the same credentials via the
+  # millpond config the driver builds.
+  lakekeeper-warehouse:
+    image: curlimages/curl
+    depends_on:
+      lakekeeper:
+        condition: service_healthy
+      lakekeeper-bootstrap:
+        condition: service_completed_successfully
+      lakekeeper-createbuckets:
+        condition: service_completed_successfully
+    restart: "no"
+    entrypoint: ["sh", "-c"]
+    command:
+      - |
+        body='{"warehouse-name":"stress","project-id":"00000000-0000-0000-0000-000000000000","storage-profile":{"type":"s3","bucket":"warehouse","key-prefix":"stress","endpoint":"http://lakekeeper-minio:9000","region":"local-01","path-style-access":true,"flavor":"minio","sts-enabled":false,"remote-signing-enabled":false},"storage-credential":{"type":"s3","credential-type":"access-key","access-key-id":"minio-root-user","secret-access-key":"minio-root-password"}}'
+        code=$$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+          http://lakekeeper:8181/management/v1/warehouse \
+          -H "Content-Type: application/json" \
+          --data "$$body")
+        echo "warehouse create returned $$code"
+        # 2xx = created; 409 = already exists (idempotent on re-up).
+        case "$$code" in 2*|409) exit 0 ;; *) exit 1 ;; esac

--- a/tests/stress/stress_driver.py
+++ b/tests/stress/stress_driver.py
@@ -1,0 +1,269 @@
+"""In-container stress driver. Spawns N writer processes against the
+Lakekeeper REST catalog and prints a JSON report per writer count to
+stdout (prefix-tagged so the host-side test can parse them out).
+
+This runs inside the docker network so the in-network hostnames
+(`lakekeeper:8181`, `lakekeeper-minio:9000`) resolve. The host-side test
+fixture brings up the compose, exec's this script, and parses stdout.
+
+Stdout is the data channel; pretty-printed lines go to stderr.
+
+Env vars (set by the compose):
+  LK_CATALOG_URI     - e.g. http://lakekeeper:8181/catalog
+  LK_MINIO_ENDPOINT  - e.g. http://lakekeeper-minio:9000
+  LK_WAREHOUSE       - e.g. stress
+  LK_NAMESPACE       - e.g. stress_ns
+  STRESS_WRITER_COUNTS - comma-separated, e.g. "2,4,8,16,32"
+  STRESS_COMMITS_PER_WRITER - e.g. "50"
+  STRESS_ROWS_PER_COMMIT - e.g. "100"
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+import os
+import statistics
+import sys
+import time
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+import pyarrow as pa
+from pyiceberg.exceptions import CommitFailedException
+
+from millpond.config import Config
+from millpond.iceberg import IcebergSink
+
+CATALOG_URI = os.environ["LK_CATALOG_URI"]
+MINIO_ENDPOINT = os.environ["LK_MINIO_ENDPOINT"]
+WAREHOUSE = os.environ["LK_WAREHOUSE"]
+NAMESPACE = os.environ["LK_NAMESPACE"]
+WRITER_COUNTS = tuple(int(x) for x in os.environ["STRESS_WRITER_COUNTS"].split(","))
+COMMITS_PER_WRITER = int(os.environ["STRESS_COMMITS_PER_WRITER"])
+ROWS_PER_COMMIT = int(os.environ["STRESS_ROWS_PER_COMMIT"])
+
+# Stdout = data channel; stderr = human-readable. The host wrapper parses
+# stdout looking for the RESULT_PREFIX line(s) and a final SUMMARY_PREFIX.
+RESULT_PREFIX = "STRESS_RESULT "
+SUMMARY_PREFIX = "STRESS_SUMMARY "
+
+
+def _stderr(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+@dataclass
+class CommitAttempt:
+    writer_id: int
+    attempt_idx: int
+    latency_ms: float
+    status: str
+    error_type: str | None
+
+
+def _wait_for_http(url: str, timeout: float = 120.0) -> None:
+    deadline = time.monotonic() + timeout
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=2) as resp:
+                if 200 <= resp.status < 300:
+                    return
+        except Exception as e:
+            last_err = e
+        time.sleep(0.5)
+    raise RuntimeError(f"endpoint {url} never came up within {timeout}s; last error: {last_err!r}")
+
+
+def _make_cfg(table_name: str) -> Config:
+    return Config(
+        bootstrap_servers="unused",
+        topic="unused",
+        group_id="unused",
+        replica_count=1,
+        ordinal=0,
+        destination="iceberg",
+        ducklake_table=None,
+        ducklake_data_path=None,
+        ducklake_connection=None,
+        rds_host=None,
+        rds_port=None,
+        rds_database=None,
+        rds_username=None,
+        rds_password=None,
+        partition_by=None,
+        iceberg_catalog_uri=CATALOG_URI,
+        iceberg_warehouse=WAREHOUSE,
+        iceberg_namespace=NAMESPACE,
+        iceberg_table=table_name,
+        iceberg_table_location=None,
+        iceberg_catalog_token=None,
+        s3_access_key_id="minio-root-user",
+        s3_secret_access_key="minio-root-password",
+        s3_region="local-01",
+        s3_endpoint=MINIO_ENDPOINT,
+        flush_size=1,
+        flush_interval_ms=1,
+        fetch_min_bytes=1,
+        fetch_max_wait_ms=1,
+        consume_batch_size=1,
+        stats_interval_ms=1,
+        broker_source="",
+        kafka_config_overrides=(),
+    )
+
+
+def _writer_worker(
+    writer_id: int,
+    table_name: str,
+    n_commits: int,
+    barrier_path: str,
+    results_queue: mp.Queue,
+) -> None:
+    cfg = _make_cfg(table_name)
+    sink = IcebergSink(cfg)
+
+    barrier = Path(barrier_path)
+    while not barrier.exists():
+        time.sleep(0.01)
+
+    results: list[CommitAttempt] = []
+    for i in range(n_commits):
+        batch = pa.table(
+            {
+                "event": [f"e-{writer_id}-{i}-{j}" for j in range(ROWS_PER_COMMIT)],
+                "team_id": [writer_id] * ROWS_PER_COMMIT,
+            }
+        )
+        t0 = time.monotonic()
+        status: str
+        error_type: str | None = None
+        try:
+            sink.write(batch)
+            status = "success"
+        except CommitFailedException as e:
+            status = "conflict"
+            error_type = type(e).__name__
+        except Exception as e:  # noqa: BLE001
+            status = "error"
+            error_type = type(e).__name__
+        latency_ms = (time.monotonic() - t0) * 1000.0
+        results.append(CommitAttempt(writer_id, i, latency_ms, status, error_type))
+        # Mirror _write_with_retry's invalidate behaviour so subsequent
+        # attempts don't pile up on the same stale snapshot.
+        if status == "conflict":
+            sink.reset_caches()
+
+    sink.close()
+    results_queue.put([(r.writer_id, r.attempt_idx, r.latency_ms, r.status, r.error_type) for r in results])
+
+
+def _percentile(samples: list[float], p: float) -> float:
+    if not samples:
+        return float("nan")
+    s = sorted(samples)
+    k = max(0, min(len(s) - 1, int(round(p / 100.0 * (len(s) - 1)))))
+    return s[k]
+
+
+def _report(n_writers: int, attempts: list[CommitAttempt]) -> dict:
+    by_status: dict[str, list[float]] = {"success": [], "conflict": [], "error": []}
+    error_types: dict[str, int] = {}
+    for a in attempts:
+        by_status.setdefault(a.status, []).append(a.latency_ms)
+        if a.error_type:
+            error_types[a.error_type] = error_types.get(a.error_type, 0) + 1
+
+    total = len(attempts)
+    n_success = len(by_status["success"])
+    n_conflict = len(by_status["conflict"])
+    n_error = len(by_status["error"])
+
+    all_latencies = [a.latency_ms for a in attempts]
+    success_latencies = by_status["success"]
+
+    return {
+        "n_writers": n_writers,
+        "total_attempts": total,
+        "success": n_success,
+        "conflict": n_conflict,
+        "error": n_error,
+        "error_types": error_types,
+        "success_rate": n_success / total if total else 0.0,
+        "conflict_rate": n_conflict / total if total else 0.0,
+        "all_p50_ms": _percentile(all_latencies, 50),
+        "all_p95_ms": _percentile(all_latencies, 95),
+        "all_p99_ms": _percentile(all_latencies, 99),
+        "success_p50_ms": _percentile(success_latencies, 50),
+        "success_p95_ms": _percentile(success_latencies, 95),
+        "success_p99_ms": _percentile(success_latencies, 99),
+        "success_mean_ms": statistics.fmean(success_latencies) if success_latencies else float("nan"),
+    }
+
+
+def _run_one(n_writers: int) -> dict:
+    table_name = f"events_n{n_writers}"
+
+    # Seed the table with one commit so all workers start at a known snapshot.
+    seed_sink = IcebergSink(_make_cfg(table_name))
+    seed_sink.write(pa.table({"event": ["seed"], "team_id": [0]}))
+    seed_sink.close()
+
+    barrier_file = Path(f"/tmp/stress-barrier-n{n_writers}")
+    if barrier_file.exists():
+        barrier_file.unlink()
+    ctx = mp.get_context("spawn")
+    # Queue must come from the same context as Process — crossing contexts
+    # (e.g. default fork queue + spawn process) raises in Python 3.12+.
+    results_queue: mp.Queue = ctx.Queue()
+    procs = []
+    for w in range(n_writers):
+        p = ctx.Process(
+            target=_writer_worker,
+            args=(w, table_name, COMMITS_PER_WRITER, str(barrier_file), results_queue),
+        )
+        p.start()
+        procs.append(p)
+
+    # Let workers construct their IcebergSinks before releasing the barrier.
+    time.sleep(2.0)
+    barrier_file.write_text("go")
+
+    all_attempts: list[CommitAttempt] = []
+    for _ in procs:
+        rows = results_queue.get(timeout=600)
+        all_attempts.extend(CommitAttempt(*r) for r in rows)
+
+    for p in procs:
+        p.join(timeout=30)
+        if p.is_alive():
+            p.terminate()
+
+    return _report(n_writers, all_attempts)
+
+
+def main() -> int:
+    _wait_for_http(f"{CATALOG_URI}/v1/config?warehouse={WAREHOUSE}")
+
+    summary = []
+    for n_writers in WRITER_COUNTS:
+        _stderr(f"--- running n_writers={n_writers} ---")
+        report = _run_one(n_writers)
+        # One self-contained JSON line per writer count.
+        print(RESULT_PREFIX + json.dumps(report), flush=True)
+        _stderr(
+            f"n={n_writers}: success={report['success']}/{report['total_attempts']}  "
+            f"conflict={report['conflict']}  errors={report['error']}  "
+            f"p50={report['success_p50_ms']:.0f}ms  p95={report['success_p95_ms']:.0f}ms"
+        )
+        summary.append(report)
+
+    print(SUMMARY_PREFIX + json.dumps(summary), flush=True)
+    _stderr("--- done ---")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/stress/summary.json
+++ b/tests/stress/summary.json
@@ -1,0 +1,97 @@
+[
+  {
+    "n_writers": 2,
+    "total_attempts": 100,
+    "success": 58,
+    "conflict": 42,
+    "error": 0,
+    "error_types": {
+      "CommitFailedException": 42
+    },
+    "success_rate": 0.58,
+    "conflict_rate": 0.42,
+    "all_p50_ms": 45.31244497047737,
+    "all_p95_ms": 111.15517601137981,
+    "all_p99_ms": 128.72942100511864,
+    "success_p50_ms": 44.642277993261814,
+    "success_p95_ms": 58.16577497171238,
+    "success_p99_ms": 66.95539702195674,
+    "success_mean_ms": 46.365117412341505
+  },
+  {
+    "n_writers": 4,
+    "total_attempts": 200,
+    "success": 56,
+    "conflict": 144,
+    "error": 0,
+    "error_types": {
+      "CommitFailedException": 144
+    },
+    "success_rate": 0.28,
+    "conflict_rate": 0.72,
+    "all_p50_ms": 47.19790298258886,
+    "all_p95_ms": 73.25601996853948,
+    "all_p99_ms": 138.56045994907618,
+    "success_p50_ms": 46.7469870345667,
+    "success_p95_ms": 56.96573294699192,
+    "success_p99_ms": 65.07173099089414,
+    "success_mean_ms": 48.383607284839464
+  },
+  {
+    "n_writers": 8,
+    "total_attempts": 400,
+    "success": 56,
+    "conflict": 344,
+    "error": 0,
+    "error_types": {
+      "CommitFailedException": 344
+    },
+    "success_rate": 0.14,
+    "conflict_rate": 0.86,
+    "all_p50_ms": 57.2675250004977,
+    "all_p95_ms": 92.36305597005412,
+    "all_p99_ms": 149.46733199758455,
+    "success_p50_ms": 56.79514998337254,
+    "success_p95_ms": 68.96723003592342,
+    "success_p99_ms": 84.68976698350161,
+    "success_mean_ms": 57.13508244869964
+  },
+  {
+    "n_writers": 16,
+    "total_attempts": 800,
+    "success": 54,
+    "conflict": 746,
+    "error": 0,
+    "error_types": {
+      "CommitFailedException": 746
+    },
+    "success_rate": 0.0675,
+    "conflict_rate": 0.9325,
+    "all_p50_ms": 89.08097399398685,
+    "all_p95_ms": 154.14720599073917,
+    "all_p99_ms": 193.98727698717266,
+    "success_p50_ms": 88.52576604112983,
+    "success_p95_ms": 120.24192401440814,
+    "success_p99_ms": 142.41545798722655,
+    "success_mean_ms": 92.23573792863775
+  },
+  {
+    "n_writers": 32,
+    "total_attempts": 1600,
+    "success": 57,
+    "conflict": 1543,
+    "error": 0,
+    "error_types": {
+      "CommitFailedException": 1543
+    },
+    "success_rate": 0.035625,
+    "conflict_rate": 0.964375,
+    "all_p50_ms": 160.24528699927032,
+    "all_p95_ms": 239.93601300753653,
+    "all_p99_ms": 410.33392201643437,
+    "success_p50_ms": 155.62982996925712,
+    "success_p95_ms": 243.21972101461142,
+    "success_p99_ms": 359.85502001130953,
+    "success_mean_ms": 174.7009150536829
+  }
+]

--- a/tests/stress/test_lakekeeper_concurrent.py
+++ b/tests/stress/test_lakekeeper_concurrent.py
@@ -1,0 +1,114 @@
+"""Characterise Lakekeeper's concurrent-commit behaviour under contention.
+
+The actual workers run *inside the docker network* (the `stress-driver`
+service in compose.lakekeeper.yaml uses the millpond image and runs
+`stress_driver.py`). This test is a thin host-side wrapper that:
+
+  1. Brings up the Lakekeeper + MinIO + Postgres stack.
+  2. Invokes the in-network driver via `docker compose run --rm stress-driver`.
+  3. Parses the driver's stdout for `STRESS_RESULT` lines and a final
+     `STRESS_SUMMARY` line; pretty-prints a comparison table; archives
+     the summary JSON next to this file.
+
+Driving from inside the network matters: Lakekeeper bakes the storage
+profile's S3 endpoint (`http://lakekeeper-minio:9000`) into the per-table
+config it returns to clients. That hostname only resolves inside the
+compose network. Running the writers in-network sidesteps the host-vs-
+container endpoint mismatch and is also the production deployment shape —
+millpond pods, Lakekeeper, and S3 live on the same network.
+
+Marker-gated (`@pytest.mark.stress`). Trigger via `just stress-lakekeeper`.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from testcontainers.compose import DockerCompose
+
+STRESS_DIR = Path(__file__).parent
+COMPOSE_FILE = "compose.lakekeeper.yaml"
+
+SUMMARY_PREFIX = "STRESS_SUMMARY "
+RESULT_PREFIX = "STRESS_RESULT "
+
+
+@pytest.fixture(scope="module")
+def lakekeeper_stack():
+    """Bring up MinIO + Postgres + Lakekeeper (with bootstrap + warehouse).
+
+    `wait=False` because docker-compose `--wait` returns non-zero when
+    one-shot init containers exit 0 (compose quirk). Health-readiness of
+    the long-running services is guaranteed by `depends_on` in the compose.
+    """
+    with DockerCompose(str(STRESS_DIR), compose_file_name=COMPOSE_FILE, pull=True, wait=False) as compose:
+        yield compose
+
+
+@pytest.mark.stress
+def test_concurrent_commits(lakekeeper_stack):
+    """Single test running the full N=2…32 sweep in one driver invocation."""
+    cmd = [
+        "docker",
+        "compose",
+        "-f",
+        COMPOSE_FILE,
+        "--profile",
+        "driver",
+        "run",
+        "--rm",
+        "--build",
+        "stress-driver",
+    ]
+    result = subprocess.run(
+        cmd,
+        cwd=str(STRESS_DIR),
+        capture_output=True,
+        text=True,
+        timeout=1800,
+        check=False,
+    )
+    # Always show stderr — it's the human-readable channel for the driver.
+    if result.stderr:
+        print("DRIVER STDERR:\n" + result.stderr)
+    if result.returncode != 0:
+        print("DRIVER STDOUT:\n" + result.stdout)
+        pytest.fail(f"stress-driver exited {result.returncode}")
+
+    # Parse the SUMMARY line — it's the authoritative aggregate.
+    summary_line: str | None = None
+    per_n_results: list[dict] = []
+    for line in result.stdout.splitlines():
+        if line.startswith(SUMMARY_PREFIX):
+            summary_line = line[len(SUMMARY_PREFIX) :]
+        elif line.startswith(RESULT_PREFIX):
+            per_n_results.append(json.loads(line[len(RESULT_PREFIX) :]))
+
+    assert summary_line is not None, "driver did not emit STRESS_SUMMARY line; stdout was:\n" + result.stdout
+    summary = json.loads(summary_line)
+
+    # Archive next to the test for the writeup.
+    (STRESS_DIR / "summary.json").write_text(json.dumps(summary, indent=2))
+
+    # Pretty-print so the run shows results clearly under `pytest -s`.
+    print()
+    print(f"{'N':>4}  {'success%':>8}  {'conflict%':>9}  {'error':>5}  {'p50ms':>6}  {'p95ms':>6}  {'p99ms':>6}")
+    for r in summary:
+        print(
+            f"{r['n_writers']:>4}  "
+            f"{r['success_rate'] * 100:>7.1f}%  "
+            f"{r['conflict_rate'] * 100:>8.1f}%  "
+            f"{r['error']:>5}  "
+            f"{r['success_p50_ms']:>6.1f}  "
+            f"{r['success_p95_ms']:>6.1f}  "
+            f"{r['success_p99_ms']:>6.1f}"
+        )
+
+    # Characterisation, not pass/fail. Only fail on non-conflict errors.
+    bad = [r for r in summary if r["error"] > 0]
+    assert not bad, (
+        f"unexpected non-conflict errors in writer counts: {[(r['n_writers'], r['error_types']) for r in bad]}"
+    )


### PR DESCRIPTION
## Summary

Empirical characterisation of Lakekeeper's behaviour under N concurrent Iceberg table commits, plus a writeup ([\`tests/stress/FINDINGS.md\`](tests/stress/FINDINGS.md)) projecting the measured curve onto observed production load. Tackles the open question from #60: \"does the catalog choice change the concurrent-commit story.\"

## What's here

| Artifact | Purpose |
|---|---|
| \`tests/stress/compose.lakekeeper.yaml\` | Postgres + MinIO + Lakekeeper, idempotent bootstrap + warehouse init |
| \`tests/stress/stress_driver.py\` | In-container N-process IcebergSink driver. Retries disabled — characterising raw catalog behaviour |
| \`tests/stress/test_lakekeeper_concurrent.py\` | Host wrapper, parses driver stdout, archives \`summary.json\` |
| \`tests/stress/FINDINGS.md\` | TL;DR + full analysis: raw measurements, catalog concurrency model, structural latency floor, two-regime explanation, production extrapolation, levers |
| \`tests/stress/summary.json\` | Raw N=2,4,8,16,32 sweep results |
| \`millpond/iceberg.py\` (+7 lines) | Pin \`py-io-impl=pyiceberg.io.pyarrow.PyArrowFileIO\`. Required for Lakekeeper — its storage-profile response otherwise routes pyiceberg through FsspecFileIO which needs \`s3fs\` |

## Headline result

From the TL;DR in FINDINGS.md, projecting today's \`IcebergSink.write()\` path against Lakekeeper at observed per-pod cadence (~11 s/flush) and measured catalog latency (p95 ~400 ms):

| N pods writing one table | Retry-exhaustion rate (3 attempts) |
|---:|---:|
|  2 |  ~0.03% |
|  8 |  ~1.6% |
| 16 |  ~8.5% |
| **32** (current scale) | **~33%** |
| 64 | ~73% |

Cliff sits at **N ≈ 16 (p95) to N ≈ 64 (p50)**. Two structural facts hold for any Iceberg REST catalog: the optimistic-concurrency model is shared across implementations, and the irreducible ~3 S3 PUTs per commit cap the ceiling at ~5–10 commits/sec/table.

## Library change required for Lakekeeper

\`millpond/iceberg.py\` pins \`py-io-impl=pyiceberg.io.pyarrow.PyArrowFileIO\`. Without this, Lakekeeper's storage-profile response routes PyIceberg through \`FsspecFileIO\`, which depends on the \`s3fs\` package (not currently a Millpond dep). Existing integration + e2e suites pass with the pin (31/31 verified locally).

Production warehouses created via the Lakekeeper management API will also need \`remote-signing-enabled: false\` in their storage-profile unless \`s3fs\` is added as a runtime dep — see FINDINGS.md \"Code changes already on this branch\" subsection.

## Reproduction

\`\`\`
just stress-lakekeeper                              # full N=2…32 sweep
cat tests/stress/summary.json                       # last-run machine-readable
\`\`\`

Marker-gated (\`@pytest.mark.stress\`), not run in CI.

## Test plan

- [x] Local stress sweep (N=2 through N=32) produces expected curve, written to summary.json
- [x] Existing integration tests pass with \`py-io-impl\` pin (\`just test-integration\`)
- [x] Existing e2e DuckLake suite passes (\`just test-e2e\`)
- [x] Existing e2e Iceberg suite passes (\`just test-e2e-iceberg\`)
- [x] Unit tests pass (\`uv run pytest -m \"not integration and not e2e and not stress\"\`)
- [x] Ruff format + lint clean on changed files
- [ ] Reviewer skim of FINDINGS.md TL;DR + Levers tables