### PR TITLE
Add allowlist filter and pre-write sort (record-handling features)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -97,10 +97,13 @@ while not shutdown:
     records = consumer.consume(num_messages=N, timeout=remaining_until_flush)
     if records:
         batch = convert_to_arrow(records)
+        batch = apply_filter(batch, cfg)                 # optional allowlist (no-op if unconfigured)
         pending.append(batch)
 
     if should_flush(pending):
-        sink.write(pending)                              # destination-agnostic
+        consolidated = pa.concat_tables(pending)
+        consolidated = apply_sort(consolidated, cfg)     # optional ascending sort (no-op if unconfigured)
+        sink.write(consolidated)                         # destination-agnostic
         consumer.commit(offsets, asynchronous=False)
         pending.clear()
 ```
@@ -206,6 +209,33 @@ Empty-batch contract: callers must not invoke `write()` with a zero-row batch. `
 Reserved-column contract: source-schema columns must not collide with backend-managed metadata column names. `sink.py` exports a shared `check_reserved_collision(batch_schema, reserved, backend_name)` helper that each backend calls at the top of its module-level `write()` — raises `ValueError("Source schema column(s) [...] collide with X-reserved metadata column names...")` at the Sink boundary before any backend-specific work. The per-backend `RESERVED_COLUMNS` constants currently hold the same set (`{"_inserted_at", "year", "month", "day", "hour"}`) — DuckLake reserves the four partition cols defensively even though it doesn't produce them itself, so a deployment-time destination switch doesn't suddenly start accepting or rejecting batches based on column-name collisions. `SAFE_IDENTIFIER` (the regex for column names safe to embed in generated SQL / pass to PyIceberg's schema constructor) also lives in `sink.py` and is shared by both schema managers.
 
 Cross-backend behaviour and performance are locked by `tests/unit/test_backend_equivalence.py` — same Arrow batch through both Sinks, parametrized assertions over the documented divergences (empty-batch, partition cols, `_inserted_at` provenance), pathological value/name coverage, schema-evolution metric parity, and conservative performance smoke contracts. The suite catches a future "let's silently align these" or "let's silently diverge these" change before merge.
+
+### Optional record handling (filter + sort)
+
+Two optional pre-sink stages, both backend-agnostic, both implemented in `main.py` so the Sink Protocol stays a pure write surface.
+
+**Filter** (`_apply_filter` in `main.py`) runs immediately after `_convert_batch` and before records enter the pending buffer. Drops records whose value in `cfg.filter_keep_field` is not in `cfg.filter_values`. Tracks two skip reasons distinctly on `records_skipped_total`:
+
+- `filter_field_missing` — column absent from batch schema, null for that row, or column type is not in the allowlist (integer / string / large_string only)
+- `filter_excluded` — column present, value not in the allowlist
+
+The column-type allowlist exists because PyArrow's `safe=True` cast happily coerces ints to bool/float/timestamp/date and silently produces semantically-wrong matches. Rejecting non-integer/non-string columns up front turns "silent surprising match" into "explicit `filter_field_missing` signal."
+
+Cast direction is values → column (the small array to the big one's type), not column → fixed type. Three properties fall out of that:
+
+1. Schema drift across batches is handled by construction (the cast is re-evaluated against the live column type each call, not against a type chosen at config load).
+2. The hot path makes one pass over the column (the final `table.filter`) — `pc.is_in` returns null for null inputs natively, and `column.null_count` is O(num_chunks).
+3. The cast site is wrapped in `try/except (ArrowInvalid, ArrowNotImplementedError, ArrowTypeError)` so an unexpected column shape lands a batch in `filter_field_missing` rather than killing the consume loop.
+
+`MILLPOND_FILTER_DROP_FIELD_NAME` is reserved at the config layer (mutex with keep, both empty or exactly one set) and explicitly rejected at startup. The denylist implementation lives in a future commit; the namespace is locked today so that change doesn't require operator env-var churn.
+
+**Sort** (`_apply_sort` in `main.py`) runs inside `_flush()` after `pa.concat_tables` but before `sink.write()`. Both backends see pre-sorted data; sink-side partition columns (year/month/day/hour added by IcebergSink, computed by the ducklake extension) are not in scope by design — operators specify sort keys against the source schema.
+
+Missing-field handling: if any `cfg.sort_by` field is absent from the batch, the whole sort is skipped (rather than partially sorting on available keys, which would silently differ from intent). Records still flow through unsorted. The metric is `sort_skipped_total{reason="field_missing"}`, deliberately distinct from `records_skipped_total` because no data is being dropped — only the layout improvement is.
+
+Log dedup: `_sort_missing_fields_warned` (module-level set) prevents per-flush log floods under sustained misconfiguration. One warning per distinct missing-fields pattern per pod lifetime; the metric is the always-on signal.
+
+Cost: ~50–200 ms per flush at production batch sizes (mostly `pa.Table.take()`'s full-column rewrite); peak memory ~2× the flush buffer during the take. Sort coverage lives in `TestApplySort` in `tests/unit/test_main.py` — the backend-equivalence suite is currently filter/sort-agnostic since both stages run upstream of the Sink boundary; if either feature ever gets per-backend variants (e.g. ORDER BY pushdown into the DuckLake INSERT), the equivalence suite should grow a parameterisation to lock the symmetry.
 
 ### DuckLake Initialization
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ Single thread, single loop. Kafka is the buffer. Offset commit is explicit (afte
 ```
 K8s StatefulSet (N replicas)
   └─ Pod (ordinal 0..N-1)
-       └─ Single loop: consume → convert → accumulate → flush → commit
+       └─ Single loop: consume → convert → [filter] → accumulate → [sort] → flush → commit
 ```
 
 - One topic and one table per deployment
 - Static partition assignment via pod ordinal — no consumer groups
 - If a pod dies, its partitions stop being consumed until K8s restarts it
+- Optional filter and sort stages — see [Record Handling](#record-handling) below
 
 ## Destinations
 
@@ -52,6 +53,42 @@ Millpond writes to one of two lake formats, selected at startup by `MILLPOND_DES
 | Multi-pod concurrent writes | Native; idempotent DDL handles races | Native; PyIceberg optimistic concurrency + retry loop handles races |
 
 The selection is a thin Protocol-based abstraction (`millpond/sink.py`) — `main.py` only sees `Sink.write(batch)`, `reset_caches()`, `close()`. Both implementations are in their own module (`ducklake.py`, `iceberg.py`).
+
+## Record Handling
+
+Two optional stages sit between Kafka conversion and the sink. Both are disabled when their env vars are unset.
+
+### Allowlist filter
+
+Drops records whose value in a configured field is not in a configured allowlist. Applied immediately after JSON→Arrow conversion, before records enter the pending buffer.
+
+```
+MILLPOND_FILTER_KEEP_FIELD_NAME=team_id
+MILLPOND_FILTER_VALUES=2,4,1956,69
+```
+
+Values auto-detect: tokens that all parse as integers become an int allowlist; otherwise the whole list is treated as strings.
+
+Two skip reasons are tracked on `millpond_records_skipped_total`:
+
+- `filter_field_missing` — column absent from this batch's schema, null for that row, or column type is not filterable (only integer and string columns are supported; bool, float, timestamp, struct, list, etc. are rejected explicitly to avoid silent surprising matches under PyArrow's `safe=True` cast semantics).
+- `filter_excluded` — column present and non-null but value not in the allowlist. Expected steady-state drop reason.
+
+`MILLPOND_FILTER_DROP_FIELD_NAME` is reserved at the config layer (mutex with keep) and currently rejected at startup. It will become a denylist filter in a future release without env-var churn.
+
+### Pre-write sort
+
+Sorts the consolidated batch by one or more columns ascending, right before `sink.write()`. Both DuckLake and Iceberg sinks see pre-sorted data, which improves Parquet compression (especially for low-cardinality keys like `team_id`) and downstream reader predicate pushdown.
+
+```
+MILLPOND_SORT_BY=team_id,timestamp
+```
+
+Sort order is left-to-right (`team_id` primary, `timestamp` secondary). Direction is ascending only today; if you need descending, file an issue. PyArrow's sort is stable, so equal-key rows preserve their consume order.
+
+If any sort field is missing from a batch's schema, the sort is skipped (records still flow through, just unsorted), `millpond_sort_skipped_total{reason="field_missing"}` increments by the record count, and a warning logs once per distinct missing-fields pattern (per pod lifetime — prevents log floods under sustained misconfiguration).
+
+Per-flush cost is ~50–200 ms on a 256 MB / 30k-row batch. Peak memory roughly doubles during the sort because `pa.Table.take()` rewrites a fresh copy of every column; budget accordingly relative to the pod's memory limit.
 
 ## Adaptive Backpressure
 
@@ -280,6 +317,17 @@ All configuration via environment variables.
 | `MILLPOND_S3_ENDPOINT` | no | | S3 endpoint override (MinIO, etc.) |
 
 `MILLPOND_S3_*` is a separate env var family from `DUCKDB_S3_*` deliberately — they target different client libraries, and a deployment switch from DuckLake to Iceberg should be a clean swap of env vars rather than re-using the DuckDB-specific names.
+
+### Optional record handling
+
+See [Record Handling](#record-handling) for context. All four variables below are optional; unset means the corresponding stage is disabled.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `MILLPOND_FILTER_KEEP_FIELD_NAME` | no | | Column name to check against the allowlist. Must be set with `MILLPOND_FILTER_VALUES`. Validated as a safe identifier. |
+| `MILLPOND_FILTER_DROP_FIELD_NAME` | no | | Reserved for a future denylist filter; setting it today raises at startup. Mutually exclusive with `MILLPOND_FILTER_KEEP_FIELD_NAME`. |
+| `MILLPOND_FILTER_VALUES` | no | | Comma-separated allowed values. Auto-detected as int if every token parses as an integer, string otherwise. Required when either filter field name is set. |
+| `MILLPOND_SORT_BY` | no | | Comma-separated column names; the batch is sorted ascending by these in tuple order before each write. Missing fields cause the sort to be skipped (records still flow). |
 
 ## Releases
 

--- a/millpond/config.py
+++ b/millpond/config.py
@@ -76,6 +76,21 @@ class Config:
     # Broker source label for metrics (e.g. "msk", "warpstream")
     broker_source: str
 
+    # Optional record filter. Exactly one of `filter_keep_field` /
+    # `filter_drop_field` may be set; whichever is set names the column to
+    # check against `filter_values`. Keep = allowlist (keep records whose
+    # value is in filter_values, drop the rest). Drop = denylist (drop
+    # records whose value is in filter_values, keep the rest). Only the
+    # keep direction is implemented today; the drop slot reserves the
+    # namespace and the mutual-exclusion contract for a future add.
+    # `filter_values` is parsed at load time and is homogeneous — either a
+    # tuple of ints (if all comma-separated tokens parsed as int) or a tuple
+    # of strings (otherwise). main.py applies this after JSON→Arrow but
+    # before the pending buffer.
+    filter_keep_field: str | None
+    filter_drop_field: str | None
+    filter_values: tuple[int, ...] | tuple[str, ...] | None
+
     # Extra librdkafka config (from KAFKA_CONSUMER_* env vars)
     kafka_config_overrides: tuple[tuple[str, str], ...]
 
@@ -105,6 +120,67 @@ def _require(name: str) -> str:
     if not val:
         raise RuntimeError(f"Required environment variable {name} is not set")
     return val
+
+
+_SAFE_COLUMN_NAME = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def _parse_filter_values(raw: str) -> tuple[int, ...] | tuple[str, ...]:
+    """Parse MILLPOND_FILTER_VALUES into a homogeneous tuple.
+
+    Try int-tuple first; fall back to string-tuple if any token fails to
+    parse. Whitespace is trimmed; empty tokens (e.g. trailing commas) are
+    dropped. An empty input raises — callers should validate the env var
+    is non-empty before calling.
+    """
+    tokens = tuple(t.strip() for t in raw.split(",") if t.strip())
+    if not tokens:
+        raise RuntimeError("MILLPOND_FILTER_VALUES must contain at least one value")
+    try:
+        return tuple(int(t) for t in tokens)
+    except ValueError:
+        return tokens
+
+
+def _load_filter_fields() -> tuple[str | None, str | None, tuple[int, ...] | tuple[str, ...] | None]:
+    """Read MILLPOND_FILTER_{KEEP,DROP}_FIELD_NAME + MILLPOND_FILTER_VALUES.
+
+    At most one of keep/drop may be set. If either is set, FILTER_VALUES is
+    required. Field names must be safe identifiers so misconfigurations
+    surface at startup rather than under load. Drop is reserved for a
+    future change — config rejects it explicitly with a clear message
+    rather than silently accepting and doing nothing.
+    """
+    keep = os.environ.get("MILLPOND_FILTER_KEEP_FIELD_NAME", "").strip() or None
+    drop = os.environ.get("MILLPOND_FILTER_DROP_FIELD_NAME", "").strip() or None
+    values_raw = os.environ.get("MILLPOND_FILTER_VALUES", "").strip()
+
+    if keep and drop:
+        raise RuntimeError("MILLPOND_FILTER_KEEP_FIELD_NAME and MILLPOND_FILTER_DROP_FIELD_NAME are mutually exclusive")
+
+    active = keep or drop
+    if bool(active) != bool(values_raw):
+        raise RuntimeError(
+            "MILLPOND_FILTER_VALUES must be set together with "
+            "MILLPOND_FILTER_KEEP_FIELD_NAME (or MILLPOND_FILTER_DROP_FIELD_NAME)"
+        )
+
+    if active is None:
+        return None, None, None
+
+    if not _SAFE_COLUMN_NAME.match(active):
+        raise RuntimeError(
+            f"Filter field name {active!r} contains unsafe characters (must match [a-zA-Z_][a-zA-Z0-9_]*)"
+        )
+
+    if drop:
+        # Reserved for a future change; rejecting explicitly today keeps the
+        # env-var namespace and the keep/drop mutual-exclusion contract
+        # stable so a later commit can flip the implementation on without
+        # any operator-facing config rename.
+        raise RuntimeError("MILLPOND_FILTER_DROP_FIELD_NAME is reserved for a future release; not implemented yet")
+
+    return keep, None, _parse_filter_values(values_raw)
 
 
 def _load_ducklake_fields() -> dict[str, str | None]:
@@ -227,6 +303,8 @@ def load() -> Config:
         if k.startswith(_KAFKA_CONSUMER_PREFIX)
     )
 
+    filter_keep_field, filter_drop_field, filter_values = _load_filter_fields()
+
     cfg = Config(
         bootstrap_servers=_require("KAFKA_BOOTSTRAP_SERVERS"),
         topic=topic,
@@ -243,6 +321,9 @@ def load() -> Config:
         consume_batch_size=int(os.environ.get("CONSUME_BATCH_SIZE", "1000")),
         stats_interval_ms=int(os.environ.get("STATS_INTERVAL_MS", "5000")),
         broker_source=os.environ.get("BROKER_SOURCE", "").strip().lower(),
+        filter_keep_field=filter_keep_field,
+        filter_drop_field=filter_drop_field,
+        filter_values=filter_values,
         kafka_config_overrides=kafka_overrides,
     )
 
@@ -255,4 +336,6 @@ def load() -> Config:
         replica_count,
         cfg.group_id,
     )
+    if cfg.filter_keep_field is not None:
+        log.info("Filter (keep): %s in %s", cfg.filter_keep_field, cfg.filter_values)
     return cfg

--- a/millpond/config.py
+++ b/millpond/config.py
@@ -91,6 +91,12 @@ class Config:
     filter_drop_field: str | None
     filter_values: tuple[int, ...] | tuple[str, ...] | None
 
+    # Optional pre-write sort. Tuple of column names; sort is ascending
+    # in tuple order. Applied to the consolidated batch right before
+    # sink.write() so both DuckLake and Iceberg paths see pre-sorted
+    # data. None disables the sort entirely.
+    sort_by: tuple[str, ...] | None
+
     # Extra librdkafka config (from KAFKA_CONSUMER_* env vars)
     kafka_config_overrides: tuple[tuple[str, str], ...]
 
@@ -181,6 +187,28 @@ def _load_filter_fields() -> tuple[str | None, str | None, tuple[int, ...] | tup
         raise RuntimeError("MILLPOND_FILTER_DROP_FIELD_NAME is reserved for a future release; not implemented yet")
 
     return keep, None, _parse_filter_values(values_raw)
+
+
+def _load_sort_by() -> tuple[str, ...] | None:
+    """Parse MILLPOND_SORT_BY into a tuple of column names.
+
+    Comma-separated; whitespace trimmed; empty tokens dropped. Each name
+    must match the safe-identifier pattern (`[a-zA-Z_][a-zA-Z0-9_]*`) so
+    a misconfiguration surfaces at startup, not at the first flush.
+    Returns None when the env var is absent or whitespace-only.
+    """
+    raw = os.environ.get("MILLPOND_SORT_BY", "").strip()
+    if not raw:
+        return None
+    fields = tuple(t.strip() for t in raw.split(",") if t.strip())
+    if not fields:
+        return None
+    for field in fields:
+        if not _SAFE_COLUMN_NAME.match(field):
+            raise RuntimeError(
+                f"MILLPOND_SORT_BY field {field!r} contains unsafe characters (must match [a-zA-Z_][a-zA-Z0-9_]*)"
+            )
+    return fields
 
 
 def _load_ducklake_fields() -> dict[str, str | None]:
@@ -304,6 +332,7 @@ def load() -> Config:
     )
 
     filter_keep_field, filter_drop_field, filter_values = _load_filter_fields()
+    sort_by = _load_sort_by()
 
     cfg = Config(
         bootstrap_servers=_require("KAFKA_BOOTSTRAP_SERVERS"),
@@ -324,6 +353,7 @@ def load() -> Config:
         filter_keep_field=filter_keep_field,
         filter_drop_field=filter_drop_field,
         filter_values=filter_values,
+        sort_by=sort_by,
         kafka_config_overrides=kafka_overrides,
     )
 
@@ -338,4 +368,6 @@ def load() -> Config:
     )
     if cfg.filter_keep_field is not None:
         log.info("Filter (keep): %s in %s", cfg.filter_keep_field, cfg.filter_values)
+    if cfg.sort_by is not None:
+        log.info("Sort by: %s (ascending)", ", ".join(cfg.sort_by))
     return cfg

--- a/millpond/main.py
+++ b/millpond/main.py
@@ -20,6 +20,16 @@ _WRITE_BASE_DELAY_S = 1.0
 _COMMIT_MAX_RETRIES = 3
 _COMMIT_BASE_DELAY_S = 0.5
 
+# Module-level set tracking which "missing sort fields" patterns we've
+# already warned about. Without this, a misconfigured sort against a
+# high-volume topic would log once per flush — at production cadence,
+# tens of thousands of log lines / hour. The key is the comma-joined
+# missing-fields tuple, so distinct misconfigurations still each get
+# one warning. Pod restart resets the set (the lifetime tied to the
+# process is intentional — operators get a fresh warning on each
+# restart, which signals a likely persistent misconfiguration).
+_sort_missing_fields_warned: set[str] = set()
+
 
 def _convert_batch(values: list[bytes]) -> pa.Table | None:
     """Convert raw message values to Arrow, timing the conversion."""
@@ -127,6 +137,50 @@ def _apply_filter(table: pa.Table, cfg: config.Config) -> pa.Table:
     return filtered
 
 
+def _apply_sort(table: pa.Table, cfg: config.Config) -> pa.Table:
+    """Sort the consolidated batch by `cfg.sort_by` (ascending) before write.
+
+    Returns the input unchanged when sort is unconfigured or when one or
+    more sort fields are missing from the batch schema. In the missing-
+    field case:
+      - Log a warning *once per distinct missing-fields pattern* (the
+        pod-lifetime dedup guards against per-flush log floods at
+        production cadence).
+      - Increment `sort_skipped_total{reason="field_missing"}` by the
+        record count so operators can detect missing-field sort gaps
+        from metrics alone.
+
+    Apply order matters: this runs in `_flush()` after `pa.concat_tables`
+    consolidates the pending buffer but before `sink.write()`. Both
+    DuckLake and Iceberg paths see pre-sorted data; sink-side partition
+    columns (year/month/day/hour added by IcebergSink, computed by the
+    ducklake extension) are not yet present and so are not in scope for
+    the sort, which is by design — operators specify sort keys against
+    the source schema, not the lake's derived columns.
+    """
+    if cfg.sort_by is None:
+        return table
+
+    missing = [f for f in cfg.sort_by if f not in table.column_names]
+    if missing:
+        key = ",".join(missing)
+        if key not in _sort_missing_fields_warned:
+            log.warning("Sort field(s) missing from batch schema: %s; skipping sort for affected flushes", missing)
+            _sort_missing_fields_warned.add(key)
+        metrics.sort_skipped_total.labels(reason="field_missing").inc(len(table))
+        return table
+
+    # PyArrow's sort_indices is stable; null_placement defaults to "at_end"
+    # which is the sensible default for ascending sort by a key with null
+    # values. Take() rewrites the table once — a full copy at flush size
+    # (~256 MB at production batches). That's the cost we pay for the
+    # write-side layout improvement; it's expected to be small relative
+    # to the sink.write() that follows.
+    sort_keys = [(field, "ascending") for field in cfg.sort_by]
+    indices = pc.sort_indices(table, sort_keys=sort_keys)
+    return table.take(indices)
+
+
 def _write_with_retry(sink, consolidated):
     """Write to the sink with exponential backoff on transient failures."""
     for attempt in range(_WRITE_MAX_RETRIES):
@@ -153,6 +207,7 @@ def _write_with_retry(sink, consolidated):
 
 def _flush(sink, cfg, kafka, consolidated, pending_bytes, pending_records, offsets, elapsed, trigger="time"):
     """Write to the sink, commit offsets, update metrics."""
+    consolidated = _apply_sort(consolidated, cfg)
     t0 = time.monotonic()
     _write_with_retry(sink, consolidated)
     write_duration = time.monotonic() - t0

--- a/millpond/main.py
+++ b/millpond/main.py
@@ -5,6 +5,7 @@ import time
 from importlib.metadata import PackageNotFoundError, version
 
 import pyarrow as pa
+import pyarrow.compute as pc
 from confluent_kafka import TopicPartition
 
 from millpond import arrow_converter, backpressure, config, consumer, logging_config, metrics, server
@@ -28,6 +29,102 @@ def _convert_batch(values: list[bytes]) -> pa.Table | None:
         duration = time.monotonic() - t0
         metrics.arrow_conversion_seconds.observe(duration)
     return table
+
+
+def _apply_filter(table: pa.Table, cfg: config.Config) -> pa.Table:
+    """Apply the configured keep-filter: drop records whose value in
+    `filter_keep_field` is not in `filter_values`.
+
+    Two reason labels on `records_skipped_total`:
+      - `filter_field_missing`: the configured field is absent from this
+        batch's schema, null for that row, or the column's Arrow type is
+        incompatible with the configured value type (i.e. the column
+        exists but the allowlist can't be applied against it — a schema
+        anomaly worth tracking distinctly).
+      - `filter_excluded`: column present and non-null but value not in
+        the configured allowlist. Expected steady-state drop reason.
+
+    Cast direction matters: we cast the (small) value array to the
+    column's type, not the (potentially large) column to a fixed type.
+    Three things fall out of that:
+      1. Schema drift across batches (one batch's `team_id` is `int64`,
+         the next is `string` because all values were null upstream) is
+         handled by construction — each call evaluates the cast against
+         the live column type, not against a type chosen at config load.
+      2. The hot path makes one pass over the column (the `table.filter`
+         at the end). No `pc.cast(column, ...)`, no `pc.is_null(column)` +
+         `pc.invert` + `pc.and_kleene` triple-pass — `pc.is_in` already
+         returns null for null inputs, and `column.null_count` is O(1).
+      3. A column type that can't accept the configured values at all
+         (struct, list, types narrower than the values) raises at the
+         single cast site, where we catch it instead of letting it kill
+         the consume loop.
+
+    No-op when filter not configured. The drop-direction filter is
+    reserved at the config layer but not implemented here yet — config
+    rejects it explicitly at startup.
+    """
+    if cfg.filter_keep_field is None or cfg.filter_values is None:
+        return table
+
+    field = cfg.filter_keep_field
+    if field not in table.column_names:
+        metrics.records_skipped_total.labels(reason="filter_field_missing").inc(len(table))
+        return table.slice(0, 0)
+
+    column = table[field]
+
+    # Column-type allowlist. PyArrow's `safe=True` cast happily coerces
+    # ints to bool, float, timestamp, date, etc. — every one of which
+    # silently produces a semantically-wrong match. Restrict the filter
+    # to integer and string columns explicitly so any other column type
+    # surfaces as `filter_field_missing` rather than a quiet, wrong match.
+    # Bool, float, timestamp, date, decimal, struct, list, map, etc. all
+    # land here.
+    if not (
+        pa.types.is_integer(column.type) or pa.types.is_string(column.type) or pa.types.is_large_string(column.type)
+    ):
+        log.warning(
+            "Filter field %r has unsupported type %s; supported types are integer and string. "
+            "Treating batch as field-missing.",
+            field,
+            column.type,
+        )
+        metrics.records_skipped_total.labels(reason="filter_field_missing").inc(len(table))
+        return table.slice(0, 0)
+
+    try:
+        # Default safe=True: any overflow or non-coercible source value
+        # raises rather than silently producing nulls. Catching here keeps
+        # a config-vs-schema mismatch (e.g. int values exceeding an int32
+        # column's range, or non-numeric strings against an int column)
+        # from crashing the pod.
+        value_array = pa.array(cfg.filter_values).cast(column.type)
+    except (pa.ArrowInvalid, pa.ArrowNotImplementedError, pa.ArrowTypeError) as e:
+        log.warning(
+            "Filter values %r incompatible with column %r type %s (%s); treating batch as field-missing",
+            cfg.filter_values,
+            field,
+            column.type,
+            e,
+        )
+        metrics.records_skipped_total.labels(reason="filter_field_missing").inc(len(table))
+        return table.slice(0, 0)
+
+    # is_in returns null for null inputs; fill_null(False) excludes them
+    # from the keep mask. Null rows are counted separately as
+    # filter_field_missing below.
+    keep_mask = pc.fill_null(pc.is_in(column, value_array), False)
+    null_count = column.null_count
+    n_original = len(table)
+    filtered = table.filter(keep_mask)
+    n_excluded = n_original - len(filtered) - null_count
+
+    if null_count > 0:
+        metrics.records_skipped_total.labels(reason="filter_field_missing").inc(null_count)
+    if n_excluded > 0:
+        metrics.records_skipped_total.labels(reason="filter_excluded").inc(n_excluded)
+    return filtered
 
 
 def _write_with_retry(sink, consolidated):
@@ -206,10 +303,12 @@ def main():
                     table = _convert_batch(values)
                     if table is not None:
                         skipped = len(values) - len(table)
-                        pending.append(table)
-                        pending_bytes += table.nbytes
-                        pending_records += len(table)
-                        metrics.pending_bytes.set(pending_bytes)
+                        table = _apply_filter(table, cfg)
+                        if len(table) > 0:
+                            pending.append(table)
+                            pending_bytes += table.nbytes
+                            pending_records += len(table)
+                            metrics.pending_bytes.set(pending_bytes)
                     else:
                         skipped = len(values)
 

--- a/millpond/metrics.py
+++ b/millpond/metrics.py
@@ -100,6 +100,15 @@ _schema_columns_widened_total = Counter(
     "Columns widened via schema evolution",
     ["pipeline", "broker_source"],
 )
+# Counts records that should have been sorted but weren't, broken down by
+# why. Distinct from `records_skipped_total` because the records still
+# land in the sink — only the sort was skipped, so the operational
+# signal is "sort coverage is degraded," not "data is missing."
+_sort_skipped_total = Counter(
+    "millpond_sort_skipped_total",
+    "Records in a flush whose sort step was skipped",
+    ["pipeline", "broker_source", "reason"],
+)
 
 # librdkafka internal stats (via statistics.interval.ms callback)
 _rdkafka_replyq = Gauge(
@@ -146,6 +155,7 @@ consumer_lag = _consumer_lag
 last_committed_offset = _last_committed_offset
 schema_columns_added_total = _schema_columns_added_total
 schema_columns_widened_total = _schema_columns_widened_total
+sort_skipped_total = _sort_skipped_total
 rdkafka_replyq = _rdkafka_replyq
 rdkafka_msg_cnt = _rdkafka_msg_cnt
 rdkafka_msg_size = _rdkafka_msg_size
@@ -160,7 +170,7 @@ def init(pipeline: str, broker_source: str = ""):
     global flush_duration_seconds, arrow_conversion_seconds
     global flush_size_bytes, flush_size_records
     global pending_bytes, buffer_fullness, consume_batch_size_current, consumer_lag, last_committed_offset
-    global schema_columns_added_total, schema_columns_widened_total
+    global schema_columns_added_total, schema_columns_widened_total, sort_skipped_total
     global rdkafka_replyq, rdkafka_msg_cnt, rdkafka_msg_size
     global rdkafka_broker_rtt_avg, rdkafka_broker_rtt_p99
 
@@ -170,6 +180,7 @@ def init(pipeline: str, broker_source: str = ""):
     records_consumed_total = _AutoCommonLabels(_records_consumed_total, pipeline, bs)
     batches_flushed_total = _AutoCommonLabels(_batches_flushed_total, pipeline, bs)
     records_skipped_total = _AutoCommonLabels(_records_skipped_total, pipeline, bs)
+    sort_skipped_total = _AutoCommonLabels(_sort_skipped_total, pipeline, bs)
     errors_total = _AutoCommonLabels(_errors_total, pipeline, bs)
     consumer_lag = _AutoCommonLabels(_consumer_lag, pipeline, bs)
     last_committed_offset = _AutoCommonLabels(_last_committed_offset, pipeline, bs)

--- a/tests/integration/test_iceberg_integration.py
+++ b/tests/integration/test_iceberg_integration.py
@@ -127,6 +127,7 @@ def _make_iceberg_cfg(catalog_uri: str, minio_endpoint: str, table_name: str) ->
         filter_keep_field=None,
         filter_drop_field=None,
         filter_values=None,
+        sort_by=None,
         kafka_config_overrides=(),
     )
 

--- a/tests/integration/test_iceberg_integration.py
+++ b/tests/integration/test_iceberg_integration.py
@@ -124,6 +124,9 @@ def _make_iceberg_cfg(catalog_uri: str, minio_endpoint: str, table_name: str) ->
         consume_batch_size=1,
         stats_interval_ms=1,
         broker_source="",
+        filter_keep_field=None,
+        filter_drop_field=None,
+        filter_values=None,
         kafka_config_overrides=(),
     )
 

--- a/tests/stress/stress_driver.py
+++ b/tests/stress/stress_driver.py
@@ -114,6 +114,7 @@ def _make_cfg(table_name: str) -> Config:
         filter_keep_field=None,
         filter_drop_field=None,
         filter_values=None,
+        sort_by=None,
         kafka_config_overrides=(),
     )
 

--- a/tests/stress/stress_driver.py
+++ b/tests/stress/stress_driver.py
@@ -111,6 +111,9 @@ def _make_cfg(table_name: str) -> Config:
         consume_batch_size=1,
         stats_interval_ms=1,
         broker_source="",
+        filter_keep_field=None,
+        filter_drop_field=None,
+        filter_values=None,
         kafka_config_overrides=(),
     )
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -404,3 +404,71 @@ class TestFilterConfig:
         monkeypatch.setenv("MILLPOND_FILTER_VALUES", "   ")
         with pytest.raises(RuntimeError, match="MILLPOND_FILTER_VALUES"):
             load()
+
+
+class TestSortByConfig:
+    """MILLPOND_SORT_BY parsing and validation."""
+
+    @pytest.fixture(autouse=True)
+    def _env(self, monkeypatch):
+        # Minimal valid DuckLake config — sort is destination-agnostic.
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+        monkeypatch.setenv("KAFKA_TOPIC", "test-topic")
+        monkeypatch.setenv("REPLICA_COUNT", "1")
+        monkeypatch.setenv("POD_NAME", "millpond-events-0")
+        monkeypatch.setenv("DUCKLAKE_TABLE", "events")
+        monkeypatch.setenv("DUCKLAKE_DATA_PATH", "s3://bucket/data")
+        monkeypatch.setenv("DUCKLAKE_RDS_HOST", "host")
+        monkeypatch.setenv("DUCKLAKE_RDS_PASSWORD", "pass")
+        monkeypatch.setenv("DUCKLAKE_CONNECTION", ":memory:")
+
+    def test_unset_yields_none(self):
+        cfg = load()
+        assert cfg.sort_by is None
+
+    def test_single_field(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_SORT_BY", "team_id")
+        cfg = load()
+        assert cfg.sort_by == ("team_id",)
+
+    def test_multi_field_order_preserved(self, monkeypatch):
+        # Sort order is determined by tuple position, so the parsing must
+        # preserve the operator-specified order verbatim.
+        monkeypatch.setenv("MILLPOND_SORT_BY", "team_id,timestamp,distinct_id")
+        cfg = load()
+        assert cfg.sort_by == ("team_id", "timestamp", "distinct_id")
+
+    def test_whitespace_around_fields_trimmed(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_SORT_BY", "  team_id ,  timestamp  ")
+        cfg = load()
+        assert cfg.sort_by == ("team_id", "timestamp")
+
+    def test_empty_tokens_dropped(self, monkeypatch):
+        # Trailing commas / doubled commas are common operator slips —
+        # drop them rather than fail loudly.
+        monkeypatch.setenv("MILLPOND_SORT_BY", "team_id,,timestamp,")
+        cfg = load()
+        assert cfg.sort_by == ("team_id", "timestamp")
+
+    def test_whitespace_only_value_yields_none(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_SORT_BY", "   ")
+        cfg = load()
+        assert cfg.sort_by is None
+
+    def test_unsafe_field_name_rejected(self, monkeypatch):
+        # Identifier safety pattern is enforced at config-load — keeps a
+        # SQL-injection-flavoured config from surfacing only under load.
+        monkeypatch.setenv("MILLPOND_SORT_BY", "team_id, foo; DROP TABLE x")
+        with pytest.raises(RuntimeError, match="unsafe characters"):
+            load()
+
+    def test_log_says_ascending(self, monkeypatch, caplog):
+        # The log line should make the (currently fixed) direction
+        # explicit so operators understand what they configured.
+        import logging
+
+        monkeypatch.setenv("MILLPOND_SORT_BY", "team_id,timestamp")
+        with caplog.at_level(logging.INFO, logger="millpond.config"):
+            load()
+        msgs = [r.message for r in caplog.records]
+        assert any("Sort by: team_id, timestamp (ascending)" in m for m in msgs)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -289,4 +289,118 @@ class TestLoadDestinationValidation:
         monkeypatch.setenv("ICEBERG_NAMESPACE", "millpond")
         cfg = load()
         assert cfg.destination == "ducklake"
-        assert cfg.iceberg_table is None
+
+
+class TestFilterConfig:
+    """MILLPOND_FILTER_{KEEP,DROP}_FIELD_NAME + MILLPOND_FILTER_VALUES."""
+
+    @pytest.fixture(autouse=True)
+    def _env(self, monkeypatch):
+        # Minimal valid DuckLake config — the filter feature is destination-agnostic.
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+        monkeypatch.setenv("KAFKA_TOPIC", "test-topic")
+        monkeypatch.setenv("REPLICA_COUNT", "1")
+        monkeypatch.setenv("POD_NAME", "millpond-events-0")
+        monkeypatch.setenv("DUCKLAKE_TABLE", "events")
+        monkeypatch.setenv("DUCKLAKE_DATA_PATH", "s3://bucket/data")
+        monkeypatch.setenv("DUCKLAKE_RDS_HOST", "host")
+        monkeypatch.setenv("DUCKLAKE_RDS_PASSWORD", "pass")
+        monkeypatch.setenv("DUCKLAKE_CONNECTION", ":memory:")
+
+    def test_unset_yields_none(self):
+        cfg = load()
+        assert cfg.filter_keep_field is None
+        assert cfg.filter_drop_field is None
+        assert cfg.filter_values is None
+
+    def test_int_allowlist_parsed_as_ints(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_FILTER_KEEP_FIELD_NAME", "team_id")
+        monkeypatch.setenv("MILLPOND_FILTER_VALUES", "2,4,1956,69")
+        cfg = load()
+        assert cfg.filter_keep_field == "team_id"
+        assert cfg.filter_values == (2, 4, 1956, 69)
+        # Homogeneous int tuple — every element must be int.
+        assert all(isinstance(v, int) for v in cfg.filter_values)
+
+    def test_string_allowlist_parsed_as_strings(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_FILTER_KEEP_FIELD_NAME", "region")
+        monkeypatch.setenv("MILLPOND_FILTER_VALUES", "us-east-1,us-west-2,eu-central-1")
+        cfg = load()
+        assert cfg.filter_keep_field == "region"
+        assert cfg.filter_values == ("us-east-1", "us-west-2", "eu-central-1")
+
+    def test_mixed_int_and_string_falls_back_to_string(self, monkeypatch):
+        # Once any token fails int parsing, the *whole* tuple is strings.
+        # This is the deterministic-typing contract — the apply code
+        # branches on the first element's type and would mis-handle a
+        # silently mixed tuple.
+        monkeypatch.setenv("MILLPOND_FILTER_KEEP_FIELD_NAME", "team_id")
+        monkeypatch.setenv("MILLPOND_FILTER_VALUES", "2,foo,4")
+        cfg = load()
+        assert cfg.filter_values == ("2", "foo", "4")
+
+    def test_whitespace_around_values_is_trimmed(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_FILTER_KEEP_FIELD_NAME", "team_id")
+        monkeypatch.setenv("MILLPOND_FILTER_VALUES", "  2 , 4  ,1956,  69  ")
+        cfg = load()
+        assert cfg.filter_values == (2, 4, 1956, 69)
+
+    def test_empty_tokens_are_dropped(self, monkeypatch):
+        # Trailing commas / repeated commas are common operator slips;
+        # drop empty tokens rather than fail loudly on them.
+        monkeypatch.setenv("MILLPOND_FILTER_KEEP_FIELD_NAME", "team_id")
+        monkeypatch.setenv("MILLPOND_FILTER_VALUES", "2,,4,")
+        cfg = load()
+        assert cfg.filter_values == (2, 4)
+
+    def test_negative_ints_parsed(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_FILTER_KEEP_FIELD_NAME", "team_id")
+        monkeypatch.setenv("MILLPOND_FILTER_VALUES", "-1,0,42")
+        cfg = load()
+        assert cfg.filter_values == (-1, 0, 42)
+
+    def test_keep_field_without_values_rejected(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_FILTER_KEEP_FIELD_NAME", "team_id")
+        with pytest.raises(RuntimeError, match="MILLPOND_FILTER_VALUES"):
+            load()
+
+    def test_values_without_field_rejected(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_FILTER_VALUES", "1,2,3")
+        with pytest.raises(RuntimeError, match="MILLPOND_FILTER_VALUES"):
+            load()
+
+    def test_keep_and_drop_mutually_exclusive(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_FILTER_KEEP_FIELD_NAME", "team_id")
+        monkeypatch.setenv("MILLPOND_FILTER_DROP_FIELD_NAME", "team_id")
+        monkeypatch.setenv("MILLPOND_FILTER_VALUES", "1,2")
+        with pytest.raises(RuntimeError, match="mutually exclusive"):
+            load()
+
+    def test_drop_direction_rejected_until_implemented(self, monkeypatch):
+        # Reserved namespace: drop is parsed and validated but explicitly
+        # refused so an operator setting it today gets a clear startup
+        # error rather than silently no-filtering.
+        monkeypatch.setenv("MILLPOND_FILTER_DROP_FIELD_NAME", "team_id")
+        monkeypatch.setenv("MILLPOND_FILTER_VALUES", "1,2")
+        with pytest.raises(RuntimeError, match="reserved for a future release"):
+            load()
+
+    def test_unsafe_field_name_rejected(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_FILTER_KEEP_FIELD_NAME", "team_id; DROP TABLE x")
+        monkeypatch.setenv("MILLPOND_FILTER_VALUES", "1")
+        with pytest.raises(RuntimeError, match="unsafe characters"):
+            load()
+
+    def test_whitespace_only_field_name_treated_as_unset(self, monkeypatch):
+        # Symmetric with how DESTINATION handles whitespace — operator
+        # rendering glitches shouldn't enable a filter accidentally.
+        monkeypatch.setenv("MILLPOND_FILTER_KEEP_FIELD_NAME", "   ")
+        cfg = load()
+        assert cfg.filter_keep_field is None
+        assert cfg.filter_values is None
+
+    def test_values_only_whitespace_treated_as_unset(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_FILTER_KEEP_FIELD_NAME", "team_id")
+        monkeypatch.setenv("MILLPOND_FILTER_VALUES", "   ")
+        with pytest.raises(RuntimeError, match="MILLPOND_FILTER_VALUES"):
+            load()

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -162,6 +162,9 @@ def _make_cfg(**overrides) -> Config:
         consume_batch_size=1000,
         stats_interval_ms=5000,
         broker_source="",
+        filter_keep_field=None,
+        filter_drop_field=None,
+        filter_values=None,
         kafka_config_overrides=(("security.protocol", "SSL"),),
     )
     defaults.update(overrides)

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -165,6 +165,7 @@ def _make_cfg(**overrides) -> Config:
         filter_keep_field=None,
         filter_drop_field=None,
         filter_values=None,
+        sort_by=None,
         kafka_config_overrides=(("security.protocol", "SSL"),),
     )
     defaults.update(overrides)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -204,6 +204,301 @@ class TestArrowConversionTiming:
         """If convert() returns None, no timing should be observed."""
         mock_converter.convert.return_value = None
 
-        table = _convert_batch([b'garbage'])
+        table = _convert_batch([b"garbage"])
         assert table is None
         mock_metrics.arrow_conversion_seconds.observe.assert_not_called()
+
+
+def _capture_skip_calls(mock_metrics):
+    """Bind (reason, count) pairs from records_skipped_total inc() calls.
+
+    The default MagicMock pattern memoizes labels(...) to a single inner
+    mock, so inc() calls across distinct reason values land in a flat
+    list and the reason→count binding is lost. This helper installs a
+    side_effect on labels() so each call returns a fresh counter that
+    appends (reason, n) into a shared log. Tests assert on the log
+    directly — both ordering and pairing are observable.
+    """
+    skip_calls: list[tuple[str, int]] = []
+
+    def _counter_for(reason):
+        counter = MagicMock()
+        counter.inc.side_effect = lambda n, r=reason: skip_calls.append((r, n))
+        return counter
+
+    mock_metrics.records_skipped_total.labels.side_effect = _counter_for
+    return skip_calls
+
+
+class TestApplyFilter:
+    """Hot-path keep-filter behaviour. Mocks the metrics module so the
+    skipped-record counter calls are visible without setting up a real
+    Prometheus registry. Each test constructs a Config-shaped object only
+    with the fields _apply_filter reads."""
+
+    def _cfg(self, *, keep=None, values=None):
+        cfg = MagicMock()
+        cfg.filter_keep_field = keep
+        cfg.filter_values = values
+        return cfg
+
+    def test_no_op_when_filter_unconfigured(self):
+        from millpond.main import _apply_filter
+
+        table = pa.table({"team_id": [1, 2, 3]})
+        result = _apply_filter(table, self._cfg())
+        # Same object: no slicing or filtering — short-circuit at the top.
+        assert result is table
+
+    @patch("millpond.main.metrics")
+    def test_int_allowlist_keeps_matching_rows(self, mock_metrics):
+        from millpond.main import _apply_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        table = pa.table({"team_id": [1, 2, 3, 4, 5], "event": ["a", "b", "c", "d", "e"]})
+        result = _apply_filter(table, self._cfg(keep="team_id", values=(2, 4)))
+
+        assert result.num_rows == 2
+        assert result.column("team_id").to_pylist() == [2, 4]
+        assert result.column("event").to_pylist() == ["b", "d"]
+        # 3 of 5 rows fail the allowlist; exactly one increment, bound to
+        # the correct reason.
+        assert skip_calls == [("filter_excluded", 3)]
+
+    @patch("millpond.main.metrics")
+    def test_string_allowlist_keeps_matching_rows(self, mock_metrics):
+        from millpond.main import _apply_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        table = pa.table({"region": ["us-east-1", "us-west-2", "eu-central-1"]})
+        result = _apply_filter(table, self._cfg(keep="region", values=("us-east-1", "eu-central-1")))
+
+        assert result.column("region").to_pylist() == ["us-east-1", "eu-central-1"]
+        assert skip_calls == [("filter_excluded", 1)]
+
+    @patch("millpond.main.metrics")
+    def test_int_values_coerce_to_string_column(self, mock_metrics):
+        # When the column is string-typed and values parsed as int, the
+        # values get cast to their canonical string form ("2") and matched
+        # against the column. JSON ints sometimes deserialise as Arrow
+        # strings; this is the supported path. Leading-zero strings like
+        # "02" deliberately do NOT match a configured value of 2 — strict
+        # string equality after coercion. See
+        # `test_leading_zero_strings_do_not_match_int_values` for the
+        # adjacent contract.
+        from millpond.main import _apply_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        table = pa.table({"team_id": ["1", "2", "3"]})
+        result = _apply_filter(table, self._cfg(keep="team_id", values=(2,)))
+
+        assert result.num_rows == 1
+        assert result.column("team_id").to_pylist() == ["2"]
+        # Two excluded rows ("1", "3"); pin the (reason, count) binding.
+        assert skip_calls == [("filter_excluded", 2)]
+
+    @patch("millpond.main.metrics")
+    def test_leading_zero_strings_do_not_match_int_values(self, mock_metrics):
+        # Documents the strict-string-equality semantic. An operator who
+        # wants to match leading-zero IDs must configure them as strings
+        # (`MILLPOND_FILTER_VALUES=02`).
+        from millpond.main import _apply_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        table = pa.table({"team_id": ["02", "2", "003"]})
+        result = _apply_filter(table, self._cfg(keep="team_id", values=(2,)))
+
+        # Only the unambiguous "2" matches; the leading-zero strings don't.
+        assert result.column("team_id").to_pylist() == ["2"]
+        assert skip_calls == [("filter_excluded", 2)]
+
+    @patch("millpond.main.metrics")
+    def test_missing_field_drops_whole_batch(self, mock_metrics):
+        from millpond.main import _apply_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        table = pa.table({"event": ["a", "b", "c"]})
+        result = _apply_filter(table, self._cfg(keep="team_id", values=(1, 2)))
+
+        # Column not in schema → whole batch lands in filter_field_missing.
+        assert result.num_rows == 0
+        assert skip_calls == [("filter_field_missing", 3)]
+
+    @patch("millpond.main.metrics")
+    def test_null_values_counted_as_field_missing(self, mock_metrics):
+        # Distinguishing the two skip-reason buckets is the whole point of
+        # the dual-counter design: missing/null is anomalous, excluded is
+        # expected steady-state behaviour. The assertion pins the bucket
+        # *and* the count, not just the sorted set of counts.
+        from millpond.main import _apply_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        table = pa.table({"team_id": pa.array([1, None, 2, None, 3], type=pa.int64())})
+        result = _apply_filter(table, self._cfg(keep="team_id", values=(1, 2)))
+
+        assert result.num_rows == 2
+        assert result.column("team_id").to_pylist() == [1, 2]
+        # 2 nulls → field_missing; 1 row (team_id=3) → excluded.
+        assert sorted(skip_calls) == [("filter_excluded", 1), ("filter_field_missing", 2)]
+
+    @patch("millpond.main.metrics")
+    def test_all_rows_kept_emits_no_skip_metric(self, mock_metrics):
+        from millpond.main import _apply_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        table = pa.table({"team_id": [1, 2, 1]})
+        result = _apply_filter(table, self._cfg(keep="team_id", values=(1, 2)))
+
+        assert result.num_rows == 3
+        assert skip_calls == []
+
+    @patch("millpond.main.metrics")
+    def test_all_rows_dropped_returns_empty_table_with_same_schema(self, mock_metrics):
+        from millpond.main import _apply_filter
+
+        _capture_skip_calls(mock_metrics)
+        table = pa.table({"team_id": [9, 10, 11], "event": ["a", "b", "c"]})
+        result = _apply_filter(table, self._cfg(keep="team_id", values=(1, 2)))
+
+        assert result.num_rows == 0
+        # Schema is preserved — important so a downstream concat doesn't trip
+        # on a column mismatch when a batch happens to filter to empty.
+        assert result.schema == table.schema
+
+    @patch("millpond.main.metrics")
+    def test_empty_input_batch_is_no_op(self, mock_metrics):
+        from millpond.main import _apply_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        table = pa.table({"team_id": pa.array([], type=pa.int64())})
+        result = _apply_filter(table, self._cfg(keep="team_id", values=(1, 2)))
+
+        assert result.num_rows == 0
+        assert skip_calls == []
+
+    # --- Schema variance / cast failure paths --------------------------------
+
+    @patch("millpond.main.metrics")
+    def test_multi_chunk_column_is_handled(self, mock_metrics):
+        # Defensive against the case where a column ends up multi-chunk
+        # (a fresh `_convert_batch` output is single-chunk, but anything
+        # that goes through ChunkedArray-producing arrow surgery later
+        # could pass one in). The compute kernels we use must work on
+        # multi-chunk inputs and `column.null_count` must aggregate
+        # across chunks correctly.
+        from millpond.main import _apply_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        team_ids = pa.chunked_array([[1, 2], [3, 4, 5], [2]])
+        events = pa.chunked_array([["a", "b"], ["c", "d", "e"], ["f"]])
+        table = pa.table({"team_id": team_ids, "event": events})
+
+        result = _apply_filter(table, self._cfg(keep="team_id", values=(2,)))
+
+        # Two rows match (the two 2s spread across chunks 0 and 2).
+        assert result.column("team_id").to_pylist() == [2, 2]
+        assert result.column("event").to_pylist() == ["b", "f"]
+        assert skip_calls == [("filter_excluded", 4)]
+
+    # --- Unsupported column types (must skip, not silently match) ----------
+    #
+    # The filter restricts itself to integer and string columns. Everything
+    # else lands the batch in `filter_field_missing` so the operator sees
+    # a clear signal in the skip-reason metric rather than a quiet,
+    # semantically-wrong match. Each of the tests below pins one specific
+    # column type the explicit allowlist rejects — bool, float, timestamp,
+    # struct, list — plus the cast-overflow case for in-range types.
+
+    @patch("millpond.main.metrics")
+    def test_bool_column_rejected_as_unsupported(self, mock_metrics):
+        # PyArrow happily casts ints to bool (0→False, non-zero→True),
+        # which would otherwise mean `MILLPOND_FILTER_VALUES=2` keeps
+        # every `True` row regardless of the configured value. The
+        # column-type allowlist explicitly rejects bool to prevent that.
+        from millpond.main import _apply_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        table = pa.table({"flag": pa.array([True, False, True, False], type=pa.bool_())})
+
+        result = _apply_filter(table, self._cfg(keep="flag", values=(1,)))
+
+        assert result.num_rows == 0
+        assert skip_calls == [("filter_field_missing", 4)]
+
+    @patch("millpond.main.metrics")
+    def test_float_column_rejected_as_unsupported(self, mock_metrics):
+        # Without the allowlist, `(2,)` would cast to `2.0` and silently
+        # match floating rows that happen to equal 2.0. We don't want
+        # equality-on-float-columns semantics to be a hidden feature.
+        from millpond.main import _apply_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        table = pa.table({"score": pa.array([1.0, 2.0, 3.0], type=pa.float64())})
+
+        result = _apply_filter(table, self._cfg(keep="score", values=(2,)))
+
+        assert result.num_rows == 0
+        assert skip_calls == [("filter_field_missing", 3)]
+
+    @patch("millpond.main.metrics")
+    def test_timestamp_column_rejected_as_unsupported(self, mock_metrics):
+        # Without the allowlist, ints cast to timestamp as
+        # microseconds-since-epoch — a wildly surprising match. Reject.
+        from millpond.main import _apply_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        ts_col = pa.array([1700000000_000000, 1700000001_000000], type=pa.timestamp("us"))
+        table = pa.table({"ts": ts_col})
+
+        result = _apply_filter(table, self._cfg(keep="ts", values=(1700000000_000000,)))
+
+        assert result.num_rows == 0
+        assert skip_calls == [("filter_field_missing", 2)]
+
+    @patch("millpond.main.metrics")
+    def test_struct_column_rejected_as_unsupported(self, mock_metrics):
+        # Struct columns hit the same allowlist rejection — critical
+        # because a struct-cast was the previous crash hazard, and the
+        # column-type check fires *before* the cast attempt.
+        from millpond.main import _apply_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        struct_col = pa.array(
+            [{"a": 1}, {"a": 2}, {"a": 3}],
+            type=pa.struct([pa.field("a", pa.int64())]),
+        )
+        table = pa.table({"team_id": struct_col})
+
+        result = _apply_filter(table, self._cfg(keep="team_id", values=(1, 2)))
+
+        assert result.num_rows == 0
+        assert skip_calls == [("filter_field_missing", 3)]
+
+    @patch("millpond.main.metrics")
+    def test_list_column_rejected_as_unsupported(self, mock_metrics):
+        from millpond.main import _apply_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        list_col = pa.array([[1, 2], [3], [4, 5, 6]], type=pa.list_(pa.int64()))
+        table = pa.table({"team_id": list_col})
+
+        result = _apply_filter(table, self._cfg(keep="team_id", values=(1, 2)))
+
+        assert result.num_rows == 0
+        assert skip_calls == [("filter_field_missing", 3)]
+
+    @patch("millpond.main.metrics")
+    def test_int_values_overflowing_int32_column_skip_batch(self, mock_metrics):
+        # Integer column type passes the allowlist; the cast itself
+        # raises on width overflow under `safe=True`, and that lands in
+        # the cast-failure branch (still `filter_field_missing`, but a
+        # different code path from the unsupported-type case above).
+        from millpond.main import _apply_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        table = pa.table({"team_id": pa.array([1, 2, 3], type=pa.int32())})
+        # 2**40 is well outside int32 range.
+        result = _apply_filter(table, self._cfg(keep="team_id", values=(2**40,)))
+
+        assert result.num_rows == 0
+        assert skip_calls == [("filter_field_missing", 3)]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -107,6 +107,11 @@ class TestFlushErrorDistinction:
         sink = _make_sink()
         cfg = MagicMock()
         cfg.table_label = "test_table"
+        # Pin sort_by to None so _apply_sort() short-circuits — otherwise
+        # the bare MagicMock returns a MagicMock for cfg.sort_by which
+        # _apply_sort treats as a configured (truthy, iterable) value and
+        # pyarrow's sort_keys validation raises.
+        cfg.sort_by = None
         kafka = MagicMock()
         table = pa.table({"a": [1, 2]})
         offsets = {("topic", 0): 42}
@@ -502,3 +507,242 @@ class TestApplyFilter:
 
         assert result.num_rows == 0
         assert skip_calls == [("filter_field_missing", 3)]
+
+
+def _capture_sort_skip_calls(mock_metrics):
+    """Bind (reason, count) pairs from sort_skipped_total inc() calls.
+
+    Mirrors `_capture_skip_calls` but for the sort-skip metric so the
+    sort tests don't have to do `labels.return_value.inc.call_args_list`
+    introspection and risk the same MagicMock memoisation pitfall the
+    filter tests hit.
+    """
+    sort_calls: list[tuple[str, int]] = []
+
+    def _counter_for(reason):
+        counter = MagicMock()
+        counter.inc.side_effect = lambda n, r=reason: sort_calls.append((r, n))
+        return counter
+
+    mock_metrics.sort_skipped_total.labels.side_effect = _counter_for
+    return sort_calls
+
+
+class TestApplySort:
+    """Hot-path pre-write sort behaviour.
+
+    `_apply_sort` runs inside `_flush()` between consolidate and write;
+    the unit tests here drive it directly with handcrafted tables.
+    `cfg` is a MagicMock with `sort_by` (and any other field we read)
+    pinned explicitly — see filter-test rationale for why the bare
+    MagicMock pattern is a trap.
+    """
+
+    def _cfg(self, sort_by=None):
+        cfg = MagicMock()
+        cfg.sort_by = sort_by
+        return cfg
+
+    def _clear_warned(self):
+        # Module-level dedup set leaks between tests if not reset.
+        import millpond.main as _main
+
+        _main._sort_missing_fields_warned.clear()
+
+    def test_no_op_when_unconfigured(self):
+        from millpond.main import _apply_sort
+
+        table = pa.table({"team_id": [3, 1, 2]})
+        result = _apply_sort(table, self._cfg(sort_by=None))
+        # Same object: short-circuit at top.
+        assert result is table
+
+    @patch("millpond.main.metrics")
+    def test_single_field_ascending(self, mock_metrics):
+        from millpond.main import _apply_sort
+
+        sort_calls = _capture_sort_skip_calls(mock_metrics)
+        table = pa.table({"team_id": [3, 1, 2], "event": ["c", "a", "b"]})
+        result = _apply_sort(table, self._cfg(sort_by=("team_id",)))
+
+        assert result.column("team_id").to_pylist() == [1, 2, 3]
+        # event column must reorder consistently — full-row reordering.
+        assert result.column("event").to_pylist() == ["a", "b", "c"]
+        assert sort_calls == []
+
+    @patch("millpond.main.metrics")
+    def test_multi_field_sort_left_to_right(self, mock_metrics):
+        # First field is primary key, second is secondary, etc. The
+        # multi-field test pins this ordering: equal team_id rows are
+        # sub-sorted by timestamp.
+        from millpond.main import _apply_sort
+
+        _capture_sort_skip_calls(mock_metrics)
+        table = pa.table(
+            {
+                "team_id": [2, 1, 2, 1],
+                "timestamp": [200, 100, 100, 200],
+                "event": ["d", "b", "c", "a"],
+            }
+        )
+        result = _apply_sort(table, self._cfg(sort_by=("team_id", "timestamp")))
+
+        assert result.column("team_id").to_pylist() == [1, 1, 2, 2]
+        assert result.column("timestamp").to_pylist() == [100, 200, 100, 200]
+        # "b" had (team_id=1, timestamp=100) → first row in sort order; etc.
+        assert result.column("event").to_pylist() == ["b", "a", "c", "d"]
+
+    @patch("millpond.main.metrics")
+    def test_sort_is_stable(self, mock_metrics):
+        # PyArrow's sort_indices is stable. Equal keys preserve input order;
+        # this lets operators reason about secondary attributes without
+        # naming them in the sort key.
+        from millpond.main import _apply_sort
+
+        _capture_sort_skip_calls(mock_metrics)
+        # Two rows share team_id=1; input order: (event=alpha) before (event=beta).
+        # After ascending sort by team_id, alpha must still precede beta.
+        table = pa.table({"team_id": [1, 2, 1], "event": ["alpha", "x", "beta"]})
+        result = _apply_sort(table, self._cfg(sort_by=("team_id",)))
+
+        assert result.column("team_id").to_pylist() == [1, 1, 2]
+        assert result.column("event").to_pylist() == ["alpha", "beta", "x"]
+
+    @patch("millpond.main.metrics")
+    def test_nulls_placed_at_end(self, mock_metrics):
+        # Default null_placement="at_end" — null rows still ride through
+        # the sink, just sorted to the tail. They are NOT counted as
+        # sort-skipped (the sort applied; some rows just happened to be
+        # null in the key).
+        from millpond.main import _apply_sort
+
+        sort_calls = _capture_sort_skip_calls(mock_metrics)
+        table = pa.table({"team_id": pa.array([3, None, 1, None, 2], type=pa.int64())})
+        result = _apply_sort(table, self._cfg(sort_by=("team_id",)))
+
+        assert result.column("team_id").to_pylist() == [1, 2, 3, None, None]
+        assert sort_calls == []
+
+    @patch("millpond.main.metrics")
+    def test_missing_field_skips_sort_and_increments_metric(self, mock_metrics):
+        # Critical contract: a missing sort field MUST NOT drop records.
+        # The data still rides through to the sink in its existing
+        # (unsorted) order; only the sort step was skipped.
+        self._clear_warned()
+        from millpond.main import _apply_sort
+
+        sort_calls = _capture_sort_skip_calls(mock_metrics)
+        table = pa.table({"event": ["c", "a", "b"]})
+        result = _apply_sort(table, self._cfg(sort_by=("team_id",)))
+
+        # Order unchanged — proves the records weren't filtered or sorted
+        # by a different key when the configured key was unavailable.
+        assert result.column("event").to_pylist() == ["c", "a", "b"]
+        assert sort_calls == [("field_missing", 3)]
+
+    @patch("millpond.main.metrics")
+    def test_partial_missing_fields_skip_sort(self, mock_metrics):
+        # Multi-field sort: if ANY configured field is absent, the whole
+        # sort is skipped (rather than partially sorting on the available
+        # fields, which would silently differ from the operator's intent).
+        self._clear_warned()
+        from millpond.main import _apply_sort
+
+        sort_calls = _capture_sort_skip_calls(mock_metrics)
+        table = pa.table({"team_id": [2, 1, 3]})  # has team_id, missing timestamp
+        result = _apply_sort(table, self._cfg(sort_by=("team_id", "timestamp")))
+
+        assert result.column("team_id").to_pylist() == [2, 1, 3]
+        assert sort_calls == [("field_missing", 3)]
+
+    @patch("millpond.main.metrics")
+    def test_missing_field_warning_logged_once_per_pattern(self, mock_metrics, caplog):
+        # The metric increments every flush; the *log* is once per
+        # missing-fields pattern. This is what keeps a misconfigured
+        # high-volume topic from spamming logs.
+        self._clear_warned()
+        import logging
+
+        from millpond.main import _apply_sort
+
+        _capture_sort_skip_calls(mock_metrics)
+        table = pa.table({"event": ["a"]})
+        cfg = self._cfg(sort_by=("team_id",))
+
+        with caplog.at_level(logging.WARNING, logger="millpond.main"):
+            for _ in range(5):
+                _apply_sort(table, cfg)
+
+        warnings_for_pattern = [
+            r for r in caplog.records if "Sort field(s) missing" in r.message and "team_id" in r.message
+        ]
+        assert len(warnings_for_pattern) == 1
+
+    @patch("millpond.main.metrics")
+    def test_distinct_missing_patterns_each_log_once(self, mock_metrics, caplog):
+        # If a deployment somehow sees two different missing-fields
+        # patterns (e.g. schema drift), each gets its own warning so the
+        # operator sees both signals.
+        self._clear_warned()
+        import logging
+
+        from millpond.main import _apply_sort
+
+        _capture_sort_skip_calls(mock_metrics)
+        cfg_a = self._cfg(sort_by=("team_id",))
+        cfg_b = self._cfg(sort_by=("distinct_id",))
+        table = pa.table({"event": ["a"]})
+
+        with caplog.at_level(logging.WARNING, logger="millpond.main"):
+            _apply_sort(table, cfg_a)
+            _apply_sort(table, cfg_a)  # already-warned pattern
+            _apply_sort(table, cfg_b)
+            _apply_sort(table, cfg_b)  # already-warned pattern
+
+        warnings = [r for r in caplog.records if "Sort field(s) missing" in r.message]
+        # One per distinct pattern.
+        assert len(warnings) == 2
+
+    @patch("millpond.main.metrics")
+    def test_empty_input_batch_is_no_op(self, mock_metrics):
+        # Edge case: a fully-filtered-out batch reaches the sort step
+        # with zero rows. sort_indices on empty returns empty; take()
+        # returns an empty table with the same schema. No metric.
+        from millpond.main import _apply_sort
+
+        sort_calls = _capture_sort_skip_calls(mock_metrics)
+        table = pa.table({"team_id": pa.array([], type=pa.int64())})
+        result = _apply_sort(table, self._cfg(sort_by=("team_id",)))
+
+        assert result.num_rows == 0
+        assert sort_calls == []
+
+    @patch("millpond.main.metrics")
+    def test_multi_chunk_column_sorted_correctly(self, mock_metrics):
+        # Defensive: sort_indices must aggregate across chunks correctly
+        # (it does in PyArrow). Pin this so a future regression doesn't
+        # ship a per-chunk sort that looks correct only on single-chunk
+        # tables.
+        from millpond.main import _apply_sort
+
+        _capture_sort_skip_calls(mock_metrics)
+        team_ids = pa.chunked_array([[3, 1], [4, 1], [2]])
+        events = pa.chunked_array([["a", "b"], ["c", "d"], ["e"]])
+        table = pa.table({"team_id": team_ids, "event": events})
+
+        result = _apply_sort(table, self._cfg(sort_by=("team_id",)))
+        assert result.column("team_id").to_pylist() == [1, 1, 2, 3, 4]
+        # Stable sort preserves the two team_id=1 rows' relative order.
+        assert result.column("event").to_pylist() == ["b", "d", "e", "a", "c"]
+
+    @patch("millpond.main.metrics")
+    def test_sorts_by_string_column(self, mock_metrics):
+        # Sort keys aren't limited to integers — string columns sort
+        # lexically, also ascending.
+        from millpond.main import _apply_sort
+
+        _capture_sort_skip_calls(mock_metrics)
+        table = pa.table({"region": ["us-west-2", "eu-central-1", "us-east-1"]})
+        result = _apply_sort(table, self._cfg(sort_by=("region",)))
+
+        assert result.column("region").to_pylist() == ["eu-central-1", "us-east-1", "us-west-2"]


### PR DESCRIPTION
## Summary

Two new optional pre-sink record-handling stages, both backend-agnostic, both implemented in \`main.py\` so the Sink Protocol stays a pure write surface. Reviewed twice (Lead QE + Principal SWE perspectives) with the filter feature reworked in response to the first round.

| Stage | Env vars | Where it runs |
|---|---|---|
| Allowlist filter | \`MILLPOND_FILTER_KEEP_FIELD_NAME\`, \`MILLPOND_FILTER_VALUES\` (\`MILLPOND_FILTER_DROP_FIELD_NAME\` reserved for a future denylist) | After JSON→Arrow, before pending buffer |
| Pre-write sort | \`MILLPOND_SORT_BY\` | After \`pa.concat_tables\`, before \`sink.write()\` |

## Commits

### \`82e18c6\` Allowlist filter

- Drops records whose value in the configured field is not in the configured allowlist.
- Two skip reasons tracked distinctly on \`records_skipped_total\`: \`filter_field_missing\` (column absent, null, or unsupported type) and \`filter_excluded\` (value not in allowlist).
- Values auto-detect int vs string at config load.
- **Column-type allowlist**: only integer and string columns are filterable. Bool/float/timestamp/struct/list/etc. are explicitly rejected because PyArrow's \`safe=True\` cast otherwise silently produces semantically-wrong matches (int \`2\` → \`True\` on a bool column, \`2.0\` on a float column, epoch-µs timestamp on a timestamp column, etc.).
- Cast direction is values→column (small array cast to big column's type, not the other way), wrapped in \`try/except\` so a single unexpected batch shape doesn't kill the consume loop. Schema drift across batches is handled by construction.
- \`MILLPOND_FILTER_DROP_FIELD_NAME\` reserved at the config layer (mutex with keep) so a later denylist add doesn't churn env-var names.
- 25 unit tests covering happy path, both skip reasons, type variance (int/string/multi-chunk ChunkedArray), unsupported types (bool, float, timestamp, struct, list), schema preservation, overflow, and metric-reason↔count binding via a \`_capture_skip_calls\` helper.

### \`6587725\` Pre-write sort + docs

- Sorts the consolidated batch ascending by one or more columns right before \`sink.write()\`. Both DuckLake and Iceberg sinks see pre-sorted data. Stable sort.
- Sink-side partition columns (\`year/month/day/hour\`) are not in scope by design — operators sort by source-schema fields.
- Missing-field semantics: any configured field absent → whole sort skipped (records still flow), \`sort_skipped_total{reason=\"field_missing\"}\` increments by record count, warning logs once per distinct missing-fields pattern per pod lifetime (dedup set guards against per-flush log floods).
- New \`sort_skipped_total\` metric, deliberately distinct from \`records_skipped_total\` because no data is dropped — only the layout improvement was skipped.
- Per-flush cost ~50–200 ms at 256 MB / 30k-row batches (mostly \`pa.Table.take()\`'s full-column rewrite); peak memory ~2× the flush buffer during the take.
- 12 unit tests for sort behaviour (single/multi-field, stability, null placement, missing-field skip, log-dedup, multi-chunk, string keys) + 8 config tests.
- README.md gets a new \"Record Handling\" section plus env-var docs; AGENT.md gets the architecture loop update and a design-decisions section explaining cast-direction, column-type allowlist, drop-direction reservation, and the sort-skipped metric semantics.

## Pre-push checklist results

- \`uv run ruff format --check millpond/\` — clean
- \`uv run ruff check millpond/\` — clean
- \`uv run pytest -m \"not integration and not e2e and not stress\"\` — **529 passed**
- \`just test-integration\` — 14 passed
- \`just test-e2e\` (DuckLake) — 4 passed
- \`just test-e2e-iceberg\` — 5 passed

## Test plan

- [x] Unit tests cover filter happy path + every skip reason + every rejected-type case
- [x] Unit tests cover sort behaviour including missing-field skip and log dedup
- [x] Integration suite passes (filter/sort env vars unset, code paths short-circuit)
- [x] E2E DuckLake + Iceberg suites pass (same)
- [ ] Smoke test with \`MILLPOND_FILTER_KEEP_FIELD_NAME=team_id MILLPOND_FILTER_VALUES=1\` against a docker-compose pipeline — verify only team-1 records land in the lake
- [ ] Smoke test with \`MILLPOND_SORT_BY=team_id,timestamp\` — verify resulting parquet files are sorted (and ideally check the compression ratio change)