### PR TITLE
docs: post-icebox-merge corrections + slim main README

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -5,13 +5,15 @@
 Always run before pushing:
 
 ```bash
-just lint              # ruff check
-just fmt-check         # ruff format --check
+just lint              # ruff check (currently scoped to millpond/ only — see note)
+just fmt-check         # ruff format --check (currently scoped to millpond/ only — see note)
 just test              # unit tests
-just test-integration  # MinIO + iceberg-rest via testcontainers (~10s)
+just test-integration  # icebox Docker stack + MinIO + iceberg-rest via testcontainers (~2 min)
 just test-e2e          # full DuckLake stack (~1m)
 just test-e2e-iceberg  # full Iceberg stack (~1m)
 ```
+
+Note: `just lint` and `just fmt-check` only run against `millpond/` today; the recipes predate the `icebox/`, `shared/`, and `tests/` additions. Pre-commit hooks run ruff project-wide, so lint failures still surface — but the just recipes themselves are scope-narrow until they're updated.
 
 All must pass. Do not push with any lint, test, integration, or e2e failures — CI runs all of these on every push and PR (`.github/workflows/ci.yaml`), and the integration/e2e jobs are gating. Catch failures locally rather than on the runner.
 
@@ -168,7 +170,7 @@ If Python ever shows up in profiles, the entire app ports to C with the same str
 
 Two critical tuning knobs for confluent-kafka-python:
 
-1. **Use `consume(num_messages=N)` batch API, not `poll()`**. Amortizes the Python↔C boundary crossing cost per call. The `consume()` [docstring](https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#confluent_kafka.Consumer.consume) explicitly notes it is more performant than calling `poll()` in a loop. Community benchmarks report significant throughput gains (see confluent-kafka-python issues [#291](https://github.com/confluentinc/confluent-kafka-python/issues/291), [#612](https://github.com/confluentinc/confluent-kafka-python/issues/612)).
+1. **Use `consume(num_messages=N)` batch API, not `poll()`**. The librdkafka C extension's per-call overhead is fixed, so one `consume(num_messages=N)` is cheaper than N `poll()` calls — the FFI-amortization argument is conceptual (it is not stated as such in the [docstring](https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#confluent_kafka.Consumer.consume), which only describes the API contract). The recommendation matches community consensus (see [confluent-kafka-python #580](https://github.com/confluentinc/confluent-kafka-python/issues/580) for the API-shape discussion). [#597](https://github.com/confluentinc/confluent-kafka-python/issues/597) reports a 4× throughput gap, but as ProcessPoolExecutor vs ThreadPoolExecutor under the GIL with both legs using `consume()` — not as `consume()` vs `poll()` — so don't cite it for the latter.
 
 2. **Set `fetch.min.bytes` to 1MB+** (default is 1 byte). This is the single biggest throughput lever — reduces fetch request count dramatically by letting the broker accumulate data before responding. Trade latency for throughput. Pair with `fetch.max.wait.ms=500`. See [Kafka consumer config docs](https://kafka.apache.org/documentation/#consumerconfigs_fetch.min.bytes) and [Confluent throughput optimization guide](https://docs.confluent.io/cloud/current/client-apps/optimizing/throughput.html).
 
@@ -180,7 +182,7 @@ Pod ordinal from StatefulSet hostname (e.g. `millpond-events-3` → ordinal `3`)
 my_partitions = [p for p in range(partition_count) if p % replica_count == ordinal]
 ```
 
-**Partition count**: discovered at startup via `consumer.list_topics(topic)`. No env var — eliminates desync risk if partitions are added server-side.
+**Partition count**: discovered at startup via `admin.list_topics(topic=cfg.topic, timeout=30)` (an `AdminClient`, not the consumer instance). No env var — eliminates desync risk if partitions are added server-side.
 
 **Replica count**: set via `REPLICA_COUNT` env var (matches `spec.replicas` in the StatefulSet). This is operator-controlled and can't be discovered reliably from inside the pod.
 
@@ -190,7 +192,7 @@ Scaling requires updating both `spec.replicas` and the `REPLICA_COUNT` env var.
 
 **`auto.offset.reset=earliest`**: required. With `assign()`, if a partition has no committed offset (new partition, or `GROUP_ID` changed), the default `latest` silently drops all existing data. `earliest` replays from the beginning — safe for at-least-once.
 
-**`group.id`**: defaults to `millpond-{topic}-{table}`. Used only for offset storage in `__consumer_offsets` (no consumer group semantics). Changing `group.id` loses all committed offsets and triggers a full replay from `earliest`.
+**`group.id`**: defaults to `millpond-{topic}-{table_label_part}` (where `table_label_part` is derived from the destination table identifier in `config.py:353`). Used only for offset storage in `__consumer_offsets` (no consumer group semantics). Changing `group.id` loses all committed offsets and triggers a full replay from `earliest`.
 
 **Monitoring caveat**: because we use `assign()` instead of `subscribe()`, standard consumer group monitoring tools (`kafka-consumer-groups.sh`, Burrow, etc.) show empty output or stale data. Use Millpond's own `millpond_consumer_lag` metric for lag monitoring, and `millpond_last_committed_offset` for offset tracking.
 
@@ -423,9 +425,9 @@ Prometheus via `prometheus_client`, HTTP on port 8000.
 
 | Risk | Mitigation |
 |------|------------|
-| Partition count desync | Partition count discovered via `consumer.list_topics()` at startup — no env var. `REPLICA_COUNT` env var must match `spec.replicas`; desync causes uneven assignment but not data loss (some partitions double-assigned, some unassigned). |
+| Partition count desync | Partition count discovered via `admin.list_topics()` at startup — no env var. `REPLICA_COUNT` env var must match `spec.replicas`; desync causes uneven assignment but not data loss (some partitions double-assigned, some unassigned). |
 | Concurrent DDL from multiple pods (two pods both evolve schema simultaneously) | DuckLake: `ADD COLUMN IF NOT EXISTS` is idempotent — multiple pods racing is harmless. `ALTER COLUMN SET DATA TYPE` widening to the same target is also idempotent. Iceberg: `update_schema()` uses optimistic concurrency; the loser raises `CommitFailedException`, the write-retry path invalidates the cache and re-reads (possibly observing the winner's evolution), then tries again. Cannot designate a single schema-owner pod because schema discovery is distributed (new fields can appear in any partition). In practice, schema changes are rare — the primary use case (events) uses a stable schema that relies on maps/dictionaries for extensibility rather than adding columns. |
-| Liveness probe only checks prometheus HTTP, not app health | Add `/healthz` endpoint that checks last-poll and last-flush recency. Pod is unhealthy if either exceeds a threshold. |
+| Liveness probe only checks prometheus HTTP, not app health | **Mitigated.** `/healthz` and `/readyz` endpoints at `millpond/server.py` check `last_poll` recency against `max_poll_age_s=300`; pod reports 503 if no poll in the last 5 minutes. |
 
 ### High
 
@@ -520,15 +522,22 @@ Prometheus metrics and health checks on port 8000 via a custom `http.server.HTTP
 | Package | Why |
 |---------|-----|
 | `confluent-kafka>=2.6` | librdkafka Python wrapper |
-| `duckdb==1.5.1` | DuckDB Python client (pinned; the ducklake extension is sensitive to minor-version moves) |
+| `duckdb==1.5.2` | DuckDB Python client (pinned; the ducklake extension is sensitive to minor-version moves) |
 | `pyiceberg[pyarrow]==0.11.1` | PyIceberg REST catalog client — pinned exactly because `millpond/iceberg.py` uses two private symbols (`_pyarrow_to_schema_without_ids`, `assign_fresh_schema_ids`). The canary test in `tests/unit/test_pyiceberg_pin.py` fails loudly on any upgrade. |
 | `pyarrow>=18.0` | Arrow tables, zero-copy DuckDB/Iceberg integration |
 | `orjson>=3.10` | Fast JSON parsing (Rust) |
 | `prometheus-client>=0.21` | Metrics exposition |
 | `pytz>=2024.1` | Required by duckdb's TIMESTAMPTZ Python conversion (1.5.x doesn't accept stdlib zoneinfo) |
 | `pyyaml>=6.0.3` | `tools/ducklake_metrics.py` query definitions |
+| `asyncpg>=0.30` | Async Postgres driver for the icebox API hot path (POST /v1/files insert + status read) |
+| `psycopg[binary,pool]>=3.2` | Sync Postgres driver for the icebox committer thread + DB/schema bootstrap |
+| `fastapi>=0.115` | icebox HTTP API (POST /v1/files, GET /v1/status, /readyz, /healthz, /metrics) |
+| `uvicorn>=0.32` | ASGI server hosting the icebox FastAPI app |
+| `httpx>=0.27` | HTTP client used by the writer-side IcebergSink to POST to icebox; also used in tests |
+| `opentelemetry-sdk>=1.30` | Structured-log OTLP export plumbing for the icebox |
+| `opentelemetry-exporter-otlp-proto-http>=1.30` | OTLP/HTTP exporter — ships icebox logs to PostHog Logs when `POSTHOG_PROJECT_TOKEN` is set |
 
-Both `duckdb` and `pyiceberg` are always installed — there is no "ducklake-only" or "iceberg-only" build variant. The lazy import in `make_sink()` means a deployment that only uses one destination doesn't pay the other's import cost at startup, but the dependency footprint on disk is identical.
+`duckdb`, `pyiceberg`, and the icebox-stack deps (`asyncpg`, `psycopg`, `fastapi`, `uvicorn`, `opentelemetry-*`) are always installed — there is no "ducklake-only" / "iceberg-only" / "writer-only" / "icebox-only" build variant. The lazy import in `make_sink()` means a deployment that only uses one destination doesn't pay the other's import cost at startup; the icebox modules are similarly imported lazily by the `icebox` console script entry point. The dependency footprint on disk is identical regardless of which binary the pod runs.
 
 ## Project Structure
 
@@ -540,23 +549,49 @@ millpond/
 ├── .github/workflows/
 │   ├── ci.yaml               # Format, lint, unit tests on PR/push
 │   └── release.yaml          # Auto-version, tarball, Docker image, GitHub release
-├── Dockerfile
-├── docker-compose.yaml       # Full dev stack (Kafka, Postgres, MinIO, Grafana)
+├── Dockerfile                # Builds one image carrying both `millpond` and `icebox` console scripts
+├── docker-compose.yaml       # DuckLake dev stack (Kafka, Postgres, MinIO, Grafana)
+├── docker-compose.iceberg.yaml  # Iceberg dev stack (Kafka, MinIO, iceberg-rest)
+├── docker-compose.ssl.yaml   # Overlay adding SSL Kafka to docker-compose.yaml
 ├── k8s/
 │   ├── statefulset.yaml
 │   ├── service.yaml          # Headless service for StatefulSet
 │   └── pdb.yaml              # PodDisruptionBudget
-├── millpond/
+├── millpond/                 # The writer
 │   ├── __init__.py
 │   ├── main.py               # Entry point, main loop, signal handling — backend-agnostic via Sink
 │   ├── config.py             # Env var → dataclass; per-destination validation
 │   ├── sink.py               # Sink Protocol + make_sink(cfg) factory (lazy backend imports)
 │   ├── arrow_converter.py    # JSON → PyArrow Table (orjson + from_pylist + numeric normalization)
 │   ├── ducklake.py           # DuckLake backend: connect, write, DuckLakeSink class
-│   ├── iceberg.py            # Iceberg backend: connect, write, SchemaManager, IcebergSink class
+│   ├── iceberg.py            # Iceberg backend (direct-commit path): connect, write, SchemaManager
+│   ├── icebox_sink.py        # Iceberg backend (icebox-coordinated path): POST /v1/files to icebox
 │   ├── schema.py             # DuckLake SchemaManager (Iceberg's is embedded in iceberg.py)
+│   ├── consumer.py           # Kafka consumer + AdminClient for partition discovery
+│   ├── backpressure.py       # Adaptive batch sizing
 │   ├── metrics.py            # Prometheus metric definitions
-│   └── server.py             # HTTP server for /metrics and /healthz
+│   └── server.py             # HTTP server for /metrics, /healthz, /readyz
+├── icebox/                   # The icebox: writer/committer-split service fronting Lakekeeper
+│   ├── __init__.py
+│   ├── main.py               # `icebox` console-script entry point; lifespan + signal wiring
+│   ├── api.py                # FastAPI app: POST /v1/files, GET /v1/status, /readyz, /healthz, /metrics
+│   ├── committer.py          # Singleton committer thread + 9-step cycle + 3-branch recovery
+│   ├── config.py             # Env-driven Config dataclass (ICEBOX_*)
+│   ├── iceberg.py            # commit_data_files + DataFile builder + snapshot_id helpers
+│   ├── kafka.py              # AdminClient + alter_consumer_group_offsets (offset commit on writers' behalf)
+│   ├── postgres_async.py     # asyncpg pool for the API hot path
+│   ├── postgres_sync.py      # psycopg pool + cycle state-machine SQL + advisory lock
+│   ├── schema.py             # PG DDL + Pydantic row models
+│   ├── schema_cache.py       # TTL cache for the table's current schema fingerprint
+│   ├── metrics.py            # Prometheus gauges/counters/histogram for the icebox
+│   ├── structured_logging.py # JSON formatter + cycle_id ContextVar + optional OTLP/HTTP export
+│   └── README.md             # icebox-specific design + operational notes
+├── shared/                   # Wire format + helpers used by both millpond/icebox_sink and icebox/
+│   ├── __init__.py
+│   ├── models.py             # Pydantic wire models (RegisterFileRequest, ParquetStats, etc.)
+│   ├── bounds.py             # Typed-JSON ↔ Iceberg single-value-serialization bytes
+│   ├── fingerprint.py        # Iceberg-schema → SHA-256 fingerprint for the cache + writer perimeter
+│   └── paths.py              # Deterministic S3 path helpers
 ├── tools/
 │   ├── ducklake_maintenance.py     # Self-contained DuckLake maintenance script (K8s CronJob, DuckLake-only)
 │   ├── ducklake_maintenance.sql    # Macros loaded at session start
@@ -564,10 +599,11 @@ millpond/
 │   ├── justfile                    # Interactive wrapper for ducklake_maintenance.py + DuckDB CLI shell
 │   └── sizing-calculator.html      # Interactive flush/object sizing calculator
 ├── tests/
-│   ├── unit/                 # Fast, no external deps; uses PyIceberg SqlCatalog for iceberg-side
-│   ├── integration/          # Local DuckDB write path + MinIO+iceberg-rest via testcontainers
-│   └── e2e/                  # Full docker-compose stack via testcontainers
+│   ├── unit/                 # Fast, no external deps; uses PyIceberg SqlCatalog for iceberg-side; covers icebox modules too
+│   ├── integration/          # Local DuckDB + MinIO + iceberg-rest + Redpanda + icebox Docker stack via testcontainers
+│   ├── e2e/                  # Full docker-compose stack via testcontainers (DuckLake + Iceberg matrices)
+│   └── stress/               # Manual-only stress harness (deselected by default; not run in CI)
 └── test/                     # Dev fixtures (producer.py, ducklake-init.sql)
 ```
 
-`tools/` is intentionally DuckLake-only — Iceberg deployments use their catalog's native compaction/expiry tooling. No equivalent of `ducklake_maintenance.py` exists for Iceberg in this repo.
+`tools/` scripts are DuckLake-specific (maintenance and state-metrics). Iceberg-side tooling lives under `icebox/`: the committer service handles batched commits and is the answer to OCC contention; there is no equivalent of `ducklake_maintenance.py` for Iceberg in this repo (compaction/expiry are still expected to come from the catalog's native tooling).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A standalone Python app that consumes from a Kafka topic and writes to a lake table. Single thread, single loop, no Kafka Connect. One deployment writes to exactly one destination — either [DuckLake](https://github.com/duckdb/ducklake), [Apache Iceberg](https://iceberg.apache.org/) via direct PyIceberg commit, or Iceberg via the bundled [**icebox**](icebox/README.md) writer/committer split (production-scale Iceberg). Selected via `MILLPOND_DESTINATION` (`ducklake` | `iceberg` | `icebox`).
 
 **Contents:**
-[Naming](#naming) | [Why](#why) | [Architecture](#architecture) | [Destinations](#destinations) | [icebox](icebox/README.md) | [Record Handling](#record-handling) | [Adaptive Backpressure](#adaptive-backpressure) | [Performance](#performance) | [Resource Footprint](#resource-footprint) | [Setup](#setup) | [Development](#development) | [Configuration](#configuration) | [Releases](#releases) | [Deployment](#deployment) | [Partitioning](#partitioning) | [Object Sizing](#object-sizing) | [Error Handling](#error-handling-and-retries) | [Multiple Pipelines](#multiple-pipelines) | [AWS Credential Isolation](#aws-credential-isolation) | [Operational Notes](#operational-notes) | [Next steps](#next-steps)
+[Naming](#naming) | [Why](#why) | [Architecture](#architecture) | [Destinations](#destinations) | [icebox](icebox/README.md) | [Record Handling](#record-handling) | [Adaptive Backpressure](#adaptive-backpressure) | [Performance](#performance) | [Resource Footprint](#resource-footprint) | [Setup](#setup) | [Development](#development) | [Configuration](#configuration) | [Releases](#releases) | [Deployment](#deployment) | [Partitioning](#partitioning) | [Object Sizing](#object-sizing) | [Error Handling](#error-handling-and-retries) | [Multiple Pipelines](#multiple-pipelines) | [AWS Credential Isolation](#aws-credential-isolation) | [Operational Notes](#operational-notes) | [tools](tools/README.md)
 
 ## Naming
 
@@ -57,7 +57,7 @@ Millpond writes to one of two lake formats, selected at startup by `MILLPOND_DES
 
 The selection is a thin Protocol-based abstraction (`millpond/sink.py`) — `main.py` only sees `Sink.write(batch)`, `reset_caches()`, `close()`. Both implementations are in their own module (`ducklake.py`, `iceberg.py`).
 
-For the Iceberg path at production scale, the writers do not commit to the catalog directly. They emit parquet to S3 and `POST /v1/files` to **[icebox](icebox/README.md)**, a writer/committer split that serializes commits from many concurrent writer pods through a single committer thread per `(namespace, table)`. This eliminates the OCC contention described in the [Next steps](#iceberg-multi-writer-commit-contention--solved-by-icebox) section below and is what makes 32 concurrent writers per Iceberg table viable. See `icebox/README.md` for the full design.
+For Iceberg at production scale, writers do not commit to the catalog directly. They emit parquet to S3 and `POST /v1/files` to **[icebox](icebox/README.md)** — a writer/committer split that serializes commits from many concurrent writer pods through a single committer thread per `(namespace, table)`, eliminating PyIceberg's REST-catalog optimistic-concurrency contention. See [`icebox/README.md`](icebox/README.md) for the full design, endpoint contract, and operational notes.
 
 ## Record Handling
 
@@ -153,116 +153,14 @@ The `just up-ssl` recipe generates self-signed certs and runs Kafka with SSL lis
 
 Requires Docker (uses `keytool` from the Kafka container image for cert generation).
 
-### DuckLake Maintenance
+### DuckLake Maintenance and state metrics
 
-`tools/ducklake_maintenance.py` is a self-contained Python script for DuckLake maintenance operations (snapshot expiry, file cleanup, orphan deletion, checkpoint, tiered compaction, deletion-queue dedup, catalog-side orphan recovery). It is baked into the Docker image at `/app/tools/ducklake_maintenance.py` and designed to run as a K8s CronJob reusing the same image and credentials as the main application.
+The `tools/` directory ships two DuckLake-only operational binaries inside the same image as the writer:
 
-```bash
-python /app/tools/ducklake_maintenance.py maintain --days 7           # expire snapshots + cleanup files
-python /app/tools/ducklake_maintenance.py maintain --days 7 --dry-run # preview only
-python /app/tools/ducklake_maintenance.py expire --days 3             # expire snapshots only
-python /app/tools/ducklake_maintenance.py cleanup --days 1            # cleanup scheduled files only
-python /app/tools/ducklake_maintenance.py cleanup-all                 # cleanup all scheduled files regardless of age
-python /app/tools/ducklake_maintenance.py dedup-deletions             # drop duplicate rows in the pending-deletion queue
-python /app/tools/ducklake_maintenance.py find-orphans                # list catalog rows whose S3 key no longer exists
-python /app/tools/ducklake_maintenance.py heal-orphans                # delete those catalog rows (gated B1/B3 safety checks)
-python /app/tools/ducklake_maintenance.py cleanup-all-safe            # dedup + heal-orphans + cleanup-all in a loop until clean
-python /app/tools/ducklake_maintenance.py fsck                        # cleanup-all-safe + ducklake_delete_orphaned_files
-python /app/tools/ducklake_maintenance.py checkpoint                  # integrated merge + expire + cleanup
-python /app/tools/ducklake_maintenance.py orphans                     # delete S3-side orphaned files (catalog has no row)
-python /app/tools/ducklake_maintenance.py compact --tier 1            # tiered compaction (see "When to add a merge job")
-```
+- **`tools/ducklake_maintenance.py`** — CLI for snapshot expiry, file cleanup, orphan recovery, tiered compaction, fsck. Runs as a K8s CronJob.
+- **`tools/ducklake_metrics.py`** — Long-running Prometheus-exposition daemon for catalog-side lake-state metrics. Runs as a single-replica Deployment.
 
-The script logs `cleanup throughput: files_processed=N elapsed_s=T rate_obj_s=R queue_depth_after=A` after every `cleanup` / `cleanup-all` (skipped on `--dry-run`), so you can confirm steady-state throughput without enabling debug logging. `files_processed` is the actual count of files the call returned, not a queue-depth delta, so the number is accurate even when other writers enqueue deletions during the run. Pass `--debug` to opt back into DuckDB's HTTP and Postgres-extension query logging — both are off by default because they add per-call overhead that compounds across tens of thousands of S3 deletes.
-
-If `PUSHGATEWAY_URL` is set, the script pushes `maintenance_start_time` (on start) and `maintenance_duration_seconds` (on completion) to a Prometheus Pushgateway, enabling Grafana annotation queries for maintenance windows.
-
-#### Catalog-side orphan recovery
-
-If a `cleanup-all` run is interrupted (DuckLake bug: an S3 NoSuchKey on DELETE rolls back the whole transaction, but the S3 deletes already-completed are permanent), the catalog ends up with rows in `ducklake_files_scheduled_for_deletion` that point at S3 keys that no longer exist. Every subsequent `cleanup-all` will crash on those orphans until they're cleaned up. The catalog-recovery subcommands handle this without manual SQL surgery:
-
-| Subcommand | Action |
-|---|---|
-| `find-orphans` | List orphan rows on stdout (read-only). |
-| `heal-orphans` | Delete the orphan rows. Two safety gates: B1 proves `ducklake_data_file` is non-empty AND no orphan path is still live; B3 aborts if any positional-delete vector references an orphan id. `--dry-run` runs the gates but skips the DELETE. |
-| `cleanup-all-safe` | Loop dedup-deletions + heal-orphans + cleanup-all under one advisory lock until cleanup-all exits clean. Caps at `--max-iterations` (default 10). |
-| `fsck` | `cleanup-all-safe` followed by `ducklake_delete_orphaned_files` (S3-side orphan sweep). The end-to-end "lake catalog is healthy" recipe. |
-
-Mutual exclusion comes from `pg_try_advisory_lock(hashtext('millpond-ducklake-maintenance')::bigint)` taken on the `pg` ATTACH; concurrent maintenance invocations bail with a clear error rather than racing each other's DELETEs.
-
-`tools/ducklake_maintenance.sql` is loaded at every session start (both by `ducklake_maintenance.py` and by the `just shell` recipe) and defines small DuckDB macros for ad-hoc inspection — `SELECT count_pending_dups()` for queue dup count, `SELECT * FROM find_catalog_orphans('s3://bucket/lake/data')` for the orphan list. The header documents the conventions (no `LEFT ANTI JOIN`, no duckdb-side `ctid`, advisory-lock key) that any new recipe must follow.
-
-`tools/justfile` wraps the script and is also baked into the image at `/justfile` for interactive use:
-
-```bash
-just --list                  # see available recipes
-just maintain-dry-run 3      # preview: expire >3 day snapshots + cleanup
-just maintain 3              # execute it
-just dedup-deletions-dry-run # preview duplicate rows in the pending-deletion queue
-just dedup-deletions         # drop them
-just find-orphans            # list catalog-side orphan rows
-just heal-orphans-dry-run    # preview heal-orphans (gates only, no DELETE)
-just heal-orphans            # delete catalog-side orphan rows
-just cleanup-all-safe        # dedup + heal + cleanup-all in a loop
-just fsck-dry-run            # preview fsck end-to-end
-just fsck                    # bring catalog to known-good state
-just shell                   # interactive DuckDB shell with lake + pg ATTACHed and macros loaded
-just orphans-dry-run         # preview S3-side orphaned files
-```
-
-All commands use the pod's existing env vars (`DUCKLAKE_RDS_*`, `DUCKDB_S3_*`, `DUCKLAKE_DATA_PATH`).
-
-### DuckLake state metrics
-
-`tools/ducklake_metrics.py` is a small long-running daemon that runs catalog-side queries against the DuckLake on a schedule and exposes results as Prometheus gauges over HTTP. Same Docker image as `ducklake_maintenance.py`; intended to run as a single-replica Deployment so a Prometheus scraper can watch lake shape, compaction backlog, snapshot age, partition skew, and the pending-deletion queue without S3 round trips.
-
-```bash
-just ducklake-metrics                       # built-ins only, listens on :9100
-just ducklake-metrics-with-config queries.yaml   # extend built-ins from user YAML
-just ducklake-metrics-list                  # print resolved query list and exit (no connection needed)
-```
-
-Endpoints: `/metrics` (Prometheus exposition), `/-/healthy` (k8s liveness), `/-/ready` (k8s readiness). The daemon reconnects to the catalog with exponential backoff (1s → 60s cap) on connect failure, and forces a reconnect after 10 consecutive query failures across all queries; transient SQL errors in a single query log + increment `ducklake_metrics_query_errors_total` without killing the process.
-
-Built-in queries:
-
-| Metric prefix | Labels | Values | Source |
-|---|---|---|---|
-| `ducklake_pending_deletes` | — | `total`, `unique_paths`, `dup_rows` | `ducklake_files_scheduled_for_deletion` |
-| `ducklake_files_per_band` | `band` (`lt1mib` / `1to5mib` / `5to10mib` / `10to32mib` / `32to64mib` / `64to128mib` / `gt128mib`) | `count`, `bytes` | `ducklake_data_file` |
-| `ducklake_compaction_candidates` | `tier` (`tier1` / `tier2` / `tier3` / `large` / `total`) | `count` | `ducklake_data_file` |
-| `ducklake_snapshots` | — | `count`, `oldest_seconds_ago`, `newest_seconds_ago` | `ducklake_snapshot` |
-| `ducklake_files_per_partition_top20` | `partition` | `count` | `ducklake_data_file` ⨝ `ducklake_file_partition_value` |
-| `ducklake_catalog` | `suffix` | `format_version` | `ducklake_metadata` (key=`version`); numeric `major.minor` lands in the value, any trailing tag (e.g. `-dev1`, `-rc7`) lands in the `suffix` label so dev/pre-release builds stay distinguishable. Empty `suffix=""` for clean releases |
-
-Plus self-metrics: `ducklake_metrics_up`, `ducklake_metrics_query_duration_seconds{query}`, `ducklake_metrics_query_last_success_timestamp{query}`, `ducklake_metrics_query_errors_total{query}`.
-
-User YAML schema (extends or overrides built-ins by name):
-
-```yaml
-queries:
-  - name: events_files_per_table
-    help: Live data file count by table (custom example)
-    interval_mins: 5            # positive integer; minimum 1
-    labels: [table_name]
-    values: [count]
-    sql: |
-      SELECT t.table_name, COUNT(*) AS count
-      FROM __ducklake_metadata_lake.ducklake_data_file df
-      JOIN __ducklake_metadata_lake.ducklake_table t USING (table_id)
-      WHERE df.end_snapshot IS NULL
-      GROUP BY t.table_name
-```
-
-Built-ins are intentionally lake-wide (no `table_name` label); per-table breakdowns belong in user YAML when needed.
-
-Configuration env vars (in addition to the standard `DUCKLAKE_*` / `DUCKDB_*` set used by `ducklake_maintenance.py`):
-
-| Variable | Default | Description |
-|---|---|---|
-| `DUCKLAKE_METRICS_PORT` | `9100` | HTTP listen port |
-| `DUCKLAKE_METRICS_CONFIG` | unset | Path to user-supplied queries YAML |
-| `DUCKLAKE_METRICS_DISABLE` | unset | Comma-separated query names to skip from built-ins |
+Subcommand and YAML schema reference, full env-var contract, and the `just` recipe inventory live in [`tools/README.md`](tools/README.md). Both binaries reuse the writer's `DUCKLAKE_RDS_*` / `DUCKDB_S3_*` / `DUCKLAKE_DATA_PATH` env vars.
 
 ## Configuration
 
@@ -436,26 +334,7 @@ At peak (9.5K/partition), the size trigger fires at ~35s producing ~320MB object
 
 ### When to add a merge job
 
-If your volume is low enough that time-triggered flushes produce <10MB objects, run periodic compaction. The `compact` subcommand implements a tiered strategy: small files merge frequently into medium files, medium files merge less often into large files. Each tier saves and restores the catalog's `target_file_size` so running one tier doesn't permanently change file sizing for inserts or other compactions.
-
-```bash
-just compact-to-tier-1-dry-run        # preview: files <1 MiB → ~5 MiB
-just compact-to-tier-1                # execute (catalog-wide)
-just compact-to-tier-2 events         # tier 1->2, scoped to one table
-just compact-probe events 4           # diagnostic: merge up to 4 adjacent files in 'events'
-```
-
-Tier ranges (verified semantics: `min_file_size` inclusive, `max_file_size` exclusive):
-
-| Recipe | Input range | Target |
-|---|---|---|
-| `compact-to-tier-1` | `[0, 1 MiB)` | ~5 MiB |
-| `compact-to-tier-2` | `[1 MiB, 10 MiB)` | ~32 MiB |
-| `compact-to-tier-3` | `[10 MiB, 64 MiB)` | ~128 MiB |
-
-The `compact` subcommand bounds DuckDB resource use during the merge — `--threads` (default 2) and `--memory-limit` (default 4GB) — because `ducklake_merge_adjacent_files` isn't fully streaming today and over-uses memory relative to input size. The defaults are conservative; raise them on lakes that fit comfortably in pod memory.
-
-This is an out-of-band maintenance operation, not part of the hot path.
+If your volume is low enough that time-triggered flushes produce <10MB objects, run periodic compaction. The `ducklake_maintenance.py compact` subcommand implements a tiered strategy: small files merge frequently into medium files, medium files merge less often into large files. Tier ranges, `target_file_size` save/restore semantics, and the `--threads` / `--memory-limit` knobs are documented in [`tools/README.md`](tools/README.md). This is an out-of-band maintenance operation, not part of the hot path.
 
 See the [sizing calculator](https://posthog.github.io/millpond/sizing-calculator.html) for interactive estimates.
 
@@ -527,14 +406,6 @@ Related issues:
 - [confluent-kafka-python #1485](https://github.com/confluentinc/confluent-kafka-python/issues/1485) — oauth token not refreshing on existing connections
 - [aws-msk-iam-auth #143](https://github.com/aws/aws-msk-iam-auth/issues/143) — re-authentication fails with OAUTHBEARER
 - [aws-msk-iam-auth #176](https://github.com/aws/aws-msk-iam-auth/issues/176) — second re-authentication fails with default credentials
-
-## Next steps
-
-### Iceberg multi-writer commit contention — solved by icebox
-
-The Iceberg sink originally couldn't sustain two pods committing to the same table at typical flush cadence. PyIceberg's REST commit attaches a branch-snapshot requirement (`expected id != actual id`); when a second writer commits between when we loaded the table and when we send the commit, the catalog rejects with `CommitFailedException: branch main has changed`. `_write_with_retry` in `main.py` invalidates caches and retries up to 3 times with exponential backoff (sleeps 1s after attempt 1, 2s after attempt 2; attempt 3 raises rather than sleeping further), but under sustained dual-writer load with `FLUSH_INTERVAL_MS=5000` the retries collide with the *next* round of commits and exhaust the budget — the pod exits.
-
-**The fix shipped:** [`icebox/`](icebox/README.md) — a writer/committer split that fronts the Iceberg catalog. Writers `POST /v1/files` with parquet-file metadata; a single committer thread per icebox deployment batches the rows into one Iceberg snapshot per cadence interval. One committer per `(namespace, table)` per environment, advisory-lock enforced, so even 32 concurrent writers contribute to one ordered stream of commits without OCC contention. See [`icebox/README.md`](icebox/README.md) for the full design and operational notes.
 
 ## Note
 This project should absolutely be called TableFowl, but that would be an [SEO](https://www.confluent.io/product/tableflow/) and linguistic palaver.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Millpond — Kafka to DuckLake or Iceberg
 
-A standalone Python app that consumes from a Kafka topic and writes to a lake table. Single thread, single loop, no Kafka Connect. One deployment writes to exactly one destination — either [DuckLake](https://github.com/duckdb/ducklake) or [Apache Iceberg](https://iceberg.apache.org/), selected via `MILLPOND_DESTINATION`.
+A standalone Python app that consumes from a Kafka topic and writes to a lake table. Single thread, single loop, no Kafka Connect. One deployment writes to exactly one destination — either [DuckLake](https://github.com/duckdb/ducklake), [Apache Iceberg](https://iceberg.apache.org/) via direct PyIceberg commit, or Iceberg via the bundled [**icebox**](icebox/README.md) writer/committer split (production-scale Iceberg). Selected via `MILLPOND_DESTINATION` (`ducklake` | `iceberg` | `icebox`).
 
 **Contents:**
-[Naming](#naming) | [Why](#why) | [Architecture](#architecture) | [Destinations](#destinations) | [Record Handling](#record-handling) | [Adaptive Backpressure](#adaptive-backpressure) | [Performance](#performance) | [Resource Footprint](#resource-footprint) | [Setup](#setup) | [Development](#development) | [Configuration](#configuration) | [Releases](#releases) | [Deployment](#deployment) | [Partitioning](#partitioning) | [Object Sizing](#object-sizing) | [Error Handling](#error-handling-and-retries) | [Multiple Pipelines](#multiple-pipelines) | [AWS Credential Isolation](#aws-credential-isolation) | [Operational Notes](#operational-notes) | [Next steps](#next-steps)
+[Naming](#naming) | [Why](#why) | [Architecture](#architecture) | [Destinations](#destinations) | [icebox](icebox/README.md) | [Record Handling](#record-handling) | [Adaptive Backpressure](#adaptive-backpressure) | [Performance](#performance) | [Resource Footprint](#resource-footprint) | [Setup](#setup) | [Development](#development) | [Configuration](#configuration) | [Releases](#releases) | [Deployment](#deployment) | [Partitioning](#partitioning) | [Object Sizing](#object-sizing) | [Error Handling](#error-handling-and-retries) | [Multiple Pipelines](#multiple-pipelines) | [AWS Credential Isolation](#aws-credential-isolation) | [Operational Notes](#operational-notes) | [Next steps](#next-steps)
 
 ## Naming
 
@@ -207,7 +207,6 @@ just cleanup-all-safe        # dedup + heal + cleanup-all in a loop
 just fsck-dry-run            # preview fsck end-to-end
 just fsck                    # bring catalog to known-good state
 just shell                   # interactive DuckDB shell with lake + pg ATTACHed and macros loaded
-just drop events             # drop a table (data files remain until cleanup)
 just orphans-dry-run         # preview S3-side orphaned files
 ```
 
@@ -276,10 +275,10 @@ All configuration via environment variables.
 | `KAFKA_BOOTSTRAP_SERVERS` | yes | | Kafka broker addresses |
 | `KAFKA_TOPIC` | yes | | Topic to consume |
 | `REPLICA_COUNT` | yes | | Number of StatefulSet replicas (must match `spec.replicas`) |
-| `MILLPOND_DESTINATION` | no | `ducklake` | Destination format: `ducklake` or `iceberg`. Case-insensitive; empty/whitespace falls back to `ducklake`. |
+| `MILLPOND_DESTINATION` | no | `ducklake` | Destination: `ducklake`, `iceberg` (direct PyIceberg commit), or `icebox` (Iceberg via the bundled writer/committer split — see [icebox/README.md](icebox/README.md)). Case-insensitive; empty/whitespace falls back to `ducklake`. |
 | `FLUSH_SIZE` | no | `104857600` | Flush after this many bytes of accumulated Arrow data (default 100MB) |
 | `FLUSH_INTERVAL_MS` | no | `60000` | Flush after this many ms |
-| `GROUP_ID` | no | `millpond-{topic}-{table}` | Kafka group.id — used for offset storage in `__consumer_offsets` only, no consumer group semantics. Changing this loses committed offsets and triggers full replay. For Iceberg the default is `millpond-{topic}-{iceberg_table}` (the namespace prefix only shows up in metrics/client.id, not group.id). |
+| `GROUP_ID` | no | `millpond-{topic}-{table_label_part}` | Kafka group.id — used for offset storage in `__consumer_offsets` only, no consumer group semantics. Changing this loses committed offsets and triggers full replay. `{table_label_part}` is derived from the destination table identifier in `millpond/config.py` (the namespace prefix only shows up in metrics/client.id, not group.id). |
 | `CONSUME_BATCH_SIZE` | no | `1000` | Max messages per `consume()` call — amortizes Python↔C boundary cost |
 | `FETCH_MIN_BYTES` | no | `1048576` | Broker accumulates at least this many bytes before responding (1MB) |
 | `FETCH_MAX_WAIT_MS` | no | `500` | Max broker wait when `fetch.min.bytes` not yet satisfied |
@@ -323,6 +322,21 @@ All configuration via environment variables.
 
 `MILLPOND_S3_*` is a separate env var family from `DUCKDB_S3_*` deliberately — they target different client libraries, and a deployment switch from DuckLake to Iceberg should be a clean swap of env vars rather than re-using the DuckDB-specific names.
 
+### icebox (required when `MILLPOND_DESTINATION=icebox`)
+
+The icebox path reuses the entire `Iceberg` env-var block above (writers still need to know the catalog URI, warehouse, namespace, table, and S3 credentials so the catalog/file metadata they POST to the icebox is correctly addressed) and adds the writer-to-icebox transport variables:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ICEBOX_URL` | yes | | In-cluster base URL of the icebox service (e.g. `http://icebox-events.megaberg.svc:8000`) |
+| `ICEBOX_BUCKET` | yes | | S3 bucket the writer drops parquet into (the icebox reads the path from the POST body; it does not re-derive it) |
+| `ICEBOX_WAREHOUSE_PREFIX` | yes | | Prefix under `ICEBOX_BUCKET` for staged parquet files (e.g. `kafka/events/data`) |
+| `ICEBOX_MAX_ATTEMPTS` | no | `6` | Max attempts for `POST /v1/files` against the icebox (the writer's flush-side retry loop, separate from the lake-write retry) |
+| `ICEBOX_MAX_BACKOFF_S` | no | `30` | Max backoff between icebox POST retries (exponential, capped at this value) |
+| `ICEBOX_TIMEOUT_S` | no | `10` | Per-request timeout against the icebox API |
+
+The icebox itself has its own env-var contract (`ICEBOX_*` consumed by `icebox/main.py` — Postgres connection, committer cadence, etc.). Those are documented in [`icebox/README.md`](icebox/README.md) and live in the icebox deployment, not the writer.
+
 ### Optional record handling
 
 See [Record Handling](#record-handling) for context. All four variables below are optional; unset means the corresponding stage is disabled.
@@ -351,7 +365,7 @@ kubectl apply -f k8s/pdb.yaml
 kubectl apply -f k8s/statefulset.yaml
 ```
 
-Partition count is discovered at startup via `consumer.list_topics()`. Each pod computes its partition assignment from its ordinal:
+Partition count is discovered at startup via `admin.list_topics(topic=cfg.topic, timeout=30)` (an `AdminClient`, not the consumer instance). Each pod computes its partition assignment from its ordinal:
 
 ```python
 my_partitions = [p for p in range(partition_count) if p % replica_count == ordinal]
@@ -456,7 +470,7 @@ The flush path has two failure points, each with its own retry policy:
 
 Both use `errors_total{type="write_retry"}` and `errors_total{type="offset_commit"}` counters so transient vs persistent failures are distinguishable in dashboards.
 
-The write-retry loop catches `Exception` broadly to cover both backends' failure modes — `duckdb.Error` for DuckLake; `pyiceberg.exceptions.CommitFailedException`, `CommitStateUnknownException`, `ServerError`, `ServiceUnavailableError` for Iceberg REST catalog 5xx; `OSError` for S3; `KafkaException` for broker disconnects. Each retry invokes `sink.reset_caches()` to drop cached table/schema state so the next attempt re-checks the catalog (covers the case where another pod evolved the schema or recreated the table between attempts).
+The write-retry loop catches `Exception` broadly to cover every backend's failure modes — `duckdb.Error` for DuckLake; `pyiceberg.exceptions.CommitFailedException`, `CommitStateUnknownException`, `ServerError`, `ServiceUnavailableError` for direct-Iceberg REST catalog 5xx; `httpx.HTTPError` + the `IceboxResponseError` / `IceboxBackpressureExhausted` raised by `millpond/icebox_sink.py` for the icebox-path POST failures; `OSError` for S3; `KafkaException` for broker disconnects. Each retry invokes `sink.reset_caches()` to drop cached table/schema state so the next attempt re-checks the catalog (covers the case where another pod evolved the schema or recreated the table between attempts).
 
 **Why crash after exhausting retries?** A persistent write failure means S3 or the catalog is down — continuing would just accumulate pending data in memory until OOM. A persistent commit failure means the Kafka coordinator is unreachable — the write already succeeded, but without committed offsets the next restart will replay the batch (at-least-once duplicates). In both cases, crashing lets K8s apply its restart backoff, and Kafka holds the data safely until the dependency recovers.
 
@@ -518,7 +532,7 @@ Related issues:
 
 ### Iceberg multi-writer commit contention — solved by icebox
 
-The Iceberg sink originally couldn't sustain two pods committing to the same table at typical flush cadence. PyIceberg's REST commit attaches a branch-snapshot requirement (`expected id != actual id`); when a second writer commits between when we loaded the table and when we send the commit, the catalog rejects with `CommitFailedException: branch main has changed`. `_write_with_retry` in `main.py` invalidates caches and retries up to 3 times with exponential backoff (1s, 2s, 4s), but under sustained dual-writer load with `FLUSH_INTERVAL_MS=5000` the retries collide with the *next* round of commits and exhaust the budget — the pod exits.
+The Iceberg sink originally couldn't sustain two pods committing to the same table at typical flush cadence. PyIceberg's REST commit attaches a branch-snapshot requirement (`expected id != actual id`); when a second writer commits between when we loaded the table and when we send the commit, the catalog rejects with `CommitFailedException: branch main has changed`. `_write_with_retry` in `main.py` invalidates caches and retries up to 3 times with exponential backoff (sleeps 1s after attempt 1, 2s after attempt 2; attempt 3 raises rather than sleeping further), but under sustained dual-writer load with `FLUSH_INTERVAL_MS=5000` the retries collide with the *next* round of commits and exhaust the budget — the pod exits.
 
 **The fix shipped:** [`icebox/`](icebox/README.md) — a writer/committer split that fronts the Iceberg catalog. Writers `POST /v1/files` with parquet-file metadata; a single committer thread per icebox deployment batches the rows into one Iceberg snapshot per cadence interval. One committer per `(namespace, table)` per environment, advisory-lock enforced, so even 32 concurrent writers contribute to one ordered stream of commits without OCC contention. See [`icebox/README.md`](icebox/README.md) for the full design and operational notes.
 

--- a/icebox/README.md
+++ b/icebox/README.md
@@ -15,9 +15,8 @@ the same flush cadence race against the catalog and the loser retries
 with exponential backoff. Under sustained dual-writer load with
 `FLUSH_INTERVAL_MS=5000` (let alone the 32 writers the production
 deployment targets), retries pile up on the *next* round of commits
-and exhaust the budget. The pod exits. See the main README's
-"Iceberg multi-writer commit contention" entry for the original
-discovery and the comment in `docker-compose.iceberg.yaml`.
+and exhaust the budget. The pod exits. The original discovery is
+also commented in `docker-compose.iceberg.yaml`.
 
 icebox solves this with a producer/consumer split:
 


### PR DESCRIPTION
## Summary

Two doc-only commits cleaning up `AGENT.md` and `README.md` after the icebox merge.

- **`4912f44`** — fixes 11 stale claims in AGENT.md and 10 in README.md that the icebox merge broke or invalidated. Highlights: `MILLPOND_DESTINATION` now accepts three values not two; missing writer-side `ICEBOX_URL` / `ICEBOX_BUCKET` / `ICEBOX_WAREHOUSE_PREFIX` env-var section added; duckdb pin bumped (1.5.1 → 1.5.2); icebox-stack deps (asyncpg, fastapi, uvicorn, opentelemetry-*, etc.) added to the Dependencies table; project structure tree gains `icebox/`, `shared/`, `tests/stress/`, `docker-compose.iceberg.yaml`; the `/healthz` + `/readyz` risk mitigation marked shipped; consume-vs-poll Kafka tuning paragraph stops citing unrelated issues (#291/#612 are about unrelated bugs, not benchmarks; the actual benchmark in #597 is about thread vs process pools, not consume vs poll); `just drop events` referenced in README but no such recipe exists — removed.
- **`011c652`** — slims the main README by ~24% (544 → 415 lines). The DuckLake maintenance and state-metrics subsections were carrying ~120 lines of operational detail that already lives in `tools/README.md`; collapse to an 8-line pointer. Drop the §Next-steps Iceberg-commit-contention subsection since the icebox is shipped, not next. Cross-reference cleanup in `icebox/README.md` to avoid pointing at the removed section.

No code changes. No runtime behavior changes.

## Test plan

- [x] `git diff main` — only `AGENT.md`, `README.md`, `icebox/README.md` touched
- [x] anchor links in README TOC all resolve to existing sections
- [x] pre-commit hooks (ruff check + ruff format) pass
- [x] verified every concrete claim in both docs against the repo state (function names, env-var defaults, metric names, exception class names, justfile recipes, workflow steps, schema constants, etc.)