### PR TITLE
feat(icebox+millpond): PostHog Logs OTLP export + iceberg table-state gauges

### DIFF
--- a/icebox/README.md
+++ b/icebox/README.md
@@ -64,11 +64,47 @@ cycle's complete trace is grep-friendly.
 When `POSTHOG_PROJECT_TOKEN` is set, the icebox additionally exports
 log records to PostHog Logs via standard OTLP/HTTP
 (`https://us.i.posthog.com/i/v1/logs` by default; override via
-`POSTHOG_LOGS_ENDPOINT`). Resource attributes are
-`service.name=icebox`, `service.namespace=<pg_schema>`,
-`service.version=<package version>`. The `BatchLogRecordProcessor` is
-flushed on the SIGTERM drain path so in-flight batches make it out
-before the process exits.
+`POSTHOG_LOGS_ENDPOINT`). The `BatchLogRecordProcessor` is flushed on
+the SIGTERM drain path so in-flight batches make it out before the
+process exits.
+
+### Resource attribute taxonomy
+
+Split by ownership so the app and the chart never set the same key.
+
+**App-owned** (passed by `icebox/main.py` → `setup_logging`):
+
+| Attr | Value | Why |
+|---|---|---|
+| `service.name` | `icebox` (constant) | One binary, one service. Per-instance differentiation is on `service.instance.id`. |
+| `service.namespace` | `millpond` (default; override via `ICEBOX_SERVICE_NAMESPACE`) | OTel-semconv "logical service grouping". **Note:** earlier versions misused this for the PG schema. Filters that targeted the old per-deployment value (`service.namespace=icebox_events_icebox` etc.) must migrate to `service.instance.id=<consumer-key>`. |
+| `service.instance.id` | The consumer key, e.g. `events-icebox` (from `ICEBOX_SERVICE_INSTANCE_ID`) | This IS the per-(namespace, table) axis. |
+| `service.version` | The millpond package version | |
+| `messaging.system` | `kafka` (only when Kafka attrs are set) | OTel messaging semconv. |
+| `messaging.destination.name` | The Kafka topic | OTel messaging semconv (chosen over vendor-prefixed `icebox.kafka.topic` for interop with OTel-aware tooling). |
+| `messaging.kafka.consumer.group` | The icebox-side consumer group id | OTel messaging semconv. |
+| `icebox.iceberg.warehouse` / `namespace` / `table` | Lakekeeper warehouse, namespace, table | Vendor-prefixed because OTel semconv has no Iceberg coverage today. |
+
+**Chart-owned** (set via the chart's `OTEL_RESOURCE_ATTRIBUTES` env on
+the icebox Deployment — auto-merged into the resource by
+`Resource.create()`):
+
+- `deployment.environment` (e.g. `managed-warehouse-prod-us`)
+- `k8s.cluster.name`, `k8s.namespace.name`, `k8s.pod.name`, `k8s.deployment.name`
+- `host.hostname`
+
+These are not passed by the app — keeping env/cluster concerns out of
+icebox code.
+
+### Per-record attributes
+
+| Attr | Source | Why |
+|---|---|---|
+| `icebox.cycle_id` | The `cycle_id_var` ContextVar set by `committer.run_cycle` | Per-record, NOT Resource. Resource attrs describe the *process*; `cycle_id` describes a *single cycle* inside it. Moving it to Resource would silently break per-cycle filtering. |
+
+The stdout JSON formatter additionally emits a plain `cycle_id` field
+in the body for stdout-only readers. PostHog Logs queries should use
+`attributes.icebox.cycle_id`.
 
 ## Tests
 

--- a/icebox/README.md
+++ b/icebox/README.md
@@ -52,7 +52,7 @@ icebox solves this with a producer/consumer split:
 | `GET /v1/status` | Operator-facing observability snapshot (pending files, last cycle, last committed snapshot id, consecutive failures). |
 | `GET /readyz` | Readiness: PG reachable AND committer heartbeat fresh. Downstream (Lakekeeper, Kafka) outages do NOT fail readyz — the icebox keeps accepting POSTs and stages files for future cycles. |
 | `GET /healthz` | Liveness only — the API process is responsive. No PG round-trip. |
-| `GET /metrics` | Prometheus exposition: pending files, oldest pending age, consecutive failures, committer heartbeat age, cycle counts and duration histogram, post counts by HTTP status. |
+| `GET /metrics` | Prometheus exposition: pending files, oldest pending age, consecutive failures, committer heartbeat age, cycle counts and duration histogram, post counts by HTTP status, schema-fingerprint cache misses (by `reason`), and **Iceberg table state** — `icebox_iceberg_table_data_files`, `_records`, `_files_size_bytes` (cumulative after last cycle) plus `_added_data_files`, `_added_records`, `_added_files_size_bytes` (per-cycle deltas). Table-state gauges are read free from each cycle's snapshot summary — no thread, no extra Lakekeeper round-trip. |
 
 ## Structured logging + PostHog Logs
 

--- a/icebox/committer.py
+++ b/icebox/committer.py
@@ -179,7 +179,11 @@ def _run_cycle_body(
             )
 
     if not claimed_ids:
-        log.info("run_cycle: no files to claim — vacuous cycle %s", cycle_id)
+        # DEBUG because vacuous cycles are normal at low ingest volume
+        # and dominate operational log volume otherwise. The
+        # icebox_cycles_total{result="skipped_no_files"} counter +
+        # committer_heartbeat metric carry the operational signal.
+        log.debug("run_cycle: no files to claim — vacuous cycle %s", cycle_id)
         result.skipped_reason = "no_files"
         # Still considered a "success" for status semantics: the loop
         # ran and we're not falling behind, just nothing to do.

--- a/icebox/committer.py
+++ b/icebox/committer.py
@@ -57,6 +57,37 @@ from icebox.structured_logging import cycle_id_var
 log = logging.getLogger(__name__)
 
 
+def _update_table_state_gauges(summary: dict[str, str]) -> None:
+    """Push iceberg snapshot summary values onto the table-state Gauges.
+
+    Caller MUST invoke this outside the iceberg-commit try block (see
+    run_cycle). If a gauge.set() were to raise inside the saga's except
+    handler, release_cycle_claim would fire AFTER the snapshot had
+    already landed — re-batching the same files for double-commit.
+
+    Defensive non-raise per key: spec-defined integer-string values can
+    show up as None (key absent) or non-parseable (producer bug). Skip
+    rather than failing the cycle's observability pass.
+    """
+    for key, gauge in (
+        # Cumulative table state — total-after-commit
+        ("total-data-files", metrics.ICEBERG_TABLE_DATA_FILES),
+        ("total-records", metrics.ICEBERG_TABLE_RECORDS),
+        ("total-files-size", metrics.ICEBERG_TABLE_FILES_SIZE_BYTES),
+        # Per-cycle deltas — compaction-churn + ingest-rate signals
+        ("added-data-files", metrics.ICEBERG_TABLE_ADDED_DATA_FILES),
+        ("added-records", metrics.ICEBERG_TABLE_ADDED_RECORDS),
+        ("added-files-size", metrics.ICEBERG_TABLE_ADDED_FILES_SIZE_BYTES),
+    ):
+        raw = summary.get(key)
+        if raw is None:
+            continue
+        try:
+            gauge.set(int(raw))
+        except (TypeError, ValueError):
+            continue
+
+
 def _cycle_result_label(result: CycleResult) -> str:
     """Map a CycleResult onto a Prometheus ``result`` label value.
 
@@ -115,7 +146,7 @@ class CommitterDeps:
     """Side-effect callables the committer depends on. Tests pass mocks."""
 
     load_table: Callable[[], Any]  # returns pyiceberg Table
-    commit_data_files: Callable[..., int] = ib.commit_data_files  # returns snapshot_id
+    commit_data_files: Callable[..., ib.CommitResult] = ib.commit_data_files
     find_snapshot_for_cycle: Callable[..., int | None] = ib.find_snapshot_for_cycle
     build_data_file: Callable[..., Any] = ib.build_data_file
     kafka_admin: Any = None  # confluent_kafka AdminClient — built once at startup
@@ -246,37 +277,16 @@ def _run_cycle_body(
             data_files.append(df)
             kafka_offset_dicts.append(kafka_offsets)
 
-        snapshot_id, snapshot_summary = deps.commit_data_files(
+        commit_result = deps.commit_data_files(
             table=table,
             data_files=data_files,
             cycle_id=cycle_id,
         )
-        result.iceberg_snapshot_id = snapshot_id
+        result.iceberg_snapshot_id = commit_result.snapshot_id
         log.info(
             "run_cycle: cycle %s iceberg-committed snapshot_id=%s",
-            cycle_id, snapshot_id,
+            cycle_id, commit_result.snapshot_id,
         )
-        # Free signal: the summary the committer just produced carries
-        # cumulative table stats. Surfaces table growth + compaction
-        # signal without a separate thread or Lakekeeper poll.
-        # Defensive None-skip: if a future PyIceberg API shift leaves
-        # snapshot_summary empty, the gauges retain their last value
-        # (which is still the truth — table state hasn't changed).
-        if snapshot_summary is not None:
-            for key, gauge in (
-                ("total-data-files", metrics.ICEBERG_TABLE_DATA_FILES),
-                ("total-records", metrics.ICEBERG_TABLE_RECORDS),
-                ("total-files-size", metrics.ICEBERG_TABLE_FILES_SIZE_BYTES),
-            ):
-                raw = snapshot_summary.get(key)
-                if raw is None:
-                    continue
-                try:
-                    gauge.set(int(raw))
-                except (TypeError, ValueError):
-                    # Summary values are spec-defined as ints-as-strings;
-                    # a non-parseable value is a producer bug, not ours.
-                    continue
 
     except Exception as exc:
         log.exception(
@@ -291,11 +301,29 @@ def _run_cycle_body(
                 ps.update_heartbeat(conn)
         return result
 
+    # CRITICAL: gauge update is OUTSIDE the iceberg-commit try block.
+    # If a gauge.set() raised here while still inside that try, the
+    # except branch would release the cycle claim AFTER the snapshot
+    # had already landed in Lakekeeper — the files would be re-batched
+    # in a future cycle and double-committed against the same data.
+    # Decouple observability from the commit saga: any failure here
+    # gets logged but doesn't poison cycle state.
+    if commit_result.summary is not None:
+        try:
+            _update_table_state_gauges(commit_result.summary)
+        except Exception:
+            log.warning(
+                "run_cycle: cycle %s table-state gauge update failed "
+                "(commit already landed; gauges hold their last value)",
+                cycle_id,
+                exc_info=True,
+            )
+
     # ---- Step 6: persist iceberg_snapshot_id BEFORE attempting Kafka -----
     with pg_pool.connection() as conn:
         with conn.transaction():
             ps.mark_iceberg_committed(
-                conn, cycle_id=cycle_id, snapshot_id=snapshot_id
+                conn, cycle_id=cycle_id, snapshot_id=commit_result.snapshot_id
             )
 
     # ---- Step 7: kafka commit --------------------------------------------
@@ -319,7 +347,7 @@ def _run_cycle_body(
         log.exception(
             "run_cycle: kafka-commit failed for cycle %s (iceberg already "
             "committed snapshot_id=%s — recovery will finalize): %s",
-            cycle_id, snapshot_id, exc,
+            cycle_id, commit_result.snapshot_id, exc,
         )
         result.error = f"kafka-commit failed (cycle stuck): {exc}"
         with pg_pool.connection() as conn:
@@ -332,7 +360,7 @@ def _run_cycle_body(
     with pg_pool.connection() as conn:
         with conn.transaction():
             ps.mark_kafka_committed(conn, cycle_id=cycle_id)
-            ps.complete_cycle(conn, cycle_id=cycle_id, snapshot_id=snapshot_id)
+            ps.complete_cycle(conn, cycle_id=cycle_id, snapshot_id=commit_result.snapshot_id)
             ps.record_success(conn)
             ps.update_heartbeat(conn)
 

--- a/icebox/committer.py
+++ b/icebox/committer.py
@@ -246,7 +246,7 @@ def _run_cycle_body(
             data_files.append(df)
             kafka_offset_dicts.append(kafka_offsets)
 
-        snapshot_id = deps.commit_data_files(
+        snapshot_id, snapshot_summary = deps.commit_data_files(
             table=table,
             data_files=data_files,
             cycle_id=cycle_id,
@@ -256,6 +256,27 @@ def _run_cycle_body(
             "run_cycle: cycle %s iceberg-committed snapshot_id=%s",
             cycle_id, snapshot_id,
         )
+        # Free signal: the summary the committer just produced carries
+        # cumulative table stats. Surfaces table growth + compaction
+        # signal without a separate thread or Lakekeeper poll.
+        # Defensive None-skip: if a future PyIceberg API shift leaves
+        # snapshot_summary empty, the gauges retain their last value
+        # (which is still the truth — table state hasn't changed).
+        if snapshot_summary is not None:
+            for key, gauge in (
+                ("total-data-files", metrics.ICEBERG_TABLE_DATA_FILES),
+                ("total-records", metrics.ICEBERG_TABLE_RECORDS),
+                ("total-files-size", metrics.ICEBERG_TABLE_FILES_SIZE_BYTES),
+            ):
+                raw = snapshot_summary.get(key)
+                if raw is None:
+                    continue
+                try:
+                    gauge.set(int(raw))
+                except (TypeError, ValueError):
+                    # Summary values are spec-defined as ints-as-strings;
+                    # a non-parseable value is a producer bug, not ours.
+                    continue
 
     except Exception as exc:
         log.exception(

--- a/icebox/config.py
+++ b/icebox/config.py
@@ -142,6 +142,17 @@ class Config:
     # to the millpond package version. Operators can override via
     # ICEBOX_SERVICE_VERSION (e.g., to expose the image digest).
     service_version: str = "unknown"
+    # service.namespace per OTel semconv — "logical grouping of related
+    # services in a deployment unit". For PostHog this is the release
+    # family ("millpond"). NOT the data-side namespace (we previously
+    # misused this field for the PG schema; the icebox.* custom attrs
+    # carry the per-(warehouse, namespace, table) facets now).
+    service_namespace: str = "millpond"
+    # service.instance.id per OTel semconv — distinguishes instances of
+    # the same service. Set by the chart to the consumer key (e.g.
+    # ``events-icebox``) so PostHog Logs can filter by instance the
+    # same way it does by service. Optional; unset = no attr.
+    service_instance_id: str | None = None
 
     # Schema-fingerprint cache TTL — how long the API perimeter
     # trusts its in-memory copy of the Iceberg table's current
@@ -315,6 +326,8 @@ def load() -> Config:
             "https://us.i.posthog.com/i/v1/logs",
         ),
         service_version=_optional("ICEBOX_SERVICE_VERSION", _default_service_version()),
+        service_namespace=_optional("ICEBOX_SERVICE_NAMESPACE", "millpond"),
+        service_instance_id=os.environ.get("ICEBOX_SERVICE_INSTANCE_ID") or None,
         schema_fingerprint_cache_ttl_seconds=_float(
             "ICEBOX_SCHEMA_FINGERPRINT_CACHE_TTL_SECONDS", 60.0
         ),

--- a/icebox/iceberg.py
+++ b/icebox/iceberg.py
@@ -180,7 +180,7 @@ def commit_data_files(
     data_files: list[DataFile],
     cycle_id: UUID,
     branch: str = "main",
-) -> int:
+) -> tuple[int, dict[str, str] | None]:
     """Commit a batch of DataFiles in a single Iceberg snapshot, tagging
     the snapshot with the cycle_id for recovery.
 
@@ -192,8 +192,16 @@ def commit_data_files(
         branch: snapshot branch. Defaults to "main".
 
     Returns:
-        The committed snapshot ID. Persists to PG so subsequent
-        recovery doesn't need to rescan the snapshot_log.
+        A ``(snapshot_id, summary)`` pair. ``snapshot_id`` is the
+        committed Iceberg snapshot ID — persisted to PG so subsequent
+        recovery doesn't need to rescan the snapshot_log. ``summary``
+        is the snapshot's Iceberg-spec summary dict (with keys like
+        ``total-data-files``, ``total-records``, ``total-files-size``,
+        etc.) extracted from the transaction's updated metadata in
+        the same scope as the commit — no extra Lakekeeper round-trip.
+        ``summary`` is ``None`` only if PyIceberg's in-transaction
+        metadata lookup unexpectedly returns no snapshot for the id we
+        just committed (defensive — should never happen).
 
     Raises:
         Whatever PyIceberg raises if the commit fails (transient FS
@@ -221,6 +229,7 @@ def commit_data_files(
     # for the snapshot the producer just built.
     snapshot_props = {CYCLE_ID_SUMMARY_KEY: str(cycle_id)}
     snapshot_id: int | None = None
+    summary: dict[str, str] | None = None
     with table.transaction() as tx:
         with tx._append_snapshot_producer(
             snapshot_properties=snapshot_props,
@@ -229,6 +238,26 @@ def commit_data_files(
             for df in data_files:
                 producer.append_data_file(df)
             snapshot_id = producer.snapshot_id
+        # After the producer context exits, the transaction's metadata
+        # includes the new snapshot. Look it up via the public
+        # ``tx.table_metadata.snapshot_by_id`` API — same scope, no
+        # extra Lakekeeper round-trip. Defensive try/except: if a
+        # future PyIceberg rev shifts the in-tx metadata view, we
+        # still get the snapshot_id back (which is the load-bearing
+        # return) and the committer's gauges just hold their previous
+        # value for that cycle.
+        try:
+            new_snapshot = tx.table_metadata.snapshot_by_id(snapshot_id)
+            if new_snapshot is not None and new_snapshot.summary is not None:
+                # Summary is a Pydantic model with dict-like ``additional_properties``;
+                # the standard fields live there too. ``model_dump`` gives us a flat dict.
+                summary = dict(new_snapshot.summary.additional_properties)
+                summary["operation"] = new_snapshot.summary.operation.value
+        except Exception:
+            # Don't let an extraction quirk kill the commit. The
+            # snapshot_id is what we need to persist; the summary is
+            # observability sugar.
+            summary = None
 
     if snapshot_id is None:
         raise RuntimeError(
@@ -236,7 +265,7 @@ def commit_data_files(
             f"cycle_id={cycle_id}; this indicates a PyIceberg API change "
             f"affecting _append_snapshot_producer"
         )
-    return snapshot_id
+    return snapshot_id, summary
 
 
 def find_snapshot_for_cycle(table: Table, cycle_id: UUID) -> int | None:

--- a/icebox/iceberg.py
+++ b/icebox/iceberg.py
@@ -27,6 +27,7 @@ calls this out as a non-goal.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 
@@ -39,6 +40,30 @@ from pyiceberg.typedef import Record
 from shared.bounds import encode_bounds
 
 log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CommitResult:
+    """The result of a successful iceberg-commit cycle.
+
+    Returned as a dataclass (not a tuple) so adding fields like
+    per-cycle delta counts or schema-evolution flags later doesn't
+    force every caller to update positional unpacking.
+
+    Attributes:
+        snapshot_id: The committed Iceberg snapshot ID. Load-bearing
+            for PG state — persisted so recovery doesn't need to
+            rescan the snapshot_log.
+        summary: The snapshot's spec-defined summary dict (keys like
+            ``total-data-files``, ``total-records``, ``added-records``,
+            etc.) extracted from the transaction's metadata in the
+            same scope as the commit — no extra Lakekeeper round-trip.
+            ``None`` only if a future PyIceberg API drift in the
+            in-tx metadata view defeats the lookup; defensive.
+    """
+
+    snapshot_id: int
+    summary: dict[str, str] | None
 
 
 # Snapshot summary key for cycle_id — the recovery scan looks for this
@@ -180,7 +205,7 @@ def commit_data_files(
     data_files: list[DataFile],
     cycle_id: UUID,
     branch: str = "main",
-) -> tuple[int, dict[str, str] | None]:
+) -> CommitResult:
     """Commit a batch of DataFiles in a single Iceberg snapshot, tagging
     the snapshot with the cycle_id for recovery.
 
@@ -192,16 +217,15 @@ def commit_data_files(
         branch: snapshot branch. Defaults to "main".
 
     Returns:
-        A ``(snapshot_id, summary)`` pair. ``snapshot_id`` is the
+        A ``CommitResult(snapshot_id, summary)``. ``snapshot_id`` is the
         committed Iceberg snapshot ID — persisted to PG so subsequent
         recovery doesn't need to rescan the snapshot_log. ``summary``
         is the snapshot's Iceberg-spec summary dict (with keys like
-        ``total-data-files``, ``total-records``, ``total-files-size``,
+        ``total-data-files``, ``total-records``, ``added-records``,
         etc.) extracted from the transaction's updated metadata in
         the same scope as the commit — no extra Lakekeeper round-trip.
-        ``summary`` is ``None`` only if PyIceberg's in-transaction
-        metadata lookup unexpectedly returns no snapshot for the id we
-        just committed (defensive — should never happen).
+        ``summary`` is ``None`` only if a future PyIceberg API drift
+        in the in-tx metadata view defeats the lookup; defensive.
 
     Raises:
         Whatever PyIceberg raises if the commit fails (transient FS
@@ -241,23 +265,31 @@ def commit_data_files(
         # After the producer context exits, the transaction's metadata
         # includes the new snapshot. Look it up via the public
         # ``tx.table_metadata.snapshot_by_id`` API — same scope, no
-        # extra Lakekeeper round-trip. Defensive try/except: if a
-        # future PyIceberg rev shifts the in-tx metadata view, we
-        # still get the snapshot_id back (which is the load-bearing
-        # return) and the committer's gauges just hold their previous
-        # value for that cycle.
+        # extra Lakekeeper round-trip.
+        #
+        # Defensive partial-extraction: pull additional_properties
+        # first (the bulk of the value); only THEN try to attach the
+        # operation. A failure during operation lookup keeps the
+        # already-extracted dict so the committer's gauges still get
+        # the cumulative+delta numbers — partial summaries beat None
+        # for observability. A failure earlier (no snapshot found at
+        # all, or additional_properties raises) degrades to summary=None.
         try:
             new_snapshot = tx.table_metadata.snapshot_by_id(snapshot_id)
-            if new_snapshot is not None and new_snapshot.summary is not None:
-                # Summary is a Pydantic model with dict-like ``additional_properties``;
-                # the standard fields live there too. ``model_dump`` gives us a flat dict.
-                summary = dict(new_snapshot.summary.additional_properties)
-                summary["operation"] = new_snapshot.summary.operation.value
         except Exception:
-            # Don't let an extraction quirk kill the commit. The
-            # snapshot_id is what we need to persist; the summary is
-            # observability sugar.
-            summary = None
+            new_snapshot = None
+        if new_snapshot is not None and new_snapshot.summary is not None:
+            try:
+                summary = dict(new_snapshot.summary.additional_properties)
+            except Exception:
+                summary = None
+            if summary is not None:
+                try:
+                    summary["posthog.icebox.operation"] = (
+                        new_snapshot.summary.operation.value
+                    )
+                except Exception:
+                    pass  # keep the additional_properties we did get
 
     if snapshot_id is None:
         raise RuntimeError(
@@ -265,7 +297,7 @@ def commit_data_files(
             f"cycle_id={cycle_id}; this indicates a PyIceberg API change "
             f"affecting _append_snapshot_producer"
         )
-    return snapshot_id, summary
+    return CommitResult(snapshot_id=snapshot_id, summary=summary)
 
 
 def find_snapshot_for_cycle(table: Table, cycle_id: UUID) -> int | None:

--- a/icebox/main.py
+++ b/icebox/main.py
@@ -55,8 +55,14 @@ def main() -> None:
         posthog_token=cfg.posthog_project_token,
         posthog_endpoint=cfg.posthog_logs_endpoint,
         service_name="icebox",
-        service_namespace=cfg.pg_schema,
+        service_namespace=cfg.service_namespace,
         service_version=cfg.service_version,
+        service_instance_id=cfg.service_instance_id,
+        iceberg_warehouse=cfg.iceberg_warehouse,
+        iceberg_namespace=cfg.iceberg_namespace,
+        iceberg_table=cfg.iceberg_table,
+        kafka_topic=cfg.kafka_topic,
+        kafka_group_id=cfg.kafka_group_id,
     )
     log.info("icebox starting on %s:%d", cfg.api_host, cfg.api_port)
 

--- a/icebox/metrics.py
+++ b/icebox/metrics.py
@@ -96,7 +96,11 @@ POST_TOTAL = Counter(
 SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL = Counter(
     "icebox_schema_fingerprint_cache_misses_total",
     "Times the writer-claimed schema fingerprint didn't match the cached "
-    "value, forcing a catalog refresh. Expected ~zero at steady state; a "
-    "non-zero rate after an ALTER TABLE is normal until cache + writers "
-    "converge.",
+    "value, forcing a catalog refresh. Partitioned by reason:\n"
+    "  - cache_stale_after_alter: the catalog refresh matched the writer "
+    "    (the cache was just behind reality — normal post-ALTER race).\n"
+    "  - fingerprint_mismatch: the refresh STILL doesn't match — the "
+    "    writer is presenting a fingerprint the catalog doesn't know. "
+    "    Alertable; the cache_stale_after_alter rate is not.",
+    labelnames=("reason",),
 )

--- a/icebox/metrics.py
+++ b/icebox/metrics.py
@@ -93,6 +93,32 @@ POST_TOTAL = Counter(
 # Schema-fingerprint cache
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Iceberg table state — read from the snapshot.summary returned by every
+# successful iceberg-commit. Free signal (no extra Lakekeeper round-trip,
+# no background thread), updated once per cycle.
+# ---------------------------------------------------------------------------
+
+ICEBERG_TABLE_DATA_FILES = Gauge(
+    "icebox_iceberg_table_data_files",
+    "Total data files in the icebox's target Iceberg table after the last "
+    "successful cycle commit. Source: snapshot.summary['total-data-files'].",
+)
+
+ICEBERG_TABLE_RECORDS = Gauge(
+    "icebox_iceberg_table_records",
+    "Total records in the icebox's target Iceberg table after the last "
+    "successful cycle commit. Source: snapshot.summary['total-records'].",
+)
+
+ICEBERG_TABLE_FILES_SIZE_BYTES = Gauge(
+    "icebox_iceberg_table_files_size_bytes",
+    "Total bytes across all data files in the icebox's target Iceberg "
+    "table after the last successful cycle commit. Source: "
+    "snapshot.summary['total-files-size'].",
+)
+
+
 SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL = Counter(
     "icebox_schema_fingerprint_cache_misses_total",
     "Times the writer-claimed schema fingerprint didn't match the cached "

--- a/icebox/metrics.py
+++ b/icebox/metrics.py
@@ -87,3 +87,16 @@ POST_TOTAL = Counter(
     "POST /v1/files responses, partitioned by HTTP status code.",
     labelnames=("status",),
 )
+
+
+# ---------------------------------------------------------------------------
+# Schema-fingerprint cache
+# ---------------------------------------------------------------------------
+
+SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL = Counter(
+    "icebox_schema_fingerprint_cache_misses_total",
+    "Times the writer-claimed schema fingerprint didn't match the cached "
+    "value, forcing a catalog refresh. Expected ~zero at steady state; a "
+    "non-zero rate after an ALTER TABLE is normal until cache + writers "
+    "converge.",
+)

--- a/icebox/metrics.py
+++ b/icebox/metrics.py
@@ -97,6 +97,14 @@ POST_TOTAL = Counter(
 # Iceberg table state — read from the snapshot.summary returned by every
 # successful iceberg-commit. Free signal (no extra Lakekeeper round-trip,
 # no background thread), updated once per cycle.
+#
+# RESERVED: these gauges are intentionally UNLABELED. Each icebox process
+# serves exactly one (Iceberg namespace, table) pair (see icebox/README.md
+# "One icebox per (Iceberg namespace, table)") — single-table invariant.
+# The per-(table) axis comes from the icebox.iceberg.* OTLP resource attrs +
+# the Prometheus job dimension. If a future change ever runs multiple
+# tables per process, adding labels here is a breaking metric-series
+# change; plan the migration explicitly.
 # ---------------------------------------------------------------------------
 
 ICEBERG_TABLE_DATA_FILES = Gauge(
@@ -116,6 +124,27 @@ ICEBERG_TABLE_FILES_SIZE_BYTES = Gauge(
     "Total bytes across all data files in the icebox's target Iceberg "
     "table after the last successful cycle commit. Source: "
     "snapshot.summary['total-files-size'].",
+)
+
+# Per-cycle deltas — operational signals distinct from cumulative state:
+# - added_data_files climbing = compaction debt growing
+# - added_records / added_files_size = effective per-cycle ingest rate
+ICEBERG_TABLE_ADDED_DATA_FILES = Gauge(
+    "icebox_iceberg_table_added_data_files",
+    "Data files added by the last successful cycle commit. Source: "
+    "snapshot.summary['added-data-files'].",
+)
+
+ICEBERG_TABLE_ADDED_RECORDS = Gauge(
+    "icebox_iceberg_table_added_records",
+    "Records added by the last successful cycle commit. Source: "
+    "snapshot.summary['added-records'].",
+)
+
+ICEBERG_TABLE_ADDED_FILES_SIZE_BYTES = Gauge(
+    "icebox_iceberg_table_added_files_size_bytes",
+    "Bytes added by the last successful cycle commit. Source: "
+    "snapshot.summary['added-files-size'].",
 )
 
 

--- a/icebox/schema_cache.py
+++ b/icebox/schema_cache.py
@@ -112,12 +112,24 @@ class SchemaFingerprintCache:
         # DEBUG because at steady state this fires on every legitimate
         # schema-evolution race (writer ran ALTER TABLE between our
         # cache refresh and its POST) AND on misconfigured writers.
-        # In 1h of prod logs this was 22% of all volume — a metric
-        # captures the rate without the per-event noise.
-        metrics.SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL.inc()
+        # In 1h of prod logs this was 22% of all volume — the labeled
+        # counter below carries the operational signal, partitioned by
+        # reason so alerts can fire on `fingerprint_mismatch` without
+        # false pages on every legitimate `cache_stale_after_alter`.
         log.debug(
             "schema_fingerprint_cache: cached fingerprint did not match "
             "writer-claimed value; forcing refresh"
         )
         refreshed = await self.current(force_refresh=True)
-        return claimed_fingerprint == refreshed
+        if claimed_fingerprint == refreshed:
+            # Refresh matched: the cache was stale post-ALTER. Normal.
+            metrics.SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL.labels(
+                reason="cache_stale_after_alter"
+            ).inc()
+            return True
+        # Refresh still doesn't match: the writer's fingerprint is
+        # unknown to the catalog. Alertable.
+        metrics.SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL.labels(
+            reason="fingerprint_mismatch"
+        ).inc()
+        return False

--- a/icebox/schema_cache.py
+++ b/icebox/schema_cache.py
@@ -33,6 +33,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from icebox import metrics
 from shared.fingerprint import schema_fingerprint
 
 log = logging.getLogger(__name__)
@@ -108,7 +109,13 @@ class SchemaFingerprintCache:
         current = await self.current()
         if claimed_fingerprint == current:
             return True
-        log.info(
+        # DEBUG because at steady state this fires on every legitimate
+        # schema-evolution race (writer ran ALTER TABLE between our
+        # cache refresh and its POST) AND on misconfigured writers.
+        # In 1h of prod logs this was 22% of all volume — a metric
+        # captures the rate without the per-event noise.
+        metrics.SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL.inc()
+        log.debug(
             "schema_fingerprint_cache: cached fingerprint did not match "
             "writer-claimed value; forcing refresh"
         )

--- a/icebox/structured_logging.py
+++ b/icebox/structured_logging.py
@@ -151,6 +151,15 @@ def setup_logging(
         root.removeHandler(handler)
     root.setLevel(level)
 
+    # Silence uvicorn's per-request access log. kubelet probes
+    # (/readyz, /healthz) + Prometheus scrape (/metrics) + every
+    # writer POST (/v1/files) generate one line each here. None of it
+    # carries operational signal that isn't already in our metrics
+    # — but together they swamp the useful committer logs (~63% of
+    # all icebox log volume per a 1h prod sample). WARNING-level
+    # keeps the door open for uvicorn to surface a startup failure.
+    logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
+
     formatter: logging.Formatter
     if fmt == "json":
         formatter = JsonFormatter()

--- a/icebox/structured_logging.py
+++ b/icebox/structured_logging.py
@@ -1,82 +1,48 @@
 """Structured-logging setup for the icebox.
 
-Provides:
+Composes the shared building blocks in ``shared.structured_logging``
+with icebox-specific bits:
+
   - ``cycle_id_var`` — a ``ContextVar`` the committer sets at the top
     of ``run_cycle`` so every log line emitted during that cycle is
     automatically stamped with the cycle's UUID.
-  - ``JsonFormatter`` — emits one JSON object per log record. Pulls
-    ``cycle_id`` from the ContextVar, includes the standard fields
-    (ts, level, logger, msg, exc), and inlines any ``extra=`` keyword
-    fields passed to the log call.
-  - ``setup_logging`` — installs the stdout handler with either the
-    JSON formatter or a plain text formatter, and (when
-    ``POSTHOG_PROJECT_TOKEN`` is set) attaches an OpenTelemetry
-    OTLP/HTTP log handler that ships records to PostHog Logs.
-
-The OTel path uses standard ``opentelemetry-sdk`` +
-``opentelemetry-exporter-otlp-proto-http``; PostHog terminates OTLP
-at ``/i/v1/logs`` so there is no PostHog-specific package needed
-(verified against ``posthog`` 7.16.x in the SDK research).
+  - ``IceboxJsonFormatter`` — JsonFormatter that pulls ``cycle_id``
+    from the ContextVar into the stdout JSON body.
+  - ``_CycleIdAttrFilter`` — OTel-side filter that stamps
+    ``icebox.cycle_id`` onto each log record as a typed attribute.
+  - ``setup_logging`` — assembles the icebox-flavored configuration
+    on top of the shared helpers.
 """
 from __future__ import annotations
 
-import json
 import logging
-import sys
 from contextvars import ContextVar
-from datetime import UTC, datetime
 from typing import Any
 
-# ContextVar carried through every committer cycle. The JsonFormatter
+from shared import structured_logging as sl
+
+# ContextVar carried through every committer cycle. The formatter
 # reads from it when rendering log records, so all logs emitted
 # during ``run_cycle`` are automatically stamped with the cycle's UUID.
 cycle_id_var: ContextVar[str | None] = ContextVar("icebox_cycle_id", default=None)
 
 
-# Standard ``LogRecord`` attrs we do NOT want to inline as JSON keys
-# (they're already in the top-level shape or are noise).
-_STANDARD_LOGRECORD_ATTRS = frozenset({
-    "name", "msg", "args", "levelname", "levelno", "pathname", "filename",
-    "module", "exc_info", "exc_text", "stack_info", "lineno", "funcName",
-    "created", "msecs", "relativeCreated", "thread", "threadName",
-    "processName", "process", "message", "taskName",
-})
+class IceboxJsonFormatter(sl.JsonFormatter):
+    """JSON formatter that inlines ``cycle_id`` into the stdout body.
 
-
-class JsonFormatter(logging.Formatter):
-    """JSON log formatter.
-
-    Output shape (one line per record):
-        {"ts": "...", "level": "INFO", "logger": "...", "msg": "...",
-         "cycle_id": "...", "<extra_key>": <extra_value>, ...,
-         "exc": "<traceback>"}
-
-    Extras passed to ``log.info("...", extra={"foo": 1})`` are inlined
-    at the top level. Values that aren't JSON-serializable are coerced
-    via ``repr``.
+    Kept separate from the OTLP-side stamping (which uses
+    ``_CycleIdAttrFilter`` with the namespaced key ``icebox.cycle_id``)
+    so the stdout JSON shape stays backward-compatible with the
+    pre-existing ``cycle_id`` body field.
     """
 
-    def format(self, record: logging.LogRecord) -> str:
-        out: dict[str, Any] = {
-            "ts": datetime.fromtimestamp(record.created, UTC).isoformat(),
-            "level": record.levelname,
-            "logger": record.name,
-            "msg": record.getMessage(),
-        }
-        cid = cycle_id_var.get()
-        if cid is not None:
-            out["cycle_id"] = cid
-        for key, value in record.__dict__.items():
-            if key in _STANDARD_LOGRECORD_ATTRS or key.startswith("_"):
-                continue
-            try:
-                json.dumps(value)
-                out[key] = value
-            except (TypeError, ValueError):
-                out[key] = repr(value)
-        if record.exc_info:
-            out["exc"] = self.formatException(record.exc_info)
-        return json.dumps(out, default=str)
+    def extra_context(self) -> dict[str, Any]:
+        return {"cycle_id": cycle_id_var.get()}
+
+
+# Backward-compat alias: tests and the rest of the codebase reference
+# ``JsonFormatter`` directly. The icebox flavor IS the default.
+JsonFormatter = IceboxJsonFormatter
 
 
 class _CycleIdAttrFilter(logging.Filter):
@@ -156,14 +122,9 @@ def setup_logging(
     Returns the OTel ``LoggerProvider`` when PostHog logging is
     enabled, so the caller can register ``provider.shutdown()`` on
     the SIGTERM drain path. Returns ``None`` when disabled.
-
-    Idempotent: re-running clears the root logger's handlers first
-    so tests and re-imports don't stack duplicate sinks.
     """
-    root = logging.getLogger()
-    for handler in list(root.handlers):
-        root.removeHandler(handler)
-    root.setLevel(level)
+    formatter = IceboxJsonFormatter() if fmt == "json" else sl.text_formatter()
+    root = sl.install_root_handlers(level=level, formatter=formatter)
 
     # Silence uvicorn's per-request access log. kubelet probes
     # (/readyz, /healthz) + Prometheus scrape (/metrics) + every
@@ -172,43 +133,10 @@ def setup_logging(
     # — but together they swamp the useful committer logs (~63% of
     # all icebox log volume per a 1h prod sample). WARNING-level
     # keeps the door open for uvicorn to surface a startup failure.
-    logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
-
-    formatter: logging.Formatter
-    if fmt == "json":
-        formatter = JsonFormatter()
-    else:
-        formatter = logging.Formatter(
-            "%(asctime)s %(levelname)s [%(name)s] %(message)s"
-        )
-
-    stream_handler = logging.StreamHandler(sys.stdout)
-    stream_handler.setFormatter(formatter)
-    root.addHandler(stream_handler)
+    sl.silence_logger("uvicorn.access", logging.WARNING)
 
     if not posthog_token:
         return None
-
-    # Lazy import: bringing OTel in only when we're actually exporting
-    # keeps the cold-start cost off the path for tests / dev that
-    # haven't set the token. The deps ARE installed (we ship them so
-    # the prod chart can opt in by setting env vars without an image
-    # rebuild), but the modules pull in a fair amount of code.
-    from opentelemetry._logs import set_logger_provider
-    from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
-
-    # The handler from opentelemetry.sdk._logs is deprecated since
-    # opentelemetry-sdk 1.42 in favor of the one from
-    # opentelemetry-instrumentation-logging. Same constructor signature
-    # (level, logger_provider), same wire behavior — the
-    # instrumentation-package version additionally defaults to NOT
-    # emitting code.{file,function,line} attributes per record, which
-    # is exactly what we want for PostHog Logs (those attrs were pure
-    # noise in the export).
-    from opentelemetry.instrumentation.logging.handler import LoggingHandler
-    from opentelemetry.sdk._logs import LoggerProvider
-    from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
-    from opentelemetry.sdk.resources import Resource
 
     # Build the resource-attr dict, dropping None values so unset
     # optionals don't render as empty strings on the wire.
@@ -236,38 +164,15 @@ def setup_logging(
     if kafka_topic is not None or kafka_group_id is not None:
         resource_attrs["messaging.system"] = "kafka"
 
-    # Resource.create() merges in OTEL_RESOURCE_ATTRIBUTES env so the
-    # chart can supply deployment.environment, k8s.*, host.hostname
-    # without an app code change. We split by key ownership (app vs.
-    # chart) so the implicit user-attrs-win precedence of merge() is
-    # never load-bearing — but a test still pins it as a safety net
-    # against future SDK refactors.
-    resource = Resource.create(resource_attrs)
-    provider = LoggerProvider(resource=resource)
-    set_logger_provider(provider)
-    provider.add_log_record_processor(
-        BatchLogRecordProcessor(
-            OTLPLogExporter(
-                endpoint=posthog_endpoint,
-                headers={"Authorization": f"Bearer {posthog_token}"},
-            )
-        )
+    provider = sl.build_otel_logger_provider(
+        posthog_token=posthog_token,
+        posthog_endpoint=posthog_endpoint,
+        resource_attrs=resource_attrs,
     )
-    # log_code_attributes=False is the explicit (and default) request to
-    # NOT stamp code.{file,function,line} on every record. The previous
-    # opentelemetry-sdk handler stamped them unconditionally; the new
-    # instrumentation-package handler defaults to off, but pinning the
-    # kwarg makes the choice deliberate code rather than implicit
-    # default — future readers see we want them off.
-    otel_handler = LoggingHandler(
+    sl.attach_otel_handler(
+        provider=provider,
+        root=root,
         level=level,
-        logger_provider=provider,
-        log_code_attributes=False,
+        extra_filters=[_CycleIdAttrFilter()],
     )
-    # Filter is OTel-side only so the stdout JSON shape stays stable
-    # (existing ``cycle_id`` body field via the formatter's
-    # ContextVar read) while OTel records gain ``icebox.cycle_id`` as
-    # a typed record attribute for PostHog Logs filtering.
-    otel_handler.addFilter(_CycleIdAttrFilter())
-    root.addHandler(otel_handler)
     return provider

--- a/icebox/structured_logging.py
+++ b/icebox/structured_logging.py
@@ -116,28 +116,42 @@ def setup_logging(
 ) -> Any | None:
     """Configure the root logger and (optionally) PostHog OTLP export.
 
-    Resource-attr shape on the OTLP side:
-      - ``service.name`` (constant ``icebox``): groups all instances of
-        the icebox binary across (env, table) in PostHog Logs.
-      - ``service.namespace`` (default ``millpond``): the release
-        family this icebox belongs to. OTel semconv intends this for
-        logical service grouping, NOT data-side namespacing — earlier
-        versions misused it for the PG schema.
+    Resource-attr taxonomy on the OTLP side, split by ownership:
+
+    **App-owned** (passed here):
+      - ``service.name`` (constant ``icebox``): one binary, one service.
+        Per-instance differentiation is on ``service.instance.id``.
+      - ``service.namespace`` (default ``millpond``): release family.
+        OTel semconv intends this for logical service grouping — NOT
+        data-side namespacing. (Earlier versions misused it for the
+        PG schema; see migration note in icebox/README.md.)
       - ``service.instance.id`` (per-consumer key, e.g.
         ``events-icebox``): differentiates instances of the same
-        service. PostHog Logs uses this as the per-pod axis.
+        service. This IS the per-pod / per-(namespace,table) axis.
       - ``service.version``: package version.
-      - ``source_type=icebox``: matches the existing PostHog
-        Vector-on-EC2 convention (which sets ``source_type=journald``)
-        so common filters carry over.
-      - ``icebox.iceberg.{warehouse,namespace,table}`` and
-        ``icebox.kafka.{topic,group_id}``: vendor-namespaced custom
-        attrs so per-(table, topic) filters work in the UI.
+      - ``messaging.system``, ``messaging.destination.name``,
+        ``messaging.kafka.consumer.group``: OTel semconv standard for
+        Kafka attrs. Picked over vendor-prefixed
+        ``icebox.kafka.*`` so future OTel-aware tooling (collector
+        processors, dashboard packs, alert templates) Just Works.
+      - ``icebox.iceberg.{warehouse,namespace,table}``: vendor-prefixed
+        because OTel semconv has no Iceberg coverage today.
 
-    Standard OTel semconv attrs (``deployment.environment``, ``k8s.*``,
-    ``host.hostname``) are NOT passed here — the chart sets them via
-    ``OTEL_RESOURCE_ATTRIBUTES`` and OTel's ``Resource.create()``
-    auto-merges. Keeps the env/cluster concern out of the icebox app.
+    **Chart-owned** (NOT passed here; supplied via
+    ``OTEL_RESOURCE_ATTRIBUTES`` env, auto-merged by ``Resource.create``):
+      - ``deployment.environment``
+      - ``k8s.cluster.name``, ``k8s.namespace.name``, ``k8s.pod.name``,
+        ``k8s.deployment.name``
+      - ``host.hostname``
+
+    Split by ownership, not by precedence — there's no key the app and
+    the chart both set, so we never depend on the implicit
+    last-arg-wins rule of ``Resource.merge``.
+
+    ``cycle_id`` is intentionally a per-record attribute
+    (``icebox.cycle_id``), NOT a Resource attribute, because it's
+    scoped to a single cycle inside the process — not a property of
+    the process itself.
 
     Returns the OTel ``LoggerProvider`` when PostHog logging is
     enabled, so the caller can register ``provider.shutdown()`` on
@@ -202,22 +216,32 @@ def setup_logging(
         "service.name": service_name,
         "service.namespace": service_namespace,
         "service.version": service_version,
-        "source_type": "icebox",
     }
+    # Kafka attrs use OTel messaging semconv (see
+    # https://opentelemetry.io/docs/specs/semconv/messaging/) so
+    # generic OTel tooling can interpret them. Iceberg attrs stay
+    # vendor-prefixed (no semconv coverage today).
     for key, value in (
         ("service.instance.id", service_instance_id),
+        ("messaging.destination.name", kafka_topic),
+        ("messaging.kafka.consumer.group", kafka_group_id),
         ("icebox.iceberg.warehouse", iceberg_warehouse),
         ("icebox.iceberg.namespace", iceberg_namespace),
         ("icebox.iceberg.table", iceberg_table),
-        ("icebox.kafka.topic", kafka_topic),
-        ("icebox.kafka.group_id", kafka_group_id),
     ):
         if value is not None:
             resource_attrs[key] = value
+    # ``messaging.system`` is the constant axis for the system itself;
+    # only emit it if we actually have Kafka attrs to qualify.
+    if kafka_topic is not None or kafka_group_id is not None:
+        resource_attrs["messaging.system"] = "kafka"
 
     # Resource.create() merges in OTEL_RESOURCE_ATTRIBUTES env so the
     # chart can supply deployment.environment, k8s.*, host.hostname
-    # without an app code change. User-passed attrs win on conflict.
+    # without an app code change. We split by key ownership (app vs.
+    # chart) so the implicit user-attrs-win precedence of merge() is
+    # never load-bearing — but a test still pins it as a safety net
+    # against future SDK refactors.
     resource = Resource.create(resource_attrs)
     provider = LoggerProvider(resource=resource)
     set_logger_provider(provider)
@@ -229,11 +253,17 @@ def setup_logging(
             )
         )
     )
-    # Same formatter so the OTel body has consistent JSON shape with
-    # what lands in stdout. OTel will wrap the record in its own
-    # envelope on the wire, but the body field will be parseable.
-    otel_handler = LoggingHandler(level=level, logger_provider=provider)
-    otel_handler.setFormatter(formatter)
+    # log_code_attributes=False is the explicit (and default) request to
+    # NOT stamp code.{file,function,line} on every record. The previous
+    # opentelemetry-sdk handler stamped them unconditionally; the new
+    # instrumentation-package handler defaults to off, but pinning the
+    # kwarg makes the choice deliberate code rather than implicit
+    # default — future readers see we want them off.
+    otel_handler = LoggingHandler(
+        level=level,
+        logger_provider=provider,
+        log_code_attributes=False,
+    )
     # Filter is OTel-side only so the stdout JSON shape stays stable
     # (existing ``cycle_id`` body field via the formatter's
     # ContextVar read) while OTel records gain ``icebox.cycle_id`` as

--- a/icebox/structured_logging.py
+++ b/icebox/structured_logging.py
@@ -79,6 +79,25 @@ class JsonFormatter(logging.Formatter):
         return json.dumps(out, default=str)
 
 
+class _CycleIdAttrFilter(logging.Filter):
+    """Stamp ``icebox.cycle_id`` onto records inside a cycle context.
+
+    Attached to the OTel handler only. The stdout JsonFormatter keeps
+    its own ContextVar read (preserves the legacy ``cycle_id`` body
+    field), while OTel record attributes get the namespaced key so
+    PostHog Logs can filter on it like any other resource/record dim.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        cid = cycle_id_var.get()
+        if cid is not None:
+            # Dotted attribute names are legal as dict keys via setattr
+            # — OTel's LoggingHandler picks these up into record attrs
+            # without further translation.
+            record.__dict__["icebox.cycle_id"] = cid
+        return True
+
+
 def setup_logging(
     *,
     level: str = "INFO",
@@ -86,10 +105,39 @@ def setup_logging(
     posthog_token: str | None = None,
     posthog_endpoint: str = "https://us.i.posthog.com/i/v1/logs",
     service_name: str = "icebox",
-    service_namespace: str = "default",
+    service_namespace: str = "millpond",
     service_version: str = "unknown",
+    service_instance_id: str | None = None,
+    iceberg_warehouse: str | None = None,
+    iceberg_namespace: str | None = None,
+    iceberg_table: str | None = None,
+    kafka_topic: str | None = None,
+    kafka_group_id: str | None = None,
 ) -> Any | None:
     """Configure the root logger and (optionally) PostHog OTLP export.
+
+    Resource-attr shape on the OTLP side:
+      - ``service.name`` (constant ``icebox``): groups all instances of
+        the icebox binary across (env, table) in PostHog Logs.
+      - ``service.namespace`` (default ``millpond``): the release
+        family this icebox belongs to. OTel semconv intends this for
+        logical service grouping, NOT data-side namespacing — earlier
+        versions misused it for the PG schema.
+      - ``service.instance.id`` (per-consumer key, e.g.
+        ``events-icebox``): differentiates instances of the same
+        service. PostHog Logs uses this as the per-pod axis.
+      - ``service.version``: package version.
+      - ``source_type=icebox``: matches the existing PostHog
+        Vector-on-EC2 convention (which sets ``source_type=journald``)
+        so common filters carry over.
+      - ``icebox.iceberg.{warehouse,namespace,table}`` and
+        ``icebox.kafka.{topic,group_id}``: vendor-namespaced custom
+        attrs so per-(table, topic) filters work in the UI.
+
+    Standard OTel semconv attrs (``deployment.environment``, ``k8s.*``,
+    ``host.hostname``) are NOT passed here — the chart sets them via
+    ``OTEL_RESOURCE_ATTRIBUTES`` and OTel's ``Resource.create()``
+    auto-merges. Keeps the env/cluster concern out of the icebox app.
 
     Returns the OTel ``LoggerProvider`` when PostHog logging is
     enabled, so the caller can register ``provider.shutdown()`` on
@@ -129,11 +177,29 @@ def setup_logging(
     from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
     from opentelemetry.sdk.resources import Resource
 
-    resource = Resource.create({
+    # Build the resource-attr dict, dropping None values so unset
+    # optionals don't render as empty strings on the wire.
+    resource_attrs: dict[str, str] = {
         "service.name": service_name,
         "service.namespace": service_namespace,
         "service.version": service_version,
-    })
+        "source_type": "icebox",
+    }
+    for key, value in (
+        ("service.instance.id", service_instance_id),
+        ("icebox.iceberg.warehouse", iceberg_warehouse),
+        ("icebox.iceberg.namespace", iceberg_namespace),
+        ("icebox.iceberg.table", iceberg_table),
+        ("icebox.kafka.topic", kafka_topic),
+        ("icebox.kafka.group_id", kafka_group_id),
+    ):
+        if value is not None:
+            resource_attrs[key] = value
+
+    # Resource.create() merges in OTEL_RESOURCE_ATTRIBUTES env so the
+    # chart can supply deployment.environment, k8s.*, host.hostname
+    # without an app code change. User-passed attrs win on conflict.
+    resource = Resource.create(resource_attrs)
     provider = LoggerProvider(resource=resource)
     set_logger_provider(provider)
     provider.add_log_record_processor(
@@ -149,5 +215,10 @@ def setup_logging(
     # envelope on the wire, but the body field will be parseable.
     otel_handler = LoggingHandler(level=level, logger_provider=provider)
     otel_handler.setFormatter(formatter)
+    # Filter is OTel-side only so the stdout JSON shape stays stable
+    # (existing ``cycle_id`` body field via the formatter's
+    # ContextVar read) while OTel records gain ``icebox.cycle_id`` as
+    # a typed record attribute for PostHog Logs filtering.
+    otel_handler.addFilter(_CycleIdAttrFilter())
     root.addHandler(otel_handler)
     return provider

--- a/icebox/structured_logging.py
+++ b/icebox/structured_logging.py
@@ -182,7 +182,17 @@ def setup_logging(
     # rebuild), but the modules pull in a fair amount of code.
     from opentelemetry._logs import set_logger_provider
     from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
-    from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+
+    # The handler from opentelemetry.sdk._logs is deprecated since
+    # opentelemetry-sdk 1.42 in favor of the one from
+    # opentelemetry-instrumentation-logging. Same constructor signature
+    # (level, logger_provider), same wire behavior — the
+    # instrumentation-package version additionally defaults to NOT
+    # emitting code.{file,function,line} attributes per record, which
+    # is exactly what we want for PostHog Logs (those attrs were pure
+    # noise in the export).
+    from opentelemetry.instrumentation.logging.handler import LoggingHandler
+    from opentelemetry.sdk._logs import LoggerProvider
     from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
     from opentelemetry.sdk.resources import Resource
 

--- a/millpond/config.py
+++ b/millpond/config.py
@@ -116,6 +116,23 @@ class Config:
     # Extra librdkafka config (from KAFKA_CONSUMER_* env vars)
     kafka_config_overrides: tuple[tuple[str, str], ...]
 
+    # Optional PostHog Logs export via OTLP/HTTP. ON when
+    # ``posthog_project_token`` is set, OFF otherwise. Endpoint
+    # defaults to the US PostHog Cloud ingress; override for EU or
+    # self-hosted PostHog. service_namespace + service_instance_id
+    # match the icebox taxonomy (see shared/structured_logging.py +
+    # icebox/README.md). service_instance_id is typically the
+    # consumer-key the chart uses for the StatefulSet name, e.g.
+    # "events-icebox" or "events".
+    posthog_project_token: str | None = None
+    posthog_logs_endpoint: str = "https://us.i.posthog.com/i/v1/logs"
+    service_namespace: str = "millpond"
+    service_instance_id: str | None = None
+    # service.version reported in OTLP resource attrs. Defaults to the
+    # millpond package version. Operators can override via
+    # MILLPOND_SERVICE_VERSION (e.g. to expose the image digest).
+    service_version: str = "unknown"
+
     @property
     def flush_interval_s(self) -> float:
         return self.flush_interval_ms / 1000.0
@@ -127,6 +144,21 @@ class Config:
         if self.destination in ("iceberg", "icebox"):
             return f"{self.iceberg_namespace}.{self.iceberg_table}"
         return self.ducklake_table or "unknown"
+
+
+def _default_service_version() -> str:
+    """Best-effort service version string for OTLP resource attrs.
+
+    Falls back to the millpond setuptools-scm version baked into the
+    package; that maps cleanly to a git rev in non-prod builds and to a
+    clean tag in prod images.
+    """
+    try:
+        from millpond._version import version
+
+        return str(version)
+    except Exception:
+        return "unknown"
 
 
 def _parse_ordinal(pod_name: str) -> int:
@@ -389,6 +421,18 @@ def load() -> Config:
         filter_values=filter_values,
         sort_by=sort_by,
         kafka_config_overrides=kafka_overrides,
+        # No ``MILLPOND_`` prefix on POSTHOG_PROJECT_TOKEN: it's a
+        # PostHog-wide secret typically sourced from a shared K8s Secret
+        # (the same one other PostHog SDKs consume), so the canonical
+        # PostHog name is what operators expect to see.
+        posthog_project_token=(os.environ.get("POSTHOG_PROJECT_TOKEN") or None),
+        posthog_logs_endpoint=os.environ.get(
+            "POSTHOG_LOGS_ENDPOINT",
+            "https://us.i.posthog.com/i/v1/logs",
+        ),
+        service_namespace=os.environ.get("MILLPOND_SERVICE_NAMESPACE", "millpond"),
+        service_instance_id=os.environ.get("MILLPOND_SERVICE_INSTANCE_ID") or None,
+        service_version=os.environ.get("MILLPOND_SERVICE_VERSION", _default_service_version()),
     )
 
     log.info(

--- a/millpond/logging_config.py
+++ b/millpond/logging_config.py
@@ -148,10 +148,3 @@ def attach_posthog_otlp(cfg) -> Any | None:
         level=os.environ.get("LOG_LEVEL", "INFO").upper(),
     )
     return provider
-
-
-# Backward-compat alias: the existing main.py calls `setup()` once.
-# Keep that working with the basic-stdout phase; callers that want
-# OTLP must additionally call attach_posthog_otlp(cfg).
-def setup() -> None:
-    setup_stdout()

--- a/millpond/logging_config.py
+++ b/millpond/logging_config.py
@@ -1,19 +1,157 @@
+"""Structured-logging setup for the millpond writer.
+
+Two-phase by design:
+
+  - ``setup_stdout()`` — called BEFORE ``config.load()`` so that
+    config-load errors land on a structured stdout sink rather than
+    Python's default plain-text root.
+  - ``attach_posthog_otlp(cfg)`` — called AFTER ``config.load()``
+    once we have the resource-attr inputs. Returns the
+    ``LoggerProvider`` so the caller can register
+    ``provider.shutdown()`` on SIGTERM. Returns ``None`` when
+    ``cfg.posthog_project_token`` is unset.
+
+The two-phase split is intentional: the OTLP path needs config to
+build the resource attrs (destination, topic, table, etc.), but we
+want logging up before config-load can fail loudly.
+
+Shared building blocks live in ``shared.structured_logging``; this
+module adds the millpond-specific pieces (pod-ordinal prefix on the
+text formatter, ``confluent_kafka`` chatter silencing, and the
+resource-attr taxonomy that mirrors the icebox's but uses
+``millpond`` as ``service.name`` and adds ``millpond.destination``
++ destination-specific custom attrs).
+"""
+
+from __future__ import annotations
+
 import logging
 import os
-import sys
+from typing import Any
+
+from shared import structured_logging as sl
 
 
-def setup() -> None:
-    level = os.environ.get("LOG_LEVEL", "INFO").upper()
+def _pod_ordinal() -> str:
+    """Best-effort pod ordinal extraction for log prefix.
+
+    Falls back to the full pod name if no `-N` suffix, and to an empty
+    string if neither POD_NAME nor HOSTNAME is set.
+    """
     pod_name = os.environ.get("POD_NAME") or os.environ.get("HOSTNAME", "")
-    # Extract ordinal from pod name (e.g. "millpond-events-2" -> "2")
-    ordinal = pod_name.rsplit("-", 1)[-1] if "-" in pod_name else pod_name
-    prefix = f"[{ordinal}]" if ordinal else ""
-    logging.basicConfig(
-        level=level,
-        format=f"%(asctime)s %(levelname)-5s {prefix}[%(name)s] %(message)s",
-        datefmt="%Y-%m-%dT%H:%M:%S",
-        stream=sys.stderr,
+    if "-" in pod_name:
+        return pod_name.rsplit("-", 1)[-1]
+    return pod_name
+
+
+def setup_stdout() -> None:
+    """Phase 1: install the stdout handler with the configured format.
+
+    Called before config.load() so config-load errors are structured.
+    Reads LOG_LEVEL + MILLPOND_LOG_FORMAT (json|text) directly from
+    env — the Config dataclass isn't built yet at this point. Also
+    silences confluent_kafka chatter (per-message INFO at WARNING+).
+    """
+    level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    fmt = os.environ.get("MILLPOND_LOG_FORMAT", "json").lower()
+    if fmt == "json":
+        formatter: logging.Formatter = sl.JsonFormatter()
+    else:
+        # Preserve the historical [ordinal][logger] prefix for text mode
+        # so dev tail-style consumers stay readable.
+        ordinal = _pod_ordinal()
+        prefix = f"[{ordinal}]" if ordinal else ""
+        formatter = logging.Formatter(
+            f"%(asctime)s %(levelname)-5s {prefix}[%(name)s] %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S",
+        )
+    sl.install_root_handlers(level=level, formatter=formatter)
+    sl.silence_logger("confluent_kafka", logging.WARNING)
+
+
+def attach_posthog_otlp(cfg) -> Any | None:
+    """Phase 2: attach the OTLP/HTTP handler to PostHog Logs.
+
+    Returns the OTel LoggerProvider when enabled (so caller can
+    register ``provider.shutdown()`` on SIGTERM) or None when
+    ``cfg.posthog_project_token`` is unset.
+
+    Resource-attr taxonomy mirrors the icebox shape, with millpond
+    differences called out:
+
+    **App-owned** (passed here):
+      - ``service.name`` = constant ``millpond``
+      - ``service.namespace`` (default ``millpond``)
+      - ``service.instance.id`` = consumer key set by chart (e.g.
+        ``events`` or ``events-icebox``)
+      - ``service.version``
+      - ``messaging.system=kafka``, ``messaging.destination.name``,
+        ``messaging.kafka.consumer.group`` — OTel messaging semconv.
+      - ``millpond.destination`` — ``ducklake`` | ``iceberg`` |
+        ``icebox``. The dimension that's missing from millpond
+        metrics today; surfacing it as a log resource attr at least
+        gives PostHog Logs a per-destination axis.
+      - For ducklake destination: ``millpond.ducklake.table``,
+        ``millpond.ducklake.data_path``.
+      - For iceberg / icebox destination:
+        ``millpond.iceberg.{warehouse,namespace,table}``. (Vendor-
+        prefixed because OTel semconv has no Iceberg coverage today.)
+      - For icebox destination only: ``millpond.icebox.url``,
+        ``millpond.icebox.bucket``.
+
+    **Chart-owned** (NOT passed; auto-merged via
+    ``OTEL_RESOURCE_ATTRIBUTES``): ``deployment.environment``,
+    ``k8s.*``, ``host.hostname``.
+    """
+    if not cfg.posthog_project_token:
+        return None
+
+    resource_attrs: dict[str, str] = {
+        "service.name": "millpond",
+        "service.namespace": cfg.service_namespace,
+        "service.version": cfg.service_version,
+        "messaging.system": "kafka",
+        "messaging.destination.name": cfg.topic,
+        "messaging.kafka.consumer.group": cfg.group_id,
+        "millpond.destination": cfg.destination,
+    }
+    if cfg.service_instance_id is not None:
+        resource_attrs["service.instance.id"] = cfg.service_instance_id
+
+    # Destination-specific custom attrs.
+    if cfg.destination == "ducklake":
+        if cfg.ducklake_table is not None:
+            resource_attrs["millpond.ducklake.table"] = cfg.ducklake_table
+        if cfg.ducklake_data_path is not None:
+            resource_attrs["millpond.ducklake.data_path"] = cfg.ducklake_data_path
+    elif cfg.destination in ("iceberg", "icebox"):
+        if cfg.iceberg_warehouse is not None:
+            resource_attrs["millpond.iceberg.warehouse"] = cfg.iceberg_warehouse
+        if cfg.iceberg_namespace is not None:
+            resource_attrs["millpond.iceberg.namespace"] = cfg.iceberg_namespace
+        if cfg.iceberg_table is not None:
+            resource_attrs["millpond.iceberg.table"] = cfg.iceberg_table
+        if cfg.destination == "icebox":
+            if cfg.icebox_url is not None:
+                resource_attrs["millpond.icebox.url"] = cfg.icebox_url
+            if cfg.icebox_bucket is not None:
+                resource_attrs["millpond.icebox.bucket"] = cfg.icebox_bucket
+
+    provider = sl.build_otel_logger_provider(
+        posthog_token=cfg.posthog_project_token,
+        posthog_endpoint=cfg.posthog_logs_endpoint,
+        resource_attrs=resource_attrs,
     )
-    # Quiet noisy libraries
-    logging.getLogger("confluent_kafka").setLevel(logging.WARNING)
+    sl.attach_otel_handler(
+        provider=provider,
+        root=logging.getLogger(),
+        level=os.environ.get("LOG_LEVEL", "INFO").upper(),
+    )
+    return provider
+
+
+# Backward-compat alias: the existing main.py calls `setup()` once.
+# Keep that working with the basic-stdout phase; callers that want
+# OTLP must additionally call attach_posthog_otlp(cfg).
+def setup() -> None:
+    setup_stdout()

--- a/millpond/main.py
+++ b/millpond/main.py
@@ -372,7 +372,7 @@ def _update_lag_metrics(kafka, tp_offsets):
 
 
 def main():
-    logging_config.setup()
+    logging_config.setup_stdout()
     try:
         __version__ = version("millpond")
     except PackageNotFoundError:
@@ -384,8 +384,14 @@ def main():
     http = None
     sink = None
     kafka = None
+    logger_provider = None
 
     cfg = config.load()
+    # OTLP/HTTP export to PostHog Logs. Returns None when
+    # cfg.posthog_project_token is unset (default for local dev). The
+    # provider is flushed on the shutdown path so in-flight batches
+    # make it out before the process exits.
+    logger_provider = logging_config.attach_posthog_otlp(cfg)
     metrics.init(f"{cfg.topic}-{cfg.table_label}", broker_source=cfg.broker_source)
 
     pending: list[pa.Table] = []
@@ -567,6 +573,13 @@ def main():
                 http.shutdown()
             except Exception:
                 log.exception("HTTP server shutdown failed")
+        if logger_provider is not None:
+            # Flush the OTLP batch processor so in-flight log records
+            # make it to PostHog Logs before the process exits.
+            try:
+                logger_provider.shutdown()
+            except Exception:
+                log.exception("OTLP logger provider shutdown failed")
         log.info("millpond shutdown complete")
 
     return 0

--- a/millpond/main.py
+++ b/millpond/main.py
@@ -387,12 +387,16 @@ def main():
     logger_provider = None
 
     cfg = config.load()
+    # metrics.init() FIRST so a failure in OTLP setup (DNS lookup at
+    # OTLPLogExporter construction, malformed token, etc.) doesn't take
+    # out the /metrics endpoint — operators still get the writer's
+    # Prometheus axis to triage the failure.
+    metrics.init(f"{cfg.topic}-{cfg.table_label}", broker_source=cfg.broker_source)
     # OTLP/HTTP export to PostHog Logs. Returns None when
     # cfg.posthog_project_token is unset (default for local dev). The
     # provider is flushed on the shutdown path so in-flight batches
     # make it out before the process exits.
     logger_provider = logging_config.attach_posthog_otlp(cfg)
-    metrics.init(f"{cfg.topic}-{cfg.table_label}", broker_source=cfg.broker_source)
 
     pending: list[pa.Table] = []
     pending_bytes = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,10 @@ dependencies = [
     # at /i/v1/logs — no PostHog-specific Python package exists.
     "opentelemetry-sdk>=1.30",
     "opentelemetry-exporter-otlp-proto-http>=1.30",
+    # 1.42 deprecated opentelemetry.sdk._logs.LoggingHandler in favor of the
+    # one shipped from opentelemetry-instrumentation-logging. Same API,
+    # same wire behavior, just no DeprecationWarning at construction.
+    "opentelemetry-instrumentation-logging>=0.50b0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,13 @@ dependencies = [
     # 1.42 deprecated opentelemetry.sdk._logs.LoggingHandler in favor of the
     # one shipped from opentelemetry-instrumentation-logging. Same API,
     # same wire behavior, just no DeprecationWarning at construction.
-    "opentelemetry-instrumentation-logging>=0.50b0",
+    # Ceiling is to bound surprise — the instrumentation contrib packages
+    # have moved module paths across minor revs before (the handler lives
+    # at opentelemetry.instrumentation.logging.handler today; that's NOT
+    # the package's documented public surface — public is
+    # LoggingInstrumentor — so a future rev could move it without a
+    # deprecation cycle. Bump deliberately.
+    "opentelemetry-instrumentation-logging>=0.50b0,<0.64",
 ]
 
 [project.optional-dependencies]

--- a/shared/structured_logging.py
+++ b/shared/structured_logging.py
@@ -128,6 +128,9 @@ def build_otel_logger_provider(
     posthog_token: str,
     posthog_endpoint: str,
     resource_attrs: dict[str, str],
+    batch_schedule_delay_millis: int = 5000,
+    batch_max_export_size: int = 512,
+    batch_max_queue_size: int = 4096,
 ) -> Any:
     """Build a LoggerProvider with the OTLP/HTTP exporter to PostHog Logs.
 
@@ -135,6 +138,18 @@ def build_otel_logger_provider(
     merges in ``OTEL_RESOURCE_ATTRIBUTES`` from env (the standard SDK
     behavior, which the chart relies on for ``deployment.environment``
     / ``k8s.*`` / ``host.hostname``).
+
+    Batch knobs are pinned to explicit values rather than letting the
+    SDK pick. At 32 writer + 6+ icebox pods exporting at the SDK
+    defaults (``schedule_delay_millis=1000``, ``max_export_batch_size=512``,
+    ``max_queue_size=2048``), the aggregate is ~38 batched exports/sec
+    to a single PostHog Logs endpoint from one deployment family. Our
+    defaults are tuned for PostHog Logs ingest: 5s schedule delay (≈ a
+    fifth of SDK chatter), the standard 512-record batch, and a 2× queue
+    so a stalled exporter doesn't drop logs during transient PostHog
+    ingress backpressure. Operators can override per-service via the
+    Config fields ``posthog_logs_schedule_delay_ms`` /
+    ``posthog_logs_max_batch_size`` / ``posthog_logs_max_queue_size``.
 
     Caller owns the returned provider — register
     ``provider.shutdown()`` on the SIGTERM drain path so the
@@ -158,7 +173,10 @@ def build_otel_logger_provider(
             OTLPLogExporter(
                 endpoint=posthog_endpoint,
                 headers={"Authorization": f"Bearer {posthog_token}"},
-            )
+            ),
+            schedule_delay_millis=batch_schedule_delay_millis,
+            max_export_batch_size=batch_max_export_size,
+            max_queue_size=batch_max_queue_size,
         )
     )
     return provider

--- a/shared/structured_logging.py
+++ b/shared/structured_logging.py
@@ -1,0 +1,195 @@
+"""Shared structured-logging building blocks for millpond + icebox.
+
+Both services emit JSON logs to stdout and (optionally) export OTLP/HTTP
+log records to PostHog Logs. This module provides the service-agnostic
+pieces:
+
+  - ``JsonFormatter`` — base JSON formatter. Subclasses override
+    ``extra_context()`` to inject per-record fields from ContextVars
+    or similar (the icebox subclass reads ``cycle_id_var``).
+  - ``text_formatter`` — plain-text formatter for local dev.
+  - ``install_root_handlers`` — clear + reattach the root logger.
+  - ``build_otel_logger_provider`` — construct a LoggerProvider with
+    the OTLP/HTTP exporter bound to PostHog Logs.
+  - ``attach_otel_handler`` — wire the OTel handler onto the root
+    logger, optionally with extra filters (e.g. ContextVar-stamping).
+  - ``silence_logger`` — pin a noisy logger at a given level.
+
+Service-specific concerns (icebox ``cycle_id``, millpond pod-ordinal
+prefix, per-service resource-attr taxonomy) stay in
+``icebox/structured_logging.py`` and ``millpond/logging_config.py``;
+they compose these blocks rather than reinventing them.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import UTC, datetime
+from typing import Any
+
+
+# Standard ``LogRecord`` attrs we do NOT want to inline as JSON keys
+# (they're already in the top-level shape or are noise).
+_STANDARD_LOGRECORD_ATTRS = frozenset({
+    "name", "msg", "args", "levelname", "levelno", "pathname", "filename",
+    "module", "exc_info", "exc_text", "stack_info", "lineno", "funcName",
+    "created", "msecs", "relativeCreated", "thread", "threadName",
+    "processName", "process", "message", "taskName",
+})
+
+
+class JsonFormatter(logging.Formatter):
+    """Base JSON log formatter.
+
+    Output shape (one line per record):
+        {"ts": "...", "level": "INFO", "logger": "...", "msg": "...",
+         "<extra_key>": <extra_value>, ..., "exc": "<traceback>"}
+
+    Extras passed to ``log.info("...", extra={"foo": 1})`` are inlined
+    at the top level. Values that aren't JSON-serializable are coerced
+    via ``repr``.
+
+    Subclasses can override ``extra_context()`` to add fields pulled
+    from ContextVars or other per-call-site sources (e.g. the icebox's
+    ``cycle_id``).
+    """
+
+    def extra_context(self) -> dict[str, Any]:  # pragma: no cover - trivial default
+        return {}
+
+    def format(self, record: logging.LogRecord) -> str:
+        out: dict[str, Any] = {
+            "ts": datetime.fromtimestamp(record.created, UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+        for key, value in self.extra_context().items():
+            if value is not None:
+                out[key] = value
+        for key, value in record.__dict__.items():
+            if key in _STANDARD_LOGRECORD_ATTRS or key.startswith("_"):
+                continue
+            try:
+                json.dumps(value)
+                out[key] = value
+            except (TypeError, ValueError):
+                out[key] = repr(value)
+        if record.exc_info:
+            out["exc"] = self.formatException(record.exc_info)
+        return json.dumps(out, default=str)
+
+
+def text_formatter() -> logging.Formatter:
+    """Plain-text formatter for local-dev readability."""
+    return logging.Formatter("%(asctime)s %(levelname)s [%(name)s] %(message)s")
+
+
+def install_root_handlers(
+    *,
+    level: str,
+    formatter: logging.Formatter,
+    root: logging.Logger | None = None,
+) -> logging.Logger:
+    """Reset the root logger and attach a single stdout handler.
+
+    Idempotent: clears existing handlers so tests, re-imports, and
+    process forks don't stack duplicate sinks. Returns the root
+    logger so callers can use it for additional handler attachment
+    (e.g. the OTel handler).
+    """
+    root = root or logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    root.setLevel(level)
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(formatter)
+    root.addHandler(stream_handler)
+    return root
+
+
+def silence_logger(name: str, level: int = logging.WARNING) -> None:
+    """Pin a noisy logger at a given level.
+
+    Pre-existing nuisance loggers we know about:
+      - ``uvicorn.access`` (icebox): probes + Prometheus scrape + every
+        POST emit one line each at INFO.
+      - ``confluent_kafka`` (millpond): librdkafka chatter at INFO.
+
+    Idempotent — safe to call if the logger hasn't been created yet
+    (Python lazy-creates loggers on first ``getLogger`` reference).
+    """
+    logging.getLogger(name).setLevel(level)
+
+
+def build_otel_logger_provider(
+    *,
+    posthog_token: str,
+    posthog_endpoint: str,
+    resource_attrs: dict[str, str],
+) -> Any:
+    """Build a LoggerProvider with the OTLP/HTTP exporter to PostHog Logs.
+
+    Resource attrs are passed verbatim; ``Resource.create`` additionally
+    merges in ``OTEL_RESOURCE_ATTRIBUTES`` from env (the standard SDK
+    behavior, which the chart relies on for ``deployment.environment``
+    / ``k8s.*`` / ``host.hostname``).
+
+    Caller owns the returned provider — register
+    ``provider.shutdown()`` on the SIGTERM drain path so the
+    BatchLogRecordProcessor flushes in-flight batches.
+
+    Lazy imports: bringing OTel modules in only when the caller has
+    decided to export keeps the cold-start cost off the path for tests
+    / dev that haven't set the token.
+    """
+    from opentelemetry._logs import set_logger_provider
+    from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+    from opentelemetry.sdk._logs import LoggerProvider
+    from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+    from opentelemetry.sdk.resources import Resource
+
+    resource = Resource.create(resource_attrs)
+    provider = LoggerProvider(resource=resource)
+    set_logger_provider(provider)
+    provider.add_log_record_processor(
+        BatchLogRecordProcessor(
+            OTLPLogExporter(
+                endpoint=posthog_endpoint,
+                headers={"Authorization": f"Bearer {posthog_token}"},
+            )
+        )
+    )
+    return provider
+
+
+def attach_otel_handler(
+    *,
+    provider: Any,
+    root: logging.Logger,
+    level: str,
+    extra_filters: list[logging.Filter] | None = None,
+) -> Any:
+    """Attach the OTel logging handler to the root logger.
+
+    ``extra_filters`` (optional) run on the OTel side only, so
+    services can stamp per-record attrs (e.g. icebox's
+    ``icebox.cycle_id``) without touching the stdout shape.
+
+    The handler comes from ``opentelemetry-instrumentation-logging``;
+    the older ``opentelemetry.sdk._logs.LoggingHandler`` was deprecated
+    in SDK 1.42. ``log_code_attributes=False`` is deliberate — the
+    code.{file,function,line} attrs are pure noise in PostHog Logs.
+    """
+    from opentelemetry.instrumentation.logging.handler import LoggingHandler
+
+    otel_handler = LoggingHandler(
+        level=level,
+        logger_provider=provider,
+        log_code_attributes=False,
+    )
+    for flt in extra_filters or ():
+        otel_handler.addFilter(flt)
+    root.addHandler(otel_handler)
+    return otel_handler

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -58,6 +58,22 @@ class TestLoad:
         assert cfg.fetch_max_wait_ms == 500
         assert cfg.consume_batch_size == 1000
         assert cfg.stats_interval_ms == 5000
+        # PostHog Logs export: off by default.
+        assert cfg.posthog_project_token is None
+        assert cfg.posthog_logs_endpoint == "https://us.i.posthog.com/i/v1/logs"
+        assert cfg.service_namespace == "millpond"
+        assert cfg.service_instance_id is None
+
+    def test_posthog_otlp_env_overrides(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_PROJECT_TOKEN", "phc_test")
+        monkeypatch.setenv("POSTHOG_LOGS_ENDPOINT", "https://eu.i.posthog.com/i/v1/logs")
+        monkeypatch.setenv("MILLPOND_SERVICE_NAMESPACE", "my-ns")
+        monkeypatch.setenv("MILLPOND_SERVICE_INSTANCE_ID", "events")
+        cfg = load()
+        assert cfg.posthog_project_token == "phc_test"
+        assert cfg.posthog_logs_endpoint == "https://eu.i.posthog.com/i/v1/logs"
+        assert cfg.service_namespace == "my-ns"
+        assert cfg.service_instance_id == "events"
 
     def test_ordinal_exceeds_replica_count(self, monkeypatch):
         monkeypatch.setenv("POD_NAME", "millpond-events-5")

--- a/tests/unit/test_icebox_committer.py
+++ b/tests/unit/test_icebox_committer.py
@@ -235,7 +235,7 @@ def _deps(
     deps = cm.CommitterDeps(
         load_table=lambda: table,
         commit_data_files=MagicMock(
-            return_value=iceberg_snapshot_id,
+            return_value=(iceberg_snapshot_id, None),
             side_effect=iceberg_commit_raises,
         ),
         find_snapshot_for_cycle=MagicMock(return_value=snapshot_log_lookup_result),
@@ -261,6 +261,58 @@ def test_run_cycle_happy_path():
     assert result.kafka_offsets_committed  # non-empty
     deps.commit_data_files.assert_called_once()
     deps.kafka_commit_offsets.assert_called_once()
+
+
+def test_run_cycle_sets_iceberg_table_gauges_from_snapshot_summary():
+    """When commit_data_files returns a summary with the spec keys,
+    the committer must surface them on the icebox.* table-state
+    Gauges. Operators want a zero-thread, zero-Lakekeeper-poll signal
+    of table growth + compaction state."""
+    from icebox.metrics import (
+        ICEBERG_TABLE_DATA_FILES,
+        ICEBERG_TABLE_FILES_SIZE_BYTES,
+        ICEBERG_TABLE_RECORDS,
+    )
+
+    deps, pool = _deps(iceberg_snapshot_id=12345)
+    # commit_data_files now returns (snapshot_id, summary). Override the
+    # _deps default so the test injects realistic Iceberg-spec values.
+    deps.commit_data_files = MagicMock(
+        return_value=(
+            12345,
+            {
+                "total-data-files": "42",
+                "total-records": "1000000",
+                "total-files-size": "987654321",
+                "operation": "append",
+            },
+        )
+    )
+
+    result = cm.run_cycle(cfg=_cfg(), pg_pool=pool, deps=deps)
+    assert result.success is True
+    assert ICEBERG_TABLE_DATA_FILES._value.get() == 42.0
+    assert ICEBERG_TABLE_RECORDS._value.get() == 1000000.0
+    assert ICEBERG_TABLE_FILES_SIZE_BYTES._value.get() == 987654321.0
+
+
+def test_run_cycle_handles_none_summary_without_touching_gauges():
+    """If commit_data_files returns summary=None (PyIceberg API drift
+    safety net), the committer must not raise and the gauges keep
+    their previous value (which is still the truth — table state
+    hasn't changed)."""
+    from icebox.metrics import ICEBERG_TABLE_DATA_FILES
+
+    # Pre-set the gauge so we can detect any clobber to 0.
+    ICEBERG_TABLE_DATA_FILES.set(999)
+
+    deps, pool = _deps(iceberg_snapshot_id=12345)
+    deps.commit_data_files = MagicMock(return_value=(12345, None))
+
+    result = cm.run_cycle(cfg=_cfg(), pg_pool=pool, deps=deps)
+    assert result.success is True
+    # Gauge unchanged — last successful value preserved.
+    assert ICEBERG_TABLE_DATA_FILES._value.get() == 999.0
 
 
 def test_run_cycle_no_files_marks_vacuous_success():
@@ -851,7 +903,7 @@ def test_recover_in_flight_cycles_loads_table_fresh_per_cycle():
 
     deps = cm.CommitterDeps(
         load_table=counting_load,
-        commit_data_files=MagicMock(return_value=999),
+        commit_data_files=MagicMock(return_value=(999, None)),
         find_snapshot_for_cycle=MagicMock(return_value=None),
         build_data_file=MagicMock(return_value=MagicMock()),
         kafka_admin=MagicMock(),
@@ -1155,7 +1207,7 @@ def test_recover_in_flight_cycles_logs_error_on_limit_hit(caplog):
     # to assert here.
     deps = cm.CommitterDeps(
         load_table=lambda: MagicMock(),
-        commit_data_files=MagicMock(return_value=1),
+        commit_data_files=MagicMock(return_value=(1, None)),
         find_snapshot_for_cycle=MagicMock(return_value=1),
         build_data_file=MagicMock(return_value=MagicMock()),
         kafka_admin=MagicMock(),

--- a/tests/unit/test_icebox_committer.py
+++ b/tests/unit/test_icebox_committer.py
@@ -13,13 +13,14 @@ from __future__ import annotations
 import inspect
 from contextlib import contextmanager
 from datetime import UTC, datetime
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
 from pyiceberg.schema import Schema
 from pyiceberg.types import IntegerType, NestedField, StringType
 
 from icebox import committer as cm
+from icebox import iceberg as ib
 from icebox.config import Config
 from icebox.schema import CommitCycleRow
 from shared.fingerprint import schema_fingerprint
@@ -235,7 +236,9 @@ def _deps(
     deps = cm.CommitterDeps(
         load_table=lambda: table,
         commit_data_files=MagicMock(
-            return_value=(iceberg_snapshot_id, None),
+            return_value=ib.CommitResult(
+                snapshot_id=iceberg_snapshot_id, summary=None
+            ),
             side_effect=iceberg_commit_raises,
         ),
         find_snapshot_for_cycle=MagicMock(return_value=snapshot_log_lookup_result),
@@ -263,37 +266,69 @@ def test_run_cycle_happy_path():
     deps.kafka_commit_offsets.assert_called_once()
 
 
+def _gauge_value(metric_name: str) -> float | None:
+    """Read a Gauge via the public REGISTRY idiom (matches the
+    pattern in test_icebox_schema_cache.py:_miss_count). Avoids
+    poking at the private ``._value.get()`` accessor that prior
+    review told us to stop using."""
+    from prometheus_client import REGISTRY
+
+    return REGISTRY.get_sample_value(metric_name)
+
+
 def test_run_cycle_sets_iceberg_table_gauges_from_snapshot_summary():
     """When commit_data_files returns a summary with the spec keys,
     the committer must surface them on the icebox.* table-state
-    Gauges. Operators want a zero-thread, zero-Lakekeeper-poll signal
-    of table growth + compaction state."""
+    Gauges — both cumulative AND per-cycle deltas. Operators want a
+    zero-thread, zero-Lakekeeper-poll signal of table growth +
+    compaction state."""
+    from icebox import iceberg as ib
     from icebox.metrics import (
+        ICEBERG_TABLE_ADDED_DATA_FILES,
+        ICEBERG_TABLE_ADDED_FILES_SIZE_BYTES,
+        ICEBERG_TABLE_ADDED_RECORDS,
         ICEBERG_TABLE_DATA_FILES,
         ICEBERG_TABLE_FILES_SIZE_BYTES,
         ICEBERG_TABLE_RECORDS,
     )
 
+    # Clear before the test so we can assert exact post-cycle values.
+    for gauge in (
+        ICEBERG_TABLE_DATA_FILES,
+        ICEBERG_TABLE_RECORDS,
+        ICEBERG_TABLE_FILES_SIZE_BYTES,
+        ICEBERG_TABLE_ADDED_DATA_FILES,
+        ICEBERG_TABLE_ADDED_RECORDS,
+        ICEBERG_TABLE_ADDED_FILES_SIZE_BYTES,
+    ):
+        gauge.set(0)
+
     deps, pool = _deps(iceberg_snapshot_id=12345)
-    # commit_data_files now returns (snapshot_id, summary). Override the
-    # _deps default so the test injects realistic Iceberg-spec values.
     deps.commit_data_files = MagicMock(
-        return_value=(
-            12345,
-            {
+        return_value=ib.CommitResult(
+            snapshot_id=12345,
+            summary={
                 "total-data-files": "42",
                 "total-records": "1000000",
                 "total-files-size": "987654321",
-                "operation": "append",
+                "added-data-files": "3",
+                "added-records": "27000",
+                "added-files-size": "12345678",
+                "posthog.icebox.operation": "append",
             },
         )
     )
 
     result = cm.run_cycle(cfg=_cfg(), pg_pool=pool, deps=deps)
     assert result.success is True
-    assert ICEBERG_TABLE_DATA_FILES._value.get() == 42.0
-    assert ICEBERG_TABLE_RECORDS._value.get() == 1000000.0
-    assert ICEBERG_TABLE_FILES_SIZE_BYTES._value.get() == 987654321.0
+    # Cumulative
+    assert _gauge_value("icebox_iceberg_table_data_files") == 42.0
+    assert _gauge_value("icebox_iceberg_table_records") == 1000000.0
+    assert _gauge_value("icebox_iceberg_table_files_size_bytes") == 987654321.0
+    # Per-cycle deltas
+    assert _gauge_value("icebox_iceberg_table_added_data_files") == 3.0
+    assert _gauge_value("icebox_iceberg_table_added_records") == 27000.0
+    assert _gauge_value("icebox_iceberg_table_added_files_size_bytes") == 12345678.0
 
 
 def test_run_cycle_handles_none_summary_without_touching_gauges():
@@ -301,18 +336,51 @@ def test_run_cycle_handles_none_summary_without_touching_gauges():
     safety net), the committer must not raise and the gauges keep
     their previous value (which is still the truth — table state
     hasn't changed)."""
+    from icebox import iceberg as ib
     from icebox.metrics import ICEBERG_TABLE_DATA_FILES
 
     # Pre-set the gauge so we can detect any clobber to 0.
     ICEBERG_TABLE_DATA_FILES.set(999)
 
     deps, pool = _deps(iceberg_snapshot_id=12345)
-    deps.commit_data_files = MagicMock(return_value=(12345, None))
+    deps.commit_data_files = MagicMock(
+        return_value=ib.CommitResult(snapshot_id=12345, summary=None)
+    )
 
     result = cm.run_cycle(cfg=_cfg(), pg_pool=pool, deps=deps)
     assert result.success is True
     # Gauge unchanged — last successful value preserved.
-    assert ICEBERG_TABLE_DATA_FILES._value.get() == 999.0
+    assert _gauge_value("icebox_iceberg_table_data_files") == 999.0
+
+
+def test_run_cycle_gauge_update_failure_does_not_poison_commit():
+    """QE MAJOR: a raise during the gauge-update path must NOT trip
+    the iceberg-commit's except branch. If it did, release_cycle_claim
+    would fire AFTER the snapshot landed — files re-batched in a
+    future cycle, double-commit. Force a gauge to raise during set()
+    and assert the cycle still completes successfully."""
+    from icebox import iceberg as ib
+    from icebox.metrics import ICEBERG_TABLE_DATA_FILES
+
+    deps, pool = _deps(iceberg_snapshot_id=12345)
+    deps.commit_data_files = MagicMock(
+        return_value=ib.CommitResult(
+            snapshot_id=12345,
+            summary={"total-data-files": "42"},
+        )
+    )
+
+    # Patch the gauge's .set to raise. The committer's narrow
+    # try/except around _update_table_state_gauges must catch this
+    # without releasing the cycle claim.
+    with patch.object(
+        ICEBERG_TABLE_DATA_FILES, "set", side_effect=RuntimeError("simulated")
+    ):
+        result = cm.run_cycle(cfg=_cfg(), pg_pool=pool, deps=deps)
+    assert result.success is True
+    assert result.iceberg_snapshot_id == 12345
+    # release_cycle_claim must NOT have fired — cycle proceeded normally.
+    deps.kafka_commit_offsets.assert_called_once()
 
 
 def test_run_cycle_no_files_marks_vacuous_success():
@@ -903,7 +971,9 @@ def test_recover_in_flight_cycles_loads_table_fresh_per_cycle():
 
     deps = cm.CommitterDeps(
         load_table=counting_load,
-        commit_data_files=MagicMock(return_value=(999, None)),
+        commit_data_files=MagicMock(
+            return_value=ib.CommitResult(snapshot_id=999, summary=None)
+        ),
         find_snapshot_for_cycle=MagicMock(return_value=None),
         build_data_file=MagicMock(return_value=MagicMock()),
         kafka_admin=MagicMock(),
@@ -1207,7 +1277,9 @@ def test_recover_in_flight_cycles_logs_error_on_limit_hit(caplog):
     # to assert here.
     deps = cm.CommitterDeps(
         load_table=lambda: MagicMock(),
-        commit_data_files=MagicMock(return_value=(1, None)),
+        commit_data_files=MagicMock(
+            return_value=ib.CommitResult(snapshot_id=1, summary=None)
+        ),
         find_snapshot_for_cycle=MagicMock(return_value=1),
         build_data_file=MagicMock(return_value=MagicMock()),
         kafka_admin=MagicMock(),

--- a/tests/unit/test_icebox_config.py
+++ b/tests/unit/test_icebox_config.py
@@ -61,6 +61,21 @@ def test_load_with_only_required_env(monkeypatch):
     assert cfg.asyncpg_pool_max == 8
     assert cfg.psycopg_pool_min == 1
     assert cfg.psycopg_pool_max == 2
+    assert cfg.service_namespace == "millpond"
+    assert cfg.service_instance_id is None
+
+
+def test_service_namespace_and_instance_id_overrides(monkeypatch):
+    _set_env(
+        monkeypatch,
+        {
+            "ICEBOX_SERVICE_NAMESPACE": "icebox-shadow",
+            "ICEBOX_SERVICE_INSTANCE_ID": "events-icebox",
+        },
+    )
+    cfg = icebox_config.load()
+    assert cfg.service_namespace == "icebox-shadow"
+    assert cfg.service_instance_id == "events-icebox"
 
 
 def test_load_missing_pg_host_raises(monkeypatch):

--- a/tests/unit/test_icebox_iceberg.py
+++ b/tests/unit/test_icebox_iceberg.py
@@ -283,9 +283,8 @@ def test_commit_data_files_uses_cycle_id_summary_key():
     tx._append_snapshot_producer.assert_called_once()
     call_kwargs = tx._append_snapshot_producer.call_args.kwargs
     assert call_kwargs["snapshot_properties"] == {CYCLE_ID_SUMMARY_KEY: str(cycle)}
-    snapshot_id, summary = result
-    assert snapshot_id == 12345
-    assert summary is None  # mock tx returns no snapshot lookup
+    assert result.snapshot_id == 12345
+    assert result.summary is None  # mock tx returns no snapshot lookup
 
 
 def test_commit_data_files_appends_each_file_to_producer():
@@ -308,8 +307,7 @@ def test_commit_data_files_reads_snapshot_id_from_producer_not_table():
     result = commit_data_files(
         table=table, data_files=[MagicMock(spec=DataFile)], cycle_id=uuid4(),
     )
-    snapshot_id, _ = result
-    assert snapshot_id == 999, (
+    assert result.snapshot_id == 999, (
         "commit_data_files must read snapshot_id from the producer, "
         "not from table.current_snapshot() which could be stale"
     )
@@ -358,15 +356,48 @@ def test_commit_data_files_extracts_summary_when_present():
     fake_snapshot.summary.operation = Operation.APPEND
 
     table, _, _ = _wire_producer_mock(snapshot_id=777, summary=fake_snapshot)
-    snapshot_id, summary = commit_data_files(
+    result = commit_data_files(
         table=table, data_files=[MagicMock(spec=DataFile)], cycle_id=uuid4()
     )
-    assert snapshot_id == 777
-    assert summary is not None
-    assert summary["total-data-files"] == "42"
-    assert summary["total-records"] == "1000000"
-    assert summary["total-files-size"] == "987654321"
-    assert summary["operation"] == "append"  # Operation enum's value
+    assert result.snapshot_id == 777
+    assert result.summary is not None
+    assert result.summary["total-data-files"] == "42"
+    assert result.summary["total-records"] == "1000000"
+    assert result.summary["total-files-size"] == "987654321"
+    # Operation key is namespaced to avoid collision with any future
+    # producer-attached `operation` summary property.
+    assert result.summary["posthog.icebox.operation"] == "append"
+
+
+def test_commit_data_files_preserves_partial_summary_when_operation_fails():
+    """Operation extraction failure must NOT discard the
+    additional_properties we already pulled. Partial summary beats
+    None — the cumulative + delta gauges still get values, only the
+    operation label is missing."""
+    # Build a hand-rolled summary object: real attribute access for
+    # additional_properties, raise on .operation. MagicMock's auto-attr
+    # short-circuits PropertyMock here, so use a plain class.
+    class _PartialSummary:
+        additional_properties = {
+            "total-data-files": "100",
+            "added-records": "500",
+        }
+
+        @property
+        def operation(self):
+            raise AttributeError("simulated PyIceberg API drift")
+
+    fake_snapshot = MagicMock()
+    fake_snapshot.summary = _PartialSummary()
+    table, _, _ = _wire_producer_mock(snapshot_id=42, summary=fake_snapshot)
+    result = commit_data_files(
+        table=table, data_files=[MagicMock(spec=DataFile)], cycle_id=uuid4()
+    )
+    assert result.snapshot_id == 42
+    assert result.summary is not None
+    assert result.summary["total-data-files"] == "100"
+    assert result.summary["added-records"] == "500"
+    assert "posthog.icebox.operation" not in result.summary
 
 
 def test_commit_data_files_returns_none_summary_when_lookup_fails():
@@ -384,11 +415,11 @@ def test_commit_data_files_returns_none_summary_when_lookup_fails():
     fake_snapshot = MagicMock()
     fake_snapshot.summary = _BoomSummary()
     table, _, _ = _wire_producer_mock(snapshot_id=555, summary=fake_snapshot)
-    snapshot_id, summary = commit_data_files(
+    result = commit_data_files(
         table=table, data_files=[MagicMock(spec=DataFile)], cycle_id=uuid4()
     )
-    assert snapshot_id == 555
-    assert summary is None
+    assert result.snapshot_id == 555
+    assert result.summary is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_icebox_iceberg.py
+++ b/tests/unit/test_icebox_iceberg.py
@@ -244,13 +244,19 @@ def test_build_data_file_respects_format_version_v1():
 # ---------------------------------------------------------------------------
 
 
-def _wire_producer_mock(snapshot_id: int | None = 12345):
+def _wire_producer_mock(snapshot_id: int | None = 12345, summary: object | None = None):
     """Build (table, tx, producer) mocks with context managers wired.
 
     The producer carries snapshot_id directly — commit_data_files reads
     it from the producer, NOT from table.current_snapshot(). Pass None
-    to simulate a PyIceberg-version mismatch where the producer's
-    snapshot_id is missing."""
+    for snapshot_id to simulate a PyIceberg-version mismatch where the
+    producer's snapshot_id is missing.
+
+    ``summary``: pass a mock Snapshot (with .summary.additional_properties
+    + .summary.operation) to exercise the post-commit summary-extraction
+    path. Default None means tx.table_metadata.snapshot_by_id returns
+    None — extraction silently skipped, summary returned as None.
+    """
     table = MagicMock()
     tx = MagicMock()
     producer = MagicMock()
@@ -259,6 +265,7 @@ def _wire_producer_mock(snapshot_id: int | None = 12345):
     table.transaction.return_value.__exit__ = lambda self, *a: None
     tx._append_snapshot_producer.return_value.__enter__ = lambda self: producer
     tx._append_snapshot_producer.return_value.__exit__ = lambda self, *a: None
+    tx.table_metadata.snapshot_by_id.return_value = summary
     return table, tx, producer
 
 
@@ -276,7 +283,9 @@ def test_commit_data_files_uses_cycle_id_summary_key():
     tx._append_snapshot_producer.assert_called_once()
     call_kwargs = tx._append_snapshot_producer.call_args.kwargs
     assert call_kwargs["snapshot_properties"] == {CYCLE_ID_SUMMARY_KEY: str(cycle)}
-    assert result == 12345
+    snapshot_id, summary = result
+    assert snapshot_id == 12345
+    assert summary is None  # mock tx returns no snapshot lookup
 
 
 def test_commit_data_files_appends_each_file_to_producer():
@@ -299,7 +308,8 @@ def test_commit_data_files_reads_snapshot_id_from_producer_not_table():
     result = commit_data_files(
         table=table, data_files=[MagicMock(spec=DataFile)], cycle_id=uuid4(),
     )
-    assert result == 999, (
+    snapshot_id, _ = result
+    assert snapshot_id == 999, (
         "commit_data_files must read snapshot_id from the producer, "
         "not from table.current_snapshot() which could be stale"
     )
@@ -328,6 +338,57 @@ def test_commit_data_files_respects_branch_arg():
         branch="staging",
     )
     assert tx._append_snapshot_producer.call_args.kwargs["branch"] == "staging"
+
+
+def test_commit_data_files_extracts_summary_when_present():
+    """The post-commit summary lookup must surface the spec keys we
+    chart (total-data-files etc.) into the returned dict so the
+    committer can update the gauges with no extra round-trip."""
+    # Build a fake Snapshot whose .summary.additional_properties carries
+    # the spec keys + a real operation enum.
+    from pyiceberg.table.snapshots import Operation
+
+    fake_snapshot = MagicMock()
+    fake_snapshot.summary.additional_properties = {
+        "total-data-files": "42",
+        "total-records": "1000000",
+        "total-files-size": "987654321",
+        "added-data-files": "3",
+    }
+    fake_snapshot.summary.operation = Operation.APPEND
+
+    table, _, _ = _wire_producer_mock(snapshot_id=777, summary=fake_snapshot)
+    snapshot_id, summary = commit_data_files(
+        table=table, data_files=[MagicMock(spec=DataFile)], cycle_id=uuid4()
+    )
+    assert snapshot_id == 777
+    assert summary is not None
+    assert summary["total-data-files"] == "42"
+    assert summary["total-records"] == "1000000"
+    assert summary["total-files-size"] == "987654321"
+    assert summary["operation"] == "append"  # Operation enum's value
+
+
+def test_commit_data_files_returns_none_summary_when_lookup_fails():
+    """A future PyIceberg API shift in the in-tx metadata view must
+    NOT kill the commit. The snapshot_id load-bearing return still
+    flows; summary is None and the committer's gauges hold their last
+    value for that cycle."""
+
+    # Wire a snapshot mock whose .summary raises on attribute access
+    class _BoomSummary:
+        @property
+        def additional_properties(self):
+            raise RuntimeError("simulated PyIceberg API drift")
+
+    fake_snapshot = MagicMock()
+    fake_snapshot.summary = _BoomSummary()
+    table, _, _ = _wire_producer_mock(snapshot_id=555, summary=fake_snapshot)
+    snapshot_id, summary = commit_data_files(
+        table=table, data_files=[MagicMock(spec=DataFile)], cycle_id=uuid4()
+    )
+    assert snapshot_id == 555
+    assert summary is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_icebox_schema_cache.py
+++ b/tests/unit/test_icebox_schema_cache.py
@@ -107,6 +107,38 @@ def test_validate_returns_false_when_mismatch_persists_after_refresh(fp_stub):
     assert loader.call_count == 2
 
 
+def test_validate_mismatch_increments_cache_miss_counter(fp_stub):
+    """The per-mismatch metric replaces the previous per-event INFO log.
+    At steady state operators read the counter rate, not the body of
+    every miss."""
+    from icebox.metrics import SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL
+
+    loader = MagicMock(
+        side_effect=[
+            _table_with_schema("fp-A"),  # initial populate
+            _table_with_schema("fp-B"),  # forced refresh after mismatch
+        ]
+    )
+    cache = SchemaFingerprintCache(load_table=loader, ttl_seconds=60.0)
+    before = SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL._value.get()
+    asyncio.run(cache.validate("fp-B"))
+    after = SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL._value.get()
+    assert after == before + 1
+
+
+def test_validate_cached_match_does_not_increment_cache_miss_counter(fp_stub):
+    """Sanity check the inverse — a cache hit must NOT touch the miss
+    counter."""
+    from icebox.metrics import SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL
+
+    loader = MagicMock(return_value=_table_with_schema("fp-X"))
+    cache = SchemaFingerprintCache(load_table=loader, ttl_seconds=60.0)
+    before = SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL._value.get()
+    asyncio.run(cache.validate("fp-X"))
+    after = SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL._value.get()
+    assert after == before
+
+
 def test_current_propagates_loader_exception(fp_stub):
     loader = MagicMock(side_effect=RuntimeError("catalog unreachable"))
     cache = SchemaFingerprintCache(load_table=loader, ttl_seconds=60.0)

--- a/tests/unit/test_icebox_schema_cache.py
+++ b/tests/unit/test_icebox_schema_cache.py
@@ -107,12 +107,22 @@ def test_validate_returns_false_when_mismatch_persists_after_refresh(fp_stub):
     assert loader.call_count == 2
 
 
-def test_validate_mismatch_increments_cache_miss_counter(fp_stub):
-    """The per-mismatch metric replaces the previous per-event INFO log.
-    At steady state operators read the counter rate, not the body of
-    every miss."""
-    from icebox.metrics import SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL
+def _miss_count(reason: str) -> float:
+    """Read the labeled cache-miss counter via the public registry idiom.
+    Returns 0.0 when the label hasn't been seen yet (sample absent)."""
+    from prometheus_client import REGISTRY
 
+    value = REGISTRY.get_sample_value(
+        "icebox_schema_fingerprint_cache_misses_total",
+        labels={"reason": reason},
+    )
+    return value or 0.0
+
+
+def test_validate_mismatch_with_stale_cache_reports_cache_stale_after_alter(fp_stub):
+    """Cache held fp-A but the catalog (post-ALTER) actually serves
+    fp-B; writer claims fp-B. Reason: cache_stale_after_alter — the
+    cache was just behind reality. Normal; not alertable."""
     loader = MagicMock(
         side_effect=[
             _table_with_schema("fp-A"),  # initial populate
@@ -120,23 +130,41 @@ def test_validate_mismatch_increments_cache_miss_counter(fp_stub):
         ]
     )
     cache = SchemaFingerprintCache(load_table=loader, ttl_seconds=60.0)
-    before = SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL._value.get()
+    before_stale = _miss_count("cache_stale_after_alter")
+    before_mismatch = _miss_count("fingerprint_mismatch")
     asyncio.run(cache.validate("fp-B"))
-    after = SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL._value.get()
-    assert after == before + 1
+    assert _miss_count("cache_stale_after_alter") == before_stale + 1
+    assert _miss_count("fingerprint_mismatch") == before_mismatch
+
+
+def test_validate_mismatch_with_unknown_fingerprint_reports_fingerprint_mismatch(fp_stub):
+    """Cache held fp-A; refresh still returns fp-A; writer claims fp-Z
+    — the catalog doesn't know fp-Z. Reason: fingerprint_mismatch.
+    Alertable."""
+    loader = MagicMock(
+        side_effect=[
+            _table_with_schema("fp-A"),
+            _table_with_schema("fp-A"),  # refresh still shows A
+        ]
+    )
+    cache = SchemaFingerprintCache(load_table=loader, ttl_seconds=60.0)
+    before_stale = _miss_count("cache_stale_after_alter")
+    before_mismatch = _miss_count("fingerprint_mismatch")
+    asyncio.run(cache.validate("fp-Z"))
+    assert _miss_count("cache_stale_after_alter") == before_stale
+    assert _miss_count("fingerprint_mismatch") == before_mismatch + 1
 
 
 def test_validate_cached_match_does_not_increment_cache_miss_counter(fp_stub):
-    """Sanity check the inverse — a cache hit must NOT touch the miss
-    counter."""
-    from icebox.metrics import SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL
-
+    """Sanity check the inverse — a cache hit must NOT touch either
+    miss-counter label."""
     loader = MagicMock(return_value=_table_with_schema("fp-X"))
     cache = SchemaFingerprintCache(load_table=loader, ttl_seconds=60.0)
-    before = SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL._value.get()
+    before_stale = _miss_count("cache_stale_after_alter")
+    before_mismatch = _miss_count("fingerprint_mismatch")
     asyncio.run(cache.validate("fp-X"))
-    after = SCHEMA_FINGERPRINT_CACHE_MISSES_TOTAL._value.get()
-    assert after == before
+    assert _miss_count("cache_stale_after_alter") == before_stale
+    assert _miss_count("fingerprint_mismatch") == before_mismatch
 
 
 def test_current_propagates_loader_exception(fp_stub):

--- a/tests/unit/test_icebox_structured_logging.py
+++ b/tests/unit/test_icebox_structured_logging.py
@@ -134,6 +134,14 @@ def test_setup_logging_text_mode_installs_plain_formatter():
     assert not isinstance(root.handlers[0].formatter, JsonFormatter)
 
 
+def test_setup_logging_silences_uvicorn_access_logger():
+    """uvicorn.access ships one line per probe + per writer POST and
+    swamps the useful committer logs. setup_logging() must pin it at
+    WARNING so probes/scrapes/POSTs don't reach stdout or OTLP."""
+    setup_logging(level="DEBUG", fmt="json")
+    assert logging.getLogger("uvicorn.access").level == logging.WARNING
+
+
 def test_setup_logging_clears_prior_handlers_on_repeat_call():
     # Re-running should not stack handlers (matters for tests +
     # process forks / reloaders).

--- a/tests/unit/test_icebox_structured_logging.py
+++ b/tests/unit/test_icebox_structured_logging.py
@@ -136,10 +136,27 @@ def test_setup_logging_text_mode_installs_plain_formatter():
 
 def test_setup_logging_silences_uvicorn_access_logger():
     """uvicorn.access ships one line per probe + per writer POST and
-    swamps the useful committer logs. setup_logging() must pin it at
-    WARNING so probes/scrapes/POSTs don't reach stdout or OTLP."""
+    swamps the useful committer logs. Effective behavior: an INFO
+    record on that logger after setup_logging() must NOT reach the
+    captured stream. Asserting on the logger.level value alone would
+    miss the case where uvicorn (or anything else) flips the level
+    back at server start."""
+    import io
+
     setup_logging(level="DEBUG", fmt="json")
-    assert logging.getLogger("uvicorn.access").level == logging.WARNING
+    # Add a capture sink to the same root handler chain
+    captured = io.StringIO()
+    root = logging.getLogger()
+    capture_handler = logging.StreamHandler(captured)
+    capture_handler.setLevel(logging.DEBUG)
+    root.addHandler(capture_handler)
+    try:
+        logging.getLogger("uvicorn.access").info(
+            'GET /healthz HTTP/1.1" 200'
+        )
+        assert "/healthz" not in captured.getvalue()
+    finally:
+        root.removeHandler(capture_handler)
 
 
 def test_setup_logging_clears_prior_handlers_on_repeat_call():
@@ -189,10 +206,11 @@ def test_setup_logging_with_posthog_token_returns_provider_and_adds_handler():
     setup_logging(level="INFO", fmt="json")
 
 
-def test_setup_logging_resource_attrs_include_icebox_custom_and_source_type():
-    """The OTLP resource should carry the icebox.* facets + source_type
-    so PostHog Logs can filter by (table, topic) and the existing
-    PostHog Vector-on-EC2 source_type filter carries over."""
+def test_setup_logging_resource_attrs_use_semconv_for_kafka_and_vendor_for_iceberg():
+    """OTLP resource attrs split: Kafka uses OTel messaging semconv
+    (interop with future tooling), Iceberg stays vendor-prefixed
+    (no semconv coverage). No `source_type` — service.name carries
+    the axis."""
     from unittest.mock import MagicMock
 
     with patch(
@@ -214,16 +232,49 @@ def test_setup_logging_resource_attrs_include_icebox_custom_and_source_type():
         attrs = dict(provider.resource.attributes)
         assert attrs["service.name"] == "icebox"
         assert attrs["service.namespace"] == "millpond"
-        assert attrs["source_type"] == "icebox"
         assert attrs["service.instance.id"] == "events-icebox"
+        # Kafka: messaging.* semconv
+        assert attrs["messaging.system"] == "kafka"
+        assert attrs["messaging.destination.name"] == "clickhouse_events_json"
+        assert (
+            attrs["messaging.kafka.consumer.group"]
+            == "millpond-icebox-clickhouse_events_json-events"
+        )
+        # Iceberg: vendor-prefixed (no semconv exists today)
         assert attrs["icebox.iceberg.warehouse"] == "ingest"
         assert attrs["icebox.iceberg.namespace"] == "kafka"
         assert attrs["icebox.iceberg.table"] == "events"
-        assert attrs["icebox.kafka.topic"] == "clickhouse_events_json"
-        assert (
-            attrs["icebox.kafka.group_id"]
-            == "millpond-icebox-clickhouse_events_json-events"
+        # Negative assertions: pre-rename names and dropped attrs
+        assert "icebox.kafka.topic" not in attrs
+        assert "icebox.kafka.group_id" not in attrs
+        assert "source_type" not in attrs
+    finally:
+        provider.shutdown()
+        setup_logging(level="INFO", fmt="json")
+
+
+def test_setup_logging_omits_messaging_system_when_no_kafka_attrs():
+    """messaging.system=kafka is only emitted when there are actual
+    Kafka attrs to qualify — don't lie about the system if we have
+    nothing to say about it."""
+    from unittest.mock import MagicMock
+
+    with patch(
+        "opentelemetry.exporter.otlp.proto.http._log_exporter.OTLPLogExporter",
+        return_value=MagicMock(),
+    ):
+        provider = setup_logging(
+            level="INFO",
+            fmt="json",
+            posthog_token="phc_test",
+            iceberg_warehouse="ingest",
+            iceberg_namespace="kafka",
+            iceberg_table="events",
         )
+    try:
+        attrs = dict(provider.resource.attributes)
+        assert "messaging.system" not in attrs
+        assert "messaging.destination.name" not in attrs
     finally:
         provider.shutdown()
         setup_logging(level="INFO", fmt="json")
@@ -249,7 +300,40 @@ def test_setup_logging_omits_none_optional_resource_attrs():
         assert "service.name" in attrs
         assert "service.instance.id" not in attrs
         assert "icebox.iceberg.warehouse" not in attrs
-        assert "icebox.kafka.topic" not in attrs
+        assert "messaging.destination.name" not in attrs
+    finally:
+        provider.shutdown()
+        setup_logging(level="INFO", fmt="json")
+
+
+def test_setup_logging_app_passed_attrs_win_over_otel_resource_attributes_env(monkeypatch):
+    """Lock the user-attrs-win contract for ``Resource.create``. Even
+    though we split by key ownership (app vs. chart) so the precedence
+    rule is never load-bearing in production, an accidental future
+    chart change that sets a key the app also sets would silently
+    swap winners if this contract reverses — pin it with a test."""
+    from unittest.mock import MagicMock
+
+    monkeypatch.setenv(
+        "OTEL_RESOURCE_ATTRIBUTES",
+        "service.namespace=env-wins,deployment.environment=prod",
+    )
+    with patch(
+        "opentelemetry.exporter.otlp.proto.http._log_exporter.OTLPLogExporter",
+        return_value=MagicMock(),
+    ):
+        provider = setup_logging(
+            level="INFO",
+            fmt="json",
+            posthog_token="phc_test",
+            service_namespace="app-wins",
+        )
+    try:
+        attrs = dict(provider.resource.attributes)
+        # Same-key conflict: app value wins (this is the contract).
+        assert attrs["service.namespace"] == "app-wins"
+        # Distinct key supplied only by env still flows through.
+        assert attrs["deployment.environment"] == "prod"
     finally:
         provider.shutdown()
         setup_logging(level="INFO", fmt="json")
@@ -282,6 +366,46 @@ def test_cycle_id_attr_filter_noop_when_contextvar_unset():
     record = _make_record(msg="no cycle context")
     flt.filter(record)
     assert "icebox.cycle_id" not in record.__dict__
+
+
+def test_cycle_id_survives_logging_makerecord_plumbing():
+    """Records produced via the public logging API path
+    (`logger.info(..., extra={...})` → `Logger.makeRecord` →
+    `LogRecord.__init__`) must carry the dotted attribute the filter
+    sets — not just hand-built `LogRecord` instances. Some
+    implementations of `LogRecord` go through `__dict__.update(extra)`
+    which can mishandle dotted keys; this test exercises the real
+    plumbing once so a regression there can't slip through."""
+    from icebox.structured_logging import _CycleIdAttrFilter
+
+    token = cycle_id_var.set("c-from-real-logger")
+    try:
+        flt = _CycleIdAttrFilter()
+        logger = logging.getLogger("test_cycle_id_real_logger")
+        logger.addFilter(flt)
+        # Add a capturing handler whose emit() inspects the record
+        # AFTER the filter runs — same lifecycle the OTel handler sees.
+        captured: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                captured.append(record)
+
+        cap = _Capture()
+        logger.addHandler(cap)
+        logger.setLevel(logging.INFO)
+        try:
+            logger.info("hello from a real logger", extra={"file_count": 7})
+            assert len(captured) == 1
+            rec = captured[0]
+            assert rec.__dict__["icebox.cycle_id"] == "c-from-real-logger"
+            # The non-dotted `extra` field came through normally too.
+            assert rec.__dict__["file_count"] == 7
+        finally:
+            logger.removeHandler(cap)
+            logger.removeFilter(flt)
+    finally:
+        cycle_id_var.reset(token)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_icebox_structured_logging.py
+++ b/tests/unit/test_icebox_structured_logging.py
@@ -181,6 +181,101 @@ def test_setup_logging_with_posthog_token_returns_provider_and_adds_handler():
     setup_logging(level="INFO", fmt="json")
 
 
+def test_setup_logging_resource_attrs_include_icebox_custom_and_source_type():
+    """The OTLP resource should carry the icebox.* facets + source_type
+    so PostHog Logs can filter by (table, topic) and the existing
+    PostHog Vector-on-EC2 source_type filter carries over."""
+    from unittest.mock import MagicMock
+
+    with patch(
+        "opentelemetry.exporter.otlp.proto.http._log_exporter.OTLPLogExporter",
+        return_value=MagicMock(),
+    ):
+        provider = setup_logging(
+            level="INFO",
+            fmt="json",
+            posthog_token="phc_test",
+            service_instance_id="events-icebox",
+            iceberg_warehouse="ingest",
+            iceberg_namespace="kafka",
+            iceberg_table="events",
+            kafka_topic="clickhouse_events_json",
+            kafka_group_id="millpond-icebox-clickhouse_events_json-events",
+        )
+    try:
+        attrs = dict(provider.resource.attributes)
+        assert attrs["service.name"] == "icebox"
+        assert attrs["service.namespace"] == "millpond"
+        assert attrs["source_type"] == "icebox"
+        assert attrs["service.instance.id"] == "events-icebox"
+        assert attrs["icebox.iceberg.warehouse"] == "ingest"
+        assert attrs["icebox.iceberg.namespace"] == "kafka"
+        assert attrs["icebox.iceberg.table"] == "events"
+        assert attrs["icebox.kafka.topic"] == "clickhouse_events_json"
+        assert (
+            attrs["icebox.kafka.group_id"]
+            == "millpond-icebox-clickhouse_events_json-events"
+        )
+    finally:
+        provider.shutdown()
+        setup_logging(level="INFO", fmt="json")
+
+
+def test_setup_logging_omits_none_optional_resource_attrs():
+    """Unset optional attrs must not render as empty strings or null
+    on the wire — they should be absent from the resource entirely."""
+    from unittest.mock import MagicMock
+
+    with patch(
+        "opentelemetry.exporter.otlp.proto.http._log_exporter.OTLPLogExporter",
+        return_value=MagicMock(),
+    ):
+        provider = setup_logging(
+            level="INFO",
+            fmt="json",
+            posthog_token="phc_test",
+        )
+    try:
+        attrs = dict(provider.resource.attributes)
+        # Required attrs present, optionals absent.
+        assert "service.name" in attrs
+        assert "service.instance.id" not in attrs
+        assert "icebox.iceberg.warehouse" not in attrs
+        assert "icebox.kafka.topic" not in attrs
+    finally:
+        provider.shutdown()
+        setup_logging(level="INFO", fmt="json")
+
+
+def test_cycle_id_attr_filter_stamps_record_when_contextvar_set():
+    """The OTel-side filter must surface ``icebox.cycle_id`` as a
+    record attribute so PostHog Logs can filter on it directly,
+    independent of the JSON body shape on stdout."""
+    from icebox.structured_logging import _CycleIdAttrFilter
+
+    flt = _CycleIdAttrFilter()
+    token = cycle_id_var.set("c-xyz")
+    try:
+        record = _make_record(msg="inside cycle")
+        flt.filter(record)
+        # Dot-keyed attrs aren't accessible via getattr-with-dots syntax;
+        # OTel reads them from __dict__ directly.
+        assert record.__dict__["icebox.cycle_id"] == "c-xyz"
+    finally:
+        cycle_id_var.reset(token)
+
+
+def test_cycle_id_attr_filter_noop_when_contextvar_unset():
+    from icebox.structured_logging import _CycleIdAttrFilter
+
+    if cycle_id_var.get() is not None:
+        cycle_id_var.set(None)
+    flt = _CycleIdAttrFilter()
+    record = _make_record(msg="no cycle context")
+    flt.filter(record)
+    assert "icebox.cycle_id" not in record.__dict__
+
+
 @pytest.fixture(autouse=True)
 def _reset_root_logger():
     """Reset root logger handlers between tests so log lines from one

--- a/tests/unit/test_millpond_logging_config.py
+++ b/tests/unit/test_millpond_logging_config.py
@@ -4,12 +4,14 @@ taxonomy emitted per destination (ducklake / iceberg / icebox).
 """
 from __future__ import annotations
 
+import dataclasses
 import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from millpond import logging_config
+from millpond.config import Config
 
 
 @pytest.fixture(autouse=True)
@@ -22,29 +24,69 @@ def _reset_root_logger():
         root.removeHandler(h)
 
 
-def _make_cfg(**overrides):
-    """Minimal cfg-like object that satisfies attach_posthog_otlp's
-    attribute access. Saves importing config.Config and wiring every
-    field — we only need what the function reads."""
-    base = dict(
-        posthog_project_token=None,
-        posthog_logs_endpoint="https://us.i.posthog.com/i/v1/logs",
-        service_namespace="millpond",
-        service_instance_id=None,
-        service_version="0.0.0",
+def _minimal_config() -> Config:
+    """A real Config instance with the minimum required field set so a
+    future rename of any field surfaces here as a TypeError, not as a
+    silent green-test/red-prod skew. Tests use ``dataclasses.replace``
+    to override just the field(s) they care about.
+
+    Per attach_posthog_otlp, posthog_project_token=None disables the
+    OTLP path — the OFF state is the default; tests turning it ON
+    pass an explicit token via replace().
+    """
+    return Config(
+        bootstrap_servers="localhost:9092",
         topic="clickhouse_events_json",
         group_id="millpond-test",
+        replica_count=1,
+        ordinal=0,
         destination="ducklake",
         ducklake_table=None,
         ducklake_data_path=None,
+        ducklake_connection=None,
+        rds_host=None,
+        rds_port=None,
+        rds_database=None,
+        rds_username=None,
+        rds_password=None,
+        partition_by=None,
+        iceberg_catalog_uri=None,
         iceberg_warehouse=None,
         iceberg_namespace=None,
         iceberg_table=None,
+        iceberg_table_location=None,
+        iceberg_catalog_token=None,
+        s3_access_key_id=None,
+        s3_secret_access_key=None,
+        s3_region=None,
+        s3_endpoint=None,
         icebox_url=None,
         icebox_bucket=None,
+        icebox_warehouse_prefix=None,
+        icebox_max_attempts=6,
+        icebox_max_backoff_s=30.0,
+        icebox_timeout_s=10.0,
+        flush_size=104857600,
+        flush_interval_ms=60000,
+        fetch_min_bytes=1048576,
+        fetch_max_wait_ms=500,
+        consume_batch_size=1000,
+        stats_interval_ms=5000,
+        broker_source="warpstream",
+        filter_keep_field=None,
+        filter_drop_field=None,
+        filter_values=None,
+        sort_by=None,
+        kafka_config_overrides=(),
     )
-    base.update(overrides)
-    return type("Cfg", (), base)()
+
+
+def _make_cfg(**overrides) -> Config:
+    """Build a real Config via dataclasses.replace from the minimal
+    baseline. Any rename of a Config field surfaces as a TypeError on
+    this call site — structural canary that the previous
+    ``type("Cfg", (), ...)`` fake lacked."""
+    return dataclasses.replace(_minimal_config(), **overrides)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_millpond_logging_config.py
+++ b/tests/unit/test_millpond_logging_config.py
@@ -1,0 +1,195 @@
+"""Unit tests for millpond/logging_config.py — the two-phase
+setup_stdout() / attach_posthog_otlp() flow and the resource-attr
+taxonomy emitted per destination (ducklake / iceberg / icebox).
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from millpond import logging_config
+
+
+@pytest.fixture(autouse=True)
+def _reset_root_logger():
+    """Clear root-handler state between tests so streams + filters
+    from one test don't leak into the next."""
+    yield
+    root = logging.getLogger()
+    for h in list(root.handlers):
+        root.removeHandler(h)
+
+
+def _make_cfg(**overrides):
+    """Minimal cfg-like object that satisfies attach_posthog_otlp's
+    attribute access. Saves importing config.Config and wiring every
+    field — we only need what the function reads."""
+    base = dict(
+        posthog_project_token=None,
+        posthog_logs_endpoint="https://us.i.posthog.com/i/v1/logs",
+        service_namespace="millpond",
+        service_instance_id=None,
+        service_version="0.0.0",
+        topic="clickhouse_events_json",
+        group_id="millpond-test",
+        destination="ducklake",
+        ducklake_table=None,
+        ducklake_data_path=None,
+        iceberg_warehouse=None,
+        iceberg_namespace=None,
+        iceberg_table=None,
+        icebox_url=None,
+        icebox_bucket=None,
+    )
+    base.update(overrides)
+    return type("Cfg", (), base)()
+
+
+# ---------------------------------------------------------------------------
+# setup_stdout
+# ---------------------------------------------------------------------------
+
+
+def test_setup_stdout_installs_json_formatter_by_default(monkeypatch):
+    from shared.structured_logging import JsonFormatter
+
+    monkeypatch.delenv("MILLPOND_LOG_FORMAT", raising=False)
+    logging_config.setup_stdout()
+    handlers = logging.getLogger().handlers
+    assert len(handlers) == 1
+    assert isinstance(handlers[0].formatter, JsonFormatter)
+
+
+def test_setup_stdout_text_mode_includes_pod_ordinal_prefix(monkeypatch):
+    monkeypatch.setenv("MILLPOND_LOG_FORMAT", "text")
+    monkeypatch.setenv("POD_NAME", "millpond-events-7")
+    logging_config.setup_stdout()
+    formatter = logging.getLogger().handlers[0].formatter
+    # The historical text format embedded [<ordinal>][<logger>]; check
+    # the format string carries the ordinal we set via POD_NAME.
+    assert "[7]" in formatter._fmt
+
+
+def test_setup_stdout_silences_confluent_kafka_logger():
+    logging_config.setup_stdout()
+    assert logging.getLogger("confluent_kafka").level == logging.WARNING
+
+
+# ---------------------------------------------------------------------------
+# attach_posthog_otlp — disabled path
+# ---------------------------------------------------------------------------
+
+
+def test_attach_posthog_otlp_returns_none_when_token_unset():
+    cfg = _make_cfg()  # token=None
+    assert logging_config.attach_posthog_otlp(cfg) is None
+
+
+# ---------------------------------------------------------------------------
+# attach_posthog_otlp — resource attrs per destination
+# ---------------------------------------------------------------------------
+
+
+def _resource_attrs_for(cfg) -> dict[str, str]:
+    """Run attach_posthog_otlp with a mocked exporter and return the
+    resource-attr dict that landed on the LoggerProvider."""
+    with patch(
+        "opentelemetry.exporter.otlp.proto.http._log_exporter.OTLPLogExporter",
+        return_value=MagicMock(),
+    ):
+        provider = logging_config.attach_posthog_otlp(cfg)
+    try:
+        return dict(provider.resource.attributes)
+    finally:
+        provider.shutdown()
+
+
+def test_resource_attrs_ducklake_destination():
+    cfg = _make_cfg(
+        posthog_project_token="phc_test",
+        service_instance_id="events",
+        destination="ducklake",
+        ducklake_table="events",
+        ducklake_data_path="s3://posthog-megaduck-mw-dev/",
+    )
+    attrs = _resource_attrs_for(cfg)
+    # Service identity
+    assert attrs["service.name"] == "millpond"
+    assert attrs["service.namespace"] == "millpond"
+    assert attrs["service.instance.id"] == "events"
+    # OTel messaging semconv
+    assert attrs["messaging.system"] == "kafka"
+    assert attrs["messaging.destination.name"] == "clickhouse_events_json"
+    assert attrs["messaging.kafka.consumer.group"] == "millpond-test"
+    # Destination dimension + ducklake-specific custom attrs
+    assert attrs["millpond.destination"] == "ducklake"
+    assert attrs["millpond.ducklake.table"] == "events"
+    assert attrs["millpond.ducklake.data_path"] == "s3://posthog-megaduck-mw-dev/"
+    # Iceberg / icebox attrs absent
+    assert "millpond.iceberg.warehouse" not in attrs
+    assert "millpond.icebox.url" not in attrs
+
+
+def test_resource_attrs_iceberg_destination():
+    cfg = _make_cfg(
+        posthog_project_token="phc_test",
+        service_instance_id="events-iceberg",
+        destination="iceberg",
+        iceberg_warehouse="ingest",
+        iceberg_namespace="kafka",
+        iceberg_table="events",
+    )
+    attrs = _resource_attrs_for(cfg)
+    assert attrs["millpond.destination"] == "iceberg"
+    assert attrs["millpond.iceberg.warehouse"] == "ingest"
+    assert attrs["millpond.iceberg.namespace"] == "kafka"
+    assert attrs["millpond.iceberg.table"] == "events"
+    # icebox-only attrs absent for plain iceberg
+    assert "millpond.icebox.url" not in attrs
+    assert "millpond.icebox.bucket" not in attrs
+    # ducklake attrs absent
+    assert "millpond.ducklake.table" not in attrs
+
+
+def test_resource_attrs_icebox_destination():
+    cfg = _make_cfg(
+        posthog_project_token="phc_test",
+        service_instance_id="events-icebox",
+        destination="icebox",
+        iceberg_warehouse="ingest",
+        iceberg_namespace="kafka",
+        iceberg_table="events",
+        icebox_url="http://millpond-events-icebox-coord:8000",
+        icebox_bucket="posthog-megaberg-mw-dev",
+    )
+    attrs = _resource_attrs_for(cfg)
+    assert attrs["millpond.destination"] == "icebox"
+    # Iceberg attrs carried over (icebox writers still target Iceberg)
+    assert attrs["millpond.iceberg.warehouse"] == "ingest"
+    assert attrs["millpond.iceberg.namespace"] == "kafka"
+    assert attrs["millpond.iceberg.table"] == "events"
+    # Icebox-specific routing attrs present
+    assert attrs["millpond.icebox.url"] == "http://millpond-events-icebox-coord:8000"
+    assert attrs["millpond.icebox.bucket"] == "posthog-megaberg-mw-dev"
+    # ducklake attrs absent
+    assert "millpond.ducklake.table" not in attrs
+
+
+def test_resource_attrs_omit_unset_optionals():
+    """service.instance.id is the per-consumer axis — omit it
+    entirely if unset rather than rendering as null/empty."""
+    cfg = _make_cfg(
+        posthog_project_token="phc_test",
+        service_instance_id=None,
+        destination="ducklake",
+        ducklake_table=None,  # also unset
+        ducklake_data_path=None,
+    )
+    attrs = _resource_attrs_for(cfg)
+    assert "service.instance.id" not in attrs
+    assert "millpond.ducklake.table" not in attrs
+    assert "millpond.ducklake.data_path" not in attrs
+    # But destination IS always emitted — it's the dimension's whole point.
+    assert attrs["millpond.destination"] == "ducklake"

--- a/tests/unit/test_pyiceberg_pin.py
+++ b/tests/unit/test_pyiceberg_pin.py
@@ -421,3 +421,92 @@ def test_pin_canary_snapshot_summary_preserves_custom_keys():
         "icebox/iceberg.py:find_snapshot_for_cycle relies on byte-identical "
         "round-trip"
     )
+
+
+# ---------------------------------------------------------------------------
+# In-transaction snapshot summary surface — load-bearing for the table-state
+# Gauges that icebox/committer.py reads from commit_data_files's returned
+# CommitResult.summary. If any of these symbols move or rename, the broad
+# try/except in icebox/iceberg.py:commit_data_files degrades to summary=None
+# SILENTLY — operators just stop seeing the gauges advance. Catch the drift
+# loudly at install time instead.
+# ---------------------------------------------------------------------------
+
+
+def test_pin_canary_table_metadata_snapshot_by_id_method_exists():
+    """commit_data_files looks up the just-committed snapshot via
+    ``tx.table_metadata.snapshot_by_id(snapshot_id)`` to extract the
+    summary in the same scope as the commit (no extra Lakekeeper
+    round-trip). If this method renames or disappears, the lookup
+    raises and summary degrades to None — operators silently lose
+    the table-state gauges.
+
+    ``TableMetadata`` is a discriminated union; the method lives on
+    each concrete version class. Pin on both V1 and V2 (the two
+    versions PostHog tables use today)."""
+    from pyiceberg.table.metadata import TableMetadataV1, TableMetadataV2
+
+    for cls in (TableMetadataV1, TableMetadataV2):
+        assert hasattr(cls, "snapshot_by_id"), (
+            f"{cls.__name__}.snapshot_by_id no longer exposed; "
+            "icebox/iceberg.py:commit_data_files post-commit summary extraction "
+            "degrades to None silently — table-state gauges stop advancing"
+        )
+
+
+def test_pin_canary_snapshot_summary_additional_properties_attr():
+    """commit_data_files flattens
+    ``snapshot.summary.additional_properties`` to extract the
+    spec-defined keys (``total-data-files``, ``added-records``, etc.).
+    If PyIceberg renames or moves that attribute, the gauge feed stops
+    silently behind the broad try/except. Pin via constructing a
+    Snapshot directly so a rename surfaces here at install time."""
+    from pyiceberg.table.snapshots import Snapshot
+
+    snap = Snapshot(
+        snapshot_id=1,
+        sequence_number=1,
+        timestamp_ms=0,
+        manifest_list="",
+        summary={
+            "operation": "append",
+            "total-data-files": "42",
+            "added-records": "100",
+        },  # type: ignore[arg-type]
+        schema_id=0,
+    )
+    assert hasattr(snap.summary, "additional_properties"), (
+        "Snapshot.summary.additional_properties no longer exposed; "
+        "icebox/iceberg.py:commit_data_files can't extract per-snapshot "
+        "stats — table-state gauges stop advancing"
+    )
+    props = snap.summary.additional_properties
+    assert props.get("total-data-files") == "42"
+    assert props.get("added-records") == "100"
+
+
+def test_pin_canary_snapshot_summary_operation_enum_value():
+    """commit_data_files captures the snapshot's operation type via
+    ``snapshot.summary.operation.value`` (Enum → string). If PyIceberg
+    changes the type (e.g., to plain str), the .value access raises
+    and partial-summary preservation logic loses the operation tag
+    silently."""
+    from pyiceberg.table.snapshots import Operation, Snapshot
+
+    snap = Snapshot(
+        snapshot_id=1,
+        sequence_number=1,
+        timestamp_ms=0,
+        manifest_list="",
+        summary={"operation": "append"},  # type: ignore[arg-type]
+        schema_id=0,
+    )
+    assert snap.summary is not None
+    op = snap.summary.operation
+    assert isinstance(op, Operation), (
+        "Snapshot.summary.operation is no longer an Operation enum; "
+        "icebox/iceberg.py:commit_data_files's `op.value` access path "
+        "now raises and silently drops the operation tag from the "
+        "extracted summary"
+    )
+    assert op.value == "append"

--- a/tests/unit/test_shared_structured_logging.py
+++ b/tests/unit/test_shared_structured_logging.py
@@ -1,0 +1,172 @@
+"""Unit tests for shared/structured_logging.py — the building blocks
+both millpond and icebox compose from."""
+from __future__ import annotations
+
+import io
+import json
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from shared import structured_logging as sl
+
+
+@pytest.fixture(autouse=True)
+def _reset_root_logger():
+    yield
+    root = logging.getLogger()
+    for h in list(root.handlers):
+        root.removeHandler(h)
+
+
+def _record(msg: str = "hello", extra: dict | None = None) -> logging.LogRecord:
+    r = logging.LogRecord(
+        name="t", level=logging.INFO, pathname="t.py", lineno=1, msg=msg, args=(), exc_info=None
+    )
+    if extra:
+        for k, v in extra.items():
+            setattr(r, k, v)
+    return r
+
+
+# ---------------------------------------------------------------------------
+# JsonFormatter
+# ---------------------------------------------------------------------------
+
+
+def test_json_formatter_emits_required_fields():
+    out = json.loads(sl.JsonFormatter().format(_record(msg="boot")))
+    assert set(out.keys()) >= {"ts", "level", "logger", "msg"}
+    assert out["msg"] == "boot"
+
+
+def test_json_formatter_inlines_extra_kwargs():
+    out = json.loads(sl.JsonFormatter().format(_record(extra={"file_count": 7})))
+    assert out["file_count"] == 7
+
+
+def test_json_formatter_extra_context_subclass_hook():
+    """Subclasses (e.g. icebox's IceboxJsonFormatter) inject per-record
+    fields by overriding extra_context()."""
+
+    class _Fmt(sl.JsonFormatter):
+        def extra_context(self):
+            return {"injected": "yes"}
+
+    out = json.loads(_Fmt().format(_record()))
+    assert out["injected"] == "yes"
+
+
+def test_json_formatter_skips_none_extra_context_values():
+    """A subclass returning None values (e.g. an unset ContextVar)
+    must not render the key with a null."""
+
+    class _Fmt(sl.JsonFormatter):
+        def extra_context(self):
+            return {"maybe": None}
+
+    out = json.loads(_Fmt().format(_record()))
+    assert "maybe" not in out
+
+
+def test_json_formatter_handles_non_serializable_via_repr():
+    class NotJSON:
+        def __repr__(self):
+            return "NotJSON(x=1)"
+
+    out = json.loads(sl.JsonFormatter().format(_record(extra={"obj": NotJSON()})))
+    assert out["obj"] == "NotJSON(x=1)"
+
+
+# ---------------------------------------------------------------------------
+# install_root_handlers + silence_logger
+# ---------------------------------------------------------------------------
+
+
+def test_install_root_handlers_replaces_existing_handlers():
+    root = logging.getLogger()
+    pre_existing = logging.StreamHandler()
+    root.addHandler(pre_existing)
+    sl.install_root_handlers(level="INFO", formatter=sl.text_formatter())
+    assert pre_existing not in root.handlers
+    assert len(root.handlers) == 1
+
+
+def test_silence_logger_pins_level():
+    sl.silence_logger("test.noisy.logger", logging.ERROR)
+    assert logging.getLogger("test.noisy.logger").level == logging.ERROR
+
+
+def test_silence_logger_effectively_drops_records_below_threshold():
+    """Asserting on logger.level alone isn't enough — pin the
+    effective behavior with a captured stream."""
+    sl.install_root_handlers(level="DEBUG", formatter=sl.JsonFormatter())
+    captured = io.StringIO()
+    root = logging.getLogger()
+    capture_handler = logging.StreamHandler(captured)
+    capture_handler.setLevel(logging.DEBUG)
+    root.addHandler(capture_handler)
+    sl.silence_logger("noisy.thing", logging.WARNING)
+    try:
+        logging.getLogger("noisy.thing").info("should-not-appear")
+        logging.getLogger("noisy.thing").warning("should-appear")
+        out = captured.getvalue()
+        assert "should-not-appear" not in out
+        assert "should-appear" in out
+    finally:
+        root.removeHandler(capture_handler)
+
+
+# ---------------------------------------------------------------------------
+# OTLP provider + handler
+# ---------------------------------------------------------------------------
+
+
+def test_build_otel_logger_provider_attaches_resource_attrs():
+    with patch(
+        "opentelemetry.exporter.otlp.proto.http._log_exporter.OTLPLogExporter",
+        return_value=MagicMock(),
+    ):
+        provider = sl.build_otel_logger_provider(
+            posthog_token="phc_test",
+            posthog_endpoint="https://example.test/i/v1/logs",
+            resource_attrs={"service.name": "test-svc", "k": "v"},
+        )
+    try:
+        attrs = dict(provider.resource.attributes)
+        assert attrs["service.name"] == "test-svc"
+        assert attrs["k"] == "v"
+    finally:
+        provider.shutdown()
+
+
+def test_attach_otel_handler_applies_extra_filters():
+    """Filters passed to attach_otel_handler must be wired onto the
+    OTel-side handler (not the stdout handler) so per-record stamping
+    only affects the OTLP export path."""
+    with patch(
+        "opentelemetry.exporter.otlp.proto.http._log_exporter.OTLPLogExporter",
+        return_value=MagicMock(),
+    ):
+        provider = sl.build_otel_logger_provider(
+            posthog_token="phc_test",
+            posthog_endpoint="https://example.test/i/v1/logs",
+            resource_attrs={"service.name": "test"},
+        )
+    try:
+        seen: list[logging.LogRecord] = []
+
+        class _Capture(logging.Filter):
+            def filter(self, record):
+                seen.append(record)
+                return True
+
+        root = sl.install_root_handlers(level="INFO", formatter=sl.JsonFormatter())
+        sl.attach_otel_handler(
+            provider=provider, root=root, level="INFO", extra_filters=[_Capture()]
+        )
+        logging.getLogger("test.otel.path").info("emit me")
+        assert any(r.getMessage() == "emit me" for r in seen)
+    finally:
+        provider.shutdown()

--- a/uv.lock
+++ b/uv.lock
@@ -508,7 +508,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.30" },
-    { name = "opentelemetry-instrumentation-logging", specifier = ">=0.50b0" },
+    { name = "opentelemetry-instrumentation-logging", specifier = ">=0.50b0,<0.64" },
     { name = "opentelemetry-sdk", specifier = ">=1.30" },
     { name = "orjson", specifier = ">=3.10" },
     { name = "prometheus-client", specifier = ">=0.21" },

--- a/uv.lock
+++ b/uv.lock
@@ -474,6 +474,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-sdk" },
     { name = "orjson" },
     { name = "prometheus-client" },
@@ -507,6 +508,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.30" },
+    { name = "opentelemetry-instrumentation-logging", specifier = ">=0.50b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.30" },
     { name = "orjson", specifier = ">=3.10" },
     { name = "prometheus-client", specifier = ">=0.21" },
@@ -649,6 +651,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/77/32/826bfa1d80ecea24f47808de03cd4a0d13c17ecc07712f45123f0f61e4ac/opentelemetry_exporter_otlp_proto_http-1.42.1.tar.gz", hash = "sha256:bf142a21035d7571ac3a09cb2e5639f49886f243972883cfe777ed3bf02b734d", size = 25406, upload-time = "2026-05-21T16:32:56.807Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/96/82cb223a1502f0787d4bbff12907f5f8d870a50731febcd5818d93ef9555/opentelemetry_exporter_otlp_proto_http-1.42.1-py3-none-any.whl", hash = "sha256:00a16da1b312a1d6c7233d600d557c91df71125af73020f3b9a7765bd699d59d", size = 21793, upload-time = "2026-05-21T16:32:35.277Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.63b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/6d/4de72d97ff54db1ed270c7a59c9b904b917c0ac7af429c086c388b824ddb/opentelemetry_instrumentation-0.63b1.tar.gz", hash = "sha256:32368d6ae52c8de20aa790a6ad86b10a76f09956092337ae37d675773990e541", size = 41081, upload-time = "2026-05-21T16:36:14.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/a1/9314e621c143e4d82a5bf7a43c2ff7a745d31023506336857607c8c543cc/opentelemetry_instrumentation-0.63b1-py3-none-any.whl", hash = "sha256:f1986716d52cc316ea5f60189098726a9071d8ecc0eee96c9ed110be08bade9c", size = 35577, upload-time = "2026-05-21T16:34:56.818Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-logging"
+version = "0.63b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/cf/119381b1ae446fb07921a452e3a8e1887aa87f9856225f9829958dc20063/opentelemetry_instrumentation_logging-0.63b1.tar.gz", hash = "sha256:aa57d1bcb8931186b5dde565e9c17c572cf02412572d962da5b1a17ee5637d2c", size = 19823, upload-time = "2026-05-21T16:36:37.276Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/71/1ba447311adf33023be14a1a309852c4cf74219f095d0055a54c1824d9ff/opentelemetry_instrumentation_logging-0.63b1-py3-none-any.whl", hash = "sha256:6b3aac8d18bc897468814d5ce4ed00f9d43588c583b4ba2288267e191b96d944", size = 15993, upload-time = "2026-05-21T16:35:35.851Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Seven commits across icebox and millpond:

1. **`feat(icebox)`**: Expanded OTLP resource-attr taxonomy for PostHog Logs filtering — `service.instance.id`, `service.namespace=millpond`, `messaging.*` semconv for Kafka, `icebox.iceberg.*` for the Iceberg destination, `icebox.cycle_id` as a per-record attribute.
2. **`chore(icebox)`**: Cut ~89% of log volume — silenced `uvicorn.access` (probes + per-POST access logs), dropped the schema-cache-mismatch and vacuous-cycle log lines to DEBUG, added `icebox_schema_fingerprint_cache_misses_total{reason}` counter as the operational replacement.
3. **`chore(icebox)`**: Migrated OTLP `LoggingHandler` from `opentelemetry.sdk._logs` (deprecated in SDK 1.42) to `opentelemetry-instrumentation-logging`. Side benefit: no more per-record `code.{file,function,line}` noise in the export.
4. **`fixup(icebox)`**: Round-1 QE + PE review pass.
5. **`feat(millpond)`**: PostHog Logs OTLP export from the writer. Shared building blocks in `shared/structured_logging.py` (JsonFormatter, install_root_handlers, build_otel_logger_provider, attach_otel_handler, silence_logger) composed by both icebox and millpond. Writer-side resource attrs include `millpond.destination={ducklake,iceberg,icebox}` — the dimension that's missing from millpond metrics today, surfaced at the log layer for now.
6. **`feat(icebox)`**: Iceberg table-state gauges (`icebox_iceberg_table_data_files`, `_records`, `_files_size_bytes` cumulative + `_added_*` per-cycle deltas) read from each cycle's snapshot summary. Zero threads, zero extra Lakekeeper round-trips. `commit_data_files()` now returns a frozen `CommitResult(snapshot_id, summary)` dataclass.
7. **`fixup`**: Round-2 QE + PE review pass.

## Resource-attr taxonomy (logs)

Split by ownership so the app and chart never set the same key.

**App-owned** (passed by the app):

| Attr | icebox value | millpond value |
|---|---|---|
| \`service.name\` | \`icebox\` | \`millpond\` |
| \`service.namespace\` | \`millpond\` (default) | \`millpond\` (default) |
| \`service.instance.id\` | consumer key (e.g. \`events-icebox\`) | consumer key |
| \`service.version\` | package version | package version |
| \`messaging.system\` | \`kafka\` | \`kafka\` |
| \`messaging.destination.name\` | Kafka topic | Kafka topic |
| \`messaging.kafka.consumer.group\` | icebox group id | writer group id |
| \`icebox.iceberg.{warehouse,namespace,table}\` | ✓ | — |
| \`millpond.destination\` | — | \`ducklake\` \| \`iceberg\` \| \`icebox\` |
| \`millpond.ducklake.{table,data_path}\` | — | when destination=ducklake |
| \`millpond.iceberg.{warehouse,namespace,table}\` | — | when destination ∈ {iceberg, icebox} |
| \`millpond.icebox.{url,bucket}\` | — | when destination=icebox |

**Chart-owned** (auto-merged via \`OTEL_RESOURCE_ATTRIBUTES\` env): \`deployment.environment\`, \`k8s.*\`, \`host.hostname\`.

\`icebox.cycle_id\` is a per-record attribute (not Resource) so PostHog Logs can filter on it for per-cycle scoping.

## New Iceberg table-state gauges

| Metric | Source key |
|---|---|
| \`icebox_iceberg_table_data_files\` | \`snapshot.summary['total-data-files']\` |
| \`icebox_iceberg_table_records\` | \`total-records\` |
| \`icebox_iceberg_table_files_size_bytes\` | \`total-files-size\` |
| \`icebox_iceberg_table_added_data_files\` | \`added-data-files\` |
| \`icebox_iceberg_table_added_records\` | \`added-records\` |
| \`icebox_iceberg_table_added_files_size_bytes\` | \`added-files-size\` |

Free signal: the summary is extracted from \`tx.table_metadata.snapshot_by_id\` inside the same transaction as the commit. Gauge update lives OUTSIDE the iceberg-commit \`try\` block so a gauge failure cannot trip the saga's except branch and release the cycle claim after the snapshot has landed (which would re-batch the files for a double-commit). Three new pin-canary tests in \`test_pyiceberg_pin.py\` bound the defensive try/except around summary extraction so a future PyIceberg API drift fails loudly at install time.

## Noise reduction

A 1h prod sample of 9,480 icebox log lines was ~89% noise. After this PR:
- \`uvicorn.access\` silenced at WARNING (–45%)
- Schema-cache mismatch dropped to DEBUG, replaced by labeled metric (–22%)
- Vacuous-cycle log dropped to DEBUG (–4%)

Useful lines (cycle outcomes, errors, bootstrap) preserved at INFO.

## Reviews

Two rounds of independent Lead-QE + Principal-Engineer review.

- Round 1 found 8 MAJOR / MINOR items addressed in commit 4. Round 2 found 4 MAJORs + several MINORs addressed in commit 7.
- Notably resolved in round 2: gauge-update double-commit hazard (decoupled from iceberg-commit \`try\` block), \`BatchLogRecordProcessor\` defaults pinned (5s schedule delay, 512 batch, 4096 queue — predictable PostHog Logs ingest pressure at 32-writer scale), \`type(\"Cfg\", ...)\` test fakes replaced with real \`Config\` via \`dataclasses.replace\`, \`messaging.*\` semconv adopted over vendor-prefixed Kafka attrs.

## Deferred (tracking follow-ups, not in this PR)

- Add \`destination\` as a millpond metrics common label. The log resource attr is a stopgap so PostHog Logs UI can filter today, but operators chasing metrics still depend on the implicit pipeline-shape differentiation. Should land before this becomes the permanent fix.
- Chart-side wiring of \`POSTHOG_PROJECT_TOKEN\` + \`OTEL_RESOURCE_ATTRIBUTES\` on the millpond writer StatefulSet. The app is fully ready; until the chart catches up, the writer OTLP path is plumbed but inert.

## Test plan

- [x] \`just lint\` clean
- [x] \`just fmt-check\` clean
- [x] \`just test\` — 1006 unit pass
- [x] \`just test-integration\` — 50 integration pass (real Docker icebox stack against testcontainers Postgres + MinIO + Lakekeeper + Redpanda)
- [ ] After deploy of icebox in mw-dev: PostHog Logs UI should show \`service.name=icebox\` filterable by \`service.instance.id\`, \`messaging.destination.name\`, \`icebox.iceberg.table\`, and per-record \`icebox.cycle_id\`. Probe / scrape / POST access logs should not appear.
- [ ] Grafana: \`icebox_iceberg_table_{data_files,records,files_size_bytes}\` advance once per cycle; \`_added_*\` show per-cycle deltas.
- [ ] After chart adds \`POSTHOG_PROJECT_TOKEN\` to the writer STS: writer logs appear in PostHog Logs with \`service.name=millpond\` and the \`millpond.destination\` axis.