### PR TITLE
fix(icebox): disable uvicorn access_log at the source

### DIFF
--- a/icebox/main.py
+++ b/icebox/main.py
@@ -162,6 +162,17 @@ def main() -> None:
         host=cfg.api_host,
         port=cfg.api_port,
         log_config=None,  # we configured logging above
+        # ``access_log=False`` is what actually stops uvicorn from
+        # emitting one INFO line per kubelet probe / Prometheus scrape /
+        # writer POST. The ``logging.getLogger("uvicorn.access")
+        # .setLevel(WARNING)`` call in setup_logging is belt-and-suspenders
+        # — it runs BEFORE uvicorn boots and uvicorn's ``Server.run()``
+        # can quietly reset logger levels during startup, defeating the
+        # silencing. Disabling at the source is bulletproof; the
+        # logger-level silencing stays in place so any code path that
+        # constructs a ``uvicorn.access`` record outside ``access_log``
+        # (e.g. a future middleware hook) also gets suppressed.
+        access_log=False,
     )
 
     log.info("icebox: uvicorn exited, waiting for committer thread")

--- a/icebox/structured_logging.py
+++ b/icebox/structured_logging.py
@@ -126,13 +126,13 @@ def setup_logging(
     formatter = IceboxJsonFormatter() if fmt == "json" else sl.text_formatter()
     root = sl.install_root_handlers(level=level, formatter=formatter)
 
-    # Silence uvicorn's per-request access log. kubelet probes
-    # (/readyz, /healthz) + Prometheus scrape (/metrics) + every
-    # writer POST (/v1/files) generate one line each here. None of it
-    # carries operational signal that isn't already in our metrics
-    # — but together they swamp the useful committer logs (~63% of
-    # all icebox log volume per a 1h prod sample). WARNING-level
-    # keeps the door open for uvicorn to surface a startup failure.
+    # Belt-and-suspenders against uvicorn.access leakage. The
+    # load-bearing silencing happens at ``uvicorn.run(access_log=False)``
+    # in icebox/main.py — verified in prod after the level-only approach
+    # turned out to be defeated by uvicorn's startup logger-config reset.
+    # This setLevel still catches any future ``uvicorn.access`` records
+    # constructed outside the standard access-log path (e.g. a
+    # middleware hook), so leaving it in place is cheap insurance.
     sl.silence_logger("uvicorn.access", logging.WARNING)
 
     if not posthog_token:


### PR DESCRIPTION
## Summary

Follow-up to the just-merged #69. The `logging.getLogger("uvicorn.access").setLevel(WARNING)` silencing landed in main and ran before `uvicorn.run()` boots — but the deployed icebox's PostHog Logs output confirms uvicorn's `Server.run()` quietly resets the logger level during startup, defeating the silencing. `GET /readyz`, `GET /healthz`, `GET /metrics`, and `POST /v1/files` access lines are all still landing.

The round-1 QE review predicted exactly this: *"uvicorn can flip the logger config at server start, defeating logger.level-based silencing — assert effective behavior, not the level."* The level-only approach was a half-measure; prod proved it.

## Fix

Pass `access_log=False` to `uvicorn.run()`. That disables the per-request access log at the source — uvicorn never constructs the records to begin with. Leave the `setLevel(WARNING)` in place as belt-and-suspenders for any future code path that emits `uvicorn.access` records outside the standard access-log emission (e.g. a middleware hook).

## Test plan

- [x] `just lint` clean, `just fmt-check` clean, `just test` (1006 unit) clean
- [ ] After the next mw-dev image bump: PostHog Logs no longer shows `uvicorn.access` lines from probes / scrapes / POSTs.

## Why this couldn't be caught in unit tests

uvicorn doesn't run in the test harness — the level-only assertion was the only behavior verifiable without booting a real server. Integration coverage would catch it but only the e2e Docker stack actually starts uvicorn, and the noise reduction wasn't asserted there. The fix is one-line and the prod observation is the verification.