### PR TITLE
fix(icebox+millpond): open writer pool; auto-bootstrap missing Iceberg tables

### DIFF
--- a/icebox/daemon.py
+++ b/icebox/daemon.py
@@ -56,7 +56,11 @@ import psycopg
 import psycopg_pool
 import requests.exceptions
 from psycopg_pool import ConnectionPool
-from pyiceberg.exceptions import CommitFailedException, CommitStateUnknownException
+from pyiceberg.exceptions import (
+    CommitFailedException,
+    CommitStateUnknownException,
+    NoSuchTableError,
+)
 
 from icebox import iceberg as ib
 from icebox import kafka as kf
@@ -120,6 +124,10 @@ class DaemonDeps:
     commit_data_files: Callable[..., ib.CommitResult] = ib.commit_data_files
     kafka_admin: Any = None
     kafka_commit_offsets: Callable[..., None] = kf.commit_offsets
+    # Lazy table-bootstrap: invoked when load_table raises
+    # NoSuchTableError and there is at least one pending row whose
+    # parquet can seed the schema. Takes the parquet's s3:// path.
+    bootstrap_table: Callable[[str], Any] | None = None
 
 
 # Exception types that mean "Lakekeeper isn't telling us the commit
@@ -388,6 +396,64 @@ def _try_commit_kafka_offsets(
         )
 
 
+def _try_bootstrap_table(
+    cfg: Config,
+    pg_pool: ConnectionPool,
+    deps: DaemonDeps,
+) -> None:
+    """Recover from NoSuchTableError by inferring the Iceberg schema
+    from a pending row's parquet footer and creating the table.
+
+    Failure modes are quiet on purpose:
+      - No pending rows yet → log INFO, sleep, retry next tick. This
+        is the common case on a fresh consumer: writer flushes will
+        materialise rows in seconds, and the NEXT tick will bootstrap.
+      - deps.bootstrap_table is None → log WARNING. Indicates a
+        mis-wired main.py; we can't recover, but don't crash either.
+      - bootstrap_table raises → log + sleep. Likely Lakekeeper /
+        S3 transient; the next NoSuchTableError catch retries.
+
+    Bootstrap is OUTSIDE the tick's PG transaction: we open a fresh
+    short-lived connection just to peek at one file_path, then call
+    Lakekeeper. The next tick re-enters daemon_loop, load_table()
+    succeeds, and the pending rows commit normally.
+    """
+    if deps.bootstrap_table is None:
+        log.warning(
+            "daemon_loop: NoSuchTableError for %s.%s but deps.bootstrap_table "
+            "is None — table must be pre-created out-of-band",
+            cfg.iceberg_namespace, cfg.iceberg_table,
+        )
+        return
+    try:
+        with pg_pool.connection() as conn:
+            file_path = ps.peek_oldest_pending_file_path(conn)
+    except psycopg.Error as exc:
+        log.warning(
+            "daemon_loop: peek_oldest_pending_file_path failed (%s); "
+            "skipping bootstrap, will retry next tick", exc,
+        )
+        return
+    if file_path is None:
+        log.info(
+            "daemon_loop: %s.%s does not exist in catalog and no pending "
+            "rows yet; waiting for first writer flush",
+            cfg.iceberg_namespace, cfg.iceberg_table,
+        )
+        return
+    log.info(
+        "daemon_loop: bootstrapping %s.%s from staged parquet %s",
+        cfg.iceberg_namespace, cfg.iceberg_table, file_path,
+    )
+    try:
+        deps.bootstrap_table(file_path)
+    except Exception as exc:
+        log.exception(
+            "daemon_loop: bootstrap_table failed (%s); will retry next tick",
+            exc,
+        )
+
+
 def refresh_state_gauges(conn: psycopg.Connection) -> None:
     """Populate the live `icebox_files_count{result}`, oldest-pending,
     and `icebox_files_bytes{result}` gauges from PG. Called by the
@@ -480,6 +546,13 @@ def daemon_loop(
             # signal as stop_event.
             log.info("daemon_loop: pg_pool closed, exiting")
             break
+        except NoSuchTableError:
+            # The Iceberg (namespace, table) doesn't exist yet. If we
+            # have any pending rows, infer the schema from the oldest
+            # one's parquet footer and create the table. Subsequent
+            # ticks then succeed. If we have NO pending rows, the
+            # writer simply hasn't flushed yet — wait it out.
+            _try_bootstrap_table(cfg, pg_pool, deps)
         except psycopg.Error as exc:
             metrics.ICEBOX_PG_UNREACHABLE_TOTAL.inc()
             log.warning("daemon_loop: PG error in tick (%s); retrying",

--- a/icebox/iceberg.py
+++ b/icebox/iceberg.py
@@ -30,15 +30,34 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
+import pyarrow.parquet as pq
+from pyiceberg.catalog import Catalog
+from pyiceberg.exceptions import TableAlreadyExistsError
+from pyiceberg.io import load_file_io
+from pyiceberg.io.pyarrow import _pyarrow_to_schema_without_ids
 from pyiceberg.manifest import DataFile, DataFileContent, FileFormat
-from pyiceberg.partitioning import PartitionSpec
-from pyiceberg.schema import Schema
+from pyiceberg.partitioning import PartitionField, PartitionSpec
+from pyiceberg.schema import Schema, assign_fresh_schema_ids
 from pyiceberg.table import Table
+from pyiceberg.transforms import IdentityTransform
 from pyiceberg.typedef import Record
 
 from shared.bounds import encode_bounds
 
 log = logging.getLogger(__name__)
+
+
+# Partition field ids by Iceberg convention start at 1000. Names match
+# what millpond/icebox_sink._add_metadata_columns stamps into the
+# parquet (int32 year/month/day/hour columns), so an IdentityTransform
+# off each column is what the writer's partition_values dict assumes.
+# All icebox-sink consumers share this layout — no per-table tuning.
+_PARTITION_FIELDS = (
+    ("year", 1000),
+    ("month", 1001),
+    ("day", 1002),
+    ("hour", 1003),
+)
 
 
 @dataclass(frozen=True)
@@ -283,3 +302,85 @@ def commit_data_files(
             "_append_snapshot_producer"
         )
     return CommitResult(snapshot_id=snapshot_id, summary=summary)
+
+
+def bootstrap_table_from_parquet(
+    *,
+    catalog: Catalog,
+    namespace: str,
+    table_name: str,
+    parquet_s3_path: str,
+) -> Table:
+    """Create (namespace, table_name) in the catalog by inferring the
+    schema from a staged parquet's footer. Returns the loaded Table.
+
+    Idempotent: if a concurrent icebox replica wins the create race,
+    catches TableAlreadyExistsError and loads instead. Safe to call
+    from every tick that would otherwise crash on NoSuchTableError —
+    the create only fires once per (namespace, table) lifetime.
+
+    Schema derivation: read arrow_schema from the parquet footer (one
+    S3 GET with a Range header — no full-file download), then apply
+    `assign_fresh_schema_ids(_pyarrow_to_schema_without_ids(...))`.
+    This is the same conversion the writer does at first-flush time
+    (millpond/icebox_sink._ensure_schema), so the resulting Iceberg
+    field ids match the ones the writer's parquet_stats are keyed by.
+
+    Partition spec: IdentityTransform on each of year/month/day/hour —
+    matches _add_metadata_columns + partition_tuple_from_spec. The
+    writer always stamps these four int32 columns; we assume their
+    presence and fail loudly otherwise so a schema regression on the
+    writer side surfaces clearly here rather than silently producing
+    an unpartitioned table.
+    """
+    file_io = load_file_io(properties=catalog.properties, location=parquet_s3_path)
+    with file_io.new_input(parquet_s3_path).open() as f:
+        arrow_schema = pq.ParquetFile(f).schema_arrow
+
+    ice_schema: Schema = assign_fresh_schema_ids(
+        _pyarrow_to_schema_without_ids(arrow_schema)
+    )
+
+    partition_fields = []
+    for name, field_id in _PARTITION_FIELDS:
+        try:
+            source = ice_schema.find_field(name)
+        except ValueError as exc:
+            raise ValueError(
+                f"bootstrap_table_from_parquet: parquet at {parquet_s3_path!r} "
+                f"missing required partition column {name!r}; expected an "
+                f"int32 stamped by millpond/icebox_sink._add_metadata_columns"
+            ) from exc
+        partition_fields.append(
+            PartitionField(
+                source_id=source.field_id,
+                field_id=field_id,
+                transform=IdentityTransform(),
+                name=name,
+            )
+        )
+    spec = PartitionSpec(*partition_fields)
+
+    log.info(
+        "bootstrap_table_from_parquet: creating %s.%s (schema=%d fields, "
+        "partition_spec=year/month/day/hour identity) from %s",
+        namespace, table_name, len(ice_schema.fields), parquet_s3_path,
+    )
+    try:
+        return catalog.create_table(
+            (namespace, table_name),
+            schema=ice_schema,
+            partition_spec=spec,
+        )
+    except TableAlreadyExistsError:
+        # Another replica beat us. Load the table they created — its
+        # schema/spec might differ from ours if writers shipped
+        # different shapes, but at THIS point any rows we held in PG
+        # already match this parquet's schema and will commit
+        # successfully or fail loudly at append time.
+        log.info(
+            "bootstrap_table_from_parquet: %s.%s already exists (replica "
+            "race); loading instead",
+            namespace, table_name,
+        )
+        return catalog.load_table((namespace, table_name))

--- a/icebox/main.py
+++ b/icebox/main.py
@@ -28,6 +28,7 @@ from pyiceberg.catalog import load_catalog
 
 from icebox import config as icebox_config
 from icebox import daemon as dm
+from icebox import iceberg as ib
 from icebox import kafka as ikafka
 from icebox import postgres_sync as ps
 from icebox.structured_logging import setup_logging
@@ -164,11 +165,8 @@ def main() -> None:
     log.info("icebox: kafka admin client built")
 
     # ---- Iceberg catalog ---------------------------------------------
-    def _load_table() -> Any:
-        # Called once per tick. Loading is cheap (Lakekeeper REST GET)
-        # and fresh metadata is required because the catalog can
-        # advance underneath us between ticks.
-        catalog = load_catalog(
+    def _build_catalog() -> Any:
+        return load_catalog(
             "icebox",
             **{
                 "type": "rest",
@@ -176,10 +174,31 @@ def main() -> None:
                 "warehouse": cfg.iceberg_warehouse,
             },
         )
-        return catalog.load_table((cfg.iceberg_namespace, cfg.iceberg_table))
+
+    def _load_table() -> Any:
+        # Called once per tick. Loading is cheap (Lakekeeper REST GET)
+        # and fresh metadata is required because the catalog can
+        # advance underneath us between ticks.
+        return _build_catalog().load_table(
+            (cfg.iceberg_namespace, cfg.iceberg_table)
+        )
+
+    def _bootstrap_table(parquet_s3_path: str) -> Any:
+        # Called by the daemon's NoSuchTableError recovery path. Reads
+        # the parquet footer from S3 (one Range GET via PyIceberg's
+        # FileIO, configured off the same catalog properties as the
+        # rest of the daemon), derives the Iceberg schema, and creates
+        # the table with year/month/day/hour identity partition spec.
+        return ib.bootstrap_table_from_parquet(
+            catalog=_build_catalog(),
+            namespace=cfg.iceberg_namespace,
+            table_name=cfg.iceberg_table,
+            parquet_s3_path=parquet_s3_path,
+        )
 
     deps = dm.DaemonDeps(
         load_table=_load_table,
+        bootstrap_table=_bootstrap_table,
         kafka_admin=admin,
     )
 

--- a/icebox/postgres_sync.py
+++ b/icebox/postgres_sync.py
@@ -328,6 +328,27 @@ def claim_pending_batch(
     ]
 
 
+PEEK_OLDEST_PENDING_FILE_PATH_SQL = """
+SELECT file_path FROM icebox_files
+WHERE result='pending'
+ORDER BY inserted_at
+LIMIT 1
+"""
+
+
+def peek_oldest_pending_file_path(conn: psycopg.Connection) -> str | None:
+    """Return the file_path of the oldest pending row, or None if the
+    table is empty / has no pending rows. Used by the daemon's
+    NoSuchTableError recovery path to find any staged parquet whose
+    schema can seed table bootstrap. No row lock — we're just reading
+    a path, not claiming work.
+    """
+    with conn.cursor() as cur:
+        cur.execute(PEEK_OLDEST_PENDING_FILE_PATH_SQL)
+        row = cur.fetchone()
+    return row[0] if row else None
+
+
 MARK_COMMITTED_SQL = """
 UPDATE icebox_files
 SET result='committed', result_at=now(), iceberg_snapshot_id=%(snapshot_id)s

--- a/millpond/icebox_sink.py
+++ b/millpond/icebox_sink.py
@@ -188,15 +188,20 @@ class IceboxClient:
                 sslmode=self.sslmode,
                 options=f"-csearch_path={self.schema}",
             )
-            # `open=False` so a malformed conninfo or unreachable PG
-            # fails on first use (during a write retry loop, which
-            # logs it) rather than at construction (which would fail
-            # the whole pod boot silently from the operator's POV).
+            # min_size=0 means construction doesn't try to open any
+            # connections (psycopg_pool only eager-connects up to
+            # min_size); the first register_file() call lazy-creates
+            # one. `open=True` therefore doesn't block boot on PG
+            # reachability — and the previous `open=False` was a
+            # latent bug because nothing else here ever called
+            # `.open()`, so register_file always raised PoolClosed.
+            # Explicit `open=True` because psycopg_pool will flip the
+            # default to False in a future release.
             self._pool = ConnectionPool(
                 conninfo,
                 min_size=self.pool_min,
                 max_size=self.pool_max,
-                open=False,
+                open=True,
             )
 
     def close(self) -> None:

--- a/tests/integration/test_icebox_writer_integration.py
+++ b/tests/integration/test_icebox_writer_integration.py
@@ -24,7 +24,10 @@ pytestmark = pytest.mark.integration
 
 
 def _make_client(cfg) -> IceboxClient:
-    client = IceboxClient(
+    # No manual pool.open() here — the production main loop doesn't
+    # open the pool either; the previous test helper masked a real
+    # PoolClosed regression by opening it explicitly.
+    return IceboxClient(
         host=cfg.pg_host,
         port=cfg.pg_port,
         database=cfg.pg_database,
@@ -33,8 +36,6 @@ def _make_client(cfg) -> IceboxClient:
         schema=cfg.pg_schema,
         sslmode=cfg.pg_sslmode,
     )
-    client._pool.open(wait=True)
-    return client
 
 
 def _make_request(file_path: str = "s3://b/file.parquet", *, offset: int = 100) -> RegisterFileRequest:

--- a/tests/unit/test_icebox_daemon.py
+++ b/tests/unit/test_icebox_daemon.py
@@ -608,3 +608,124 @@ def test_transient_exception_tuple_covers_requests_and_pyiceberg():
         CommitStateUnknownException,
     }
     assert set(dm._TRANSIENT_EXCEPTIONS) == expected
+
+
+# ---------------------------------------------------------------------------
+# NoSuchTableError → bootstrap_table recovery
+# ---------------------------------------------------------------------------
+
+
+def test_loop_calls_bootstrap_table_on_no_such_table_with_pending_row():
+    """daemon_loop's NoSuchTableError catch-block must:
+      1. peek_oldest_pending_file_path on its own pool conn
+      2. invoke deps.bootstrap_table(file_path) when a row exists
+      3. NOT crash (next tick will load_table successfully)"""
+    import threading as _t
+    import time as _time
+
+    from pyiceberg.exceptions import NoSuchTableError
+
+    cfg = _make_cfg(committer_cadence_seconds=0.05)
+    deps, _ = _make_deps()
+    deps.load_table = MagicMock(side_effect=NoSuchTableError("table not found"))
+    deps.bootstrap_table = MagicMock(return_value=MagicMock())
+
+    # PG pool: peek_oldest_pending_file_path issues SELECT → fetchone
+    # returns the staged parquet path. Same conn handles the tick's
+    # load_table failure (which throws before any cursor is touched).
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = ("s3://b/seed.parquet",)
+    conn.cursor.return_value.__enter__ = lambda self: cursor
+    conn.cursor.return_value.__exit__ = lambda self, *a: None
+    pg_pool = MagicMock()
+    pg_pool.connection.return_value.__enter__ = lambda self: conn
+    pg_pool.connection.return_value.__exit__ = lambda self, *a: None
+
+    stop = _t.Event()
+    runner = _t.Thread(
+        target=dm.daemon_loop,
+        kwargs={"cfg": cfg, "pg_pool": pg_pool, "deps": deps, "stop_event": stop},
+        daemon=True,
+    )
+    runner.start()
+    _time.sleep(0.3)
+    stop.set()
+    runner.join(timeout=2.0)
+
+    deps.bootstrap_table.assert_called_with("s3://b/seed.parquet")
+    assert deps.bootstrap_table.call_count >= 1
+
+
+def test_loop_no_such_table_with_no_pending_rows_skips_bootstrap():
+    """No pending rows yet — we can't infer a schema, so don't call
+    bootstrap_table. The next tick will retry; eventually a writer
+    flushes and the bootstrap fires."""
+    import threading as _t
+    import time as _time
+
+    from pyiceberg.exceptions import NoSuchTableError
+
+    cfg = _make_cfg(committer_cadence_seconds=0.05)
+    deps, _ = _make_deps()
+    deps.load_table = MagicMock(side_effect=NoSuchTableError("table not found"))
+    deps.bootstrap_table = MagicMock()
+
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = None  # peek → no pending rows
+    conn.cursor.return_value.__enter__ = lambda self: cursor
+    conn.cursor.return_value.__exit__ = lambda self, *a: None
+    pg_pool = MagicMock()
+    pg_pool.connection.return_value.__enter__ = lambda self: conn
+    pg_pool.connection.return_value.__exit__ = lambda self, *a: None
+
+    stop = _t.Event()
+    runner = _t.Thread(
+        target=dm.daemon_loop,
+        kwargs={"cfg": cfg, "pg_pool": pg_pool, "deps": deps, "stop_event": stop},
+        daemon=True,
+    )
+    runner.start()
+    _time.sleep(0.3)
+    stop.set()
+    runner.join(timeout=2.0)
+
+    deps.bootstrap_table.assert_not_called()
+
+
+def test_loop_no_such_table_without_bootstrap_dep_logs_and_continues(caplog):
+    """If deps.bootstrap_table is None (mis-wired main.py), the loop
+    must log a WARNING and NOT crash. The daemon's one job is to stay
+    up."""
+    import logging as _logging
+    import threading as _t
+    import time as _time
+
+    from pyiceberg.exceptions import NoSuchTableError
+
+    cfg = _make_cfg(committer_cadence_seconds=0.05)
+    deps, _ = _make_deps()
+    deps.load_table = MagicMock(side_effect=NoSuchTableError("table not found"))
+    deps.bootstrap_table = None  # mis-wired
+
+    pg_pool = MagicMock()
+    pg_pool.connection.return_value.__enter__ = lambda self: MagicMock()
+    pg_pool.connection.return_value.__exit__ = lambda self, *a: None
+
+    stop = _t.Event()
+    runner = _t.Thread(
+        target=dm.daemon_loop,
+        kwargs={"cfg": cfg, "pg_pool": pg_pool, "deps": deps, "stop_event": stop},
+        daemon=True,
+    )
+    with caplog.at_level(_logging.WARNING, logger="icebox.daemon"):
+        runner.start()
+        _time.sleep(0.3)
+        stop.set()
+        runner.join(timeout=2.0)
+
+    assert any(
+        "bootstrap_table is None" in rec.message
+        for rec in caplog.records
+    ), "expected a WARNING when deps.bootstrap_table is missing"

--- a/tests/unit/test_icebox_iceberg.py
+++ b/tests/unit/test_icebox_iceberg.py
@@ -414,3 +414,194 @@ def test_commit_data_files_returns_none_summary_when_lookup_fails():
     assert result.summary is None
 
 
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_table_from_parquet
+# ---------------------------------------------------------------------------
+
+
+def _stage_parquet_bytes() -> bytes:
+    """Build the smallest parquet that mirrors what
+    millpond/icebox_sink._add_metadata_columns stamps: a few data
+    columns plus year/month/day/hour int32 partition columns and an
+    _inserted_at timestamp."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    table = pa.table({
+        "team_id": pa.array([1, 2], type=pa.int64()),
+        "event": pa.array(["a", "b"], type=pa.string()),
+        "_inserted_at": pa.array([0, 0], type=pa.timestamp("us", tz="UTC")),
+        "year": pa.array([2026, 2026], type=pa.int32()),
+        "month": pa.array([6, 6], type=pa.int32()),
+        "day": pa.array([8, 8], type=pa.int32()),
+        "hour": pa.array([16, 16], type=pa.int32()),
+    })
+    buf = pa.BufferOutputStream()
+    with pq.ParquetWriter(buf, table.schema) as w:
+        w.write_table(table)
+    return buf.getvalue().to_pybytes()
+
+
+def _fake_catalog_with_parquet(parquet_bytes: bytes):
+    """Catalog double whose `properties` are empty and whose FileIO
+    resolves to a single in-memory parquet, regardless of path. Returns
+    (catalog, create_table_calls) so tests can inspect what was created.
+    """
+    import io
+    from unittest.mock import MagicMock
+
+    catalog = MagicMock()
+    catalog.properties = {}
+    return catalog, _patch_file_io_to_return(parquet_bytes)
+
+
+def _patch_file_io_to_return(parquet_bytes: bytes):
+    """Return a monkeypatch helper bound at call time."""
+    return parquet_bytes
+
+
+def test_bootstrap_table_creates_table_with_inferred_schema_and_partition_spec(
+    monkeypatch,
+):
+    """Round-trip: bootstrap_table_from_parquet reads the parquet
+    footer, derives an Iceberg schema with deterministic field ids,
+    builds the year/month/day/hour identity PartitionSpec, and calls
+    catalog.create_table with both."""
+    import io
+    from unittest.mock import MagicMock
+
+    from icebox import iceberg as ib_mod
+
+    parquet_bytes = _stage_parquet_bytes()
+
+    # Patch load_file_io so we don't actually hit S3 — return a FileIO
+    # whose new_input(path).open() returns a BytesIO of our parquet.
+    fake_input = MagicMock()
+    fake_input.open.return_value.__enter__ = lambda self: io.BytesIO(parquet_bytes)
+    fake_input.open.return_value.__exit__ = lambda self, *a: None
+    fake_io = MagicMock()
+    fake_io.new_input.return_value = fake_input
+    monkeypatch.setattr(ib_mod, "load_file_io", lambda properties, location: fake_io)
+
+    catalog = MagicMock()
+    catalog.properties = {}
+    created_table = MagicMock()
+    catalog.create_table.return_value = created_table
+
+    result = ib_mod.bootstrap_table_from_parquet(
+        catalog=catalog,
+        namespace="kafka",
+        table_name="ai_events",
+        parquet_s3_path="s3://b/foo.parquet",
+    )
+
+    assert result is created_table
+    # create_table called exactly once with (identifier, schema, partition_spec).
+    catalog.create_table.assert_called_once()
+    call = catalog.create_table.call_args
+    assert call.args == (("kafka", "ai_events"),)
+    assert "schema" in call.kwargs and "partition_spec" in call.kwargs
+    schema = call.kwargs["schema"]
+    spec = call.kwargs["partition_spec"]
+
+    # Schema has every data column the parquet had.
+    names = {f.name for f in schema.fields}
+    assert {"team_id", "event", "_inserted_at", "year", "month", "day", "hour"} <= names
+
+    # PartitionSpec: 4 identity transforms on the int32 partition cols.
+    from pyiceberg.transforms import IdentityTransform
+    assert len(spec.fields) == 4
+    spec_by_name = {pf.name: pf for pf in spec.fields}
+    for name, expected_field_id in (
+        ("year", 1000), ("month", 1001), ("day", 1002), ("hour", 1003),
+    ):
+        assert name in spec_by_name
+        pf = spec_by_name[name]
+        assert pf.field_id == expected_field_id
+        assert isinstance(pf.transform, IdentityTransform)
+        # source_id points at the partition column itself (identity),
+        # NOT at _inserted_at.
+        assert schema.find_field(pf.source_id).name == name
+
+
+def test_bootstrap_table_returns_loaded_table_on_replica_race(monkeypatch):
+    """If another replica wins the create race, catalog.create_table
+    raises TableAlreadyExistsError; the helper falls back to load_table
+    and returns its result. Multiple icebox replicas can call this
+    concurrently without one crashing out."""
+    import io
+    from unittest.mock import MagicMock
+
+    from pyiceberg.exceptions import TableAlreadyExistsError
+
+    from icebox import iceberg as ib_mod
+
+    fake_input = MagicMock()
+    fake_input.open.return_value.__enter__ = lambda self: io.BytesIO(_stage_parquet_bytes())
+    fake_input.open.return_value.__exit__ = lambda self, *a: None
+    fake_io = MagicMock()
+    fake_io.new_input.return_value = fake_input
+    monkeypatch.setattr(ib_mod, "load_file_io", lambda properties, location: fake_io)
+
+    catalog = MagicMock()
+    catalog.properties = {}
+    catalog.create_table.side_effect = TableAlreadyExistsError("losing the race")
+    raced_table = MagicMock()
+    catalog.load_table.return_value = raced_table
+
+    result = ib_mod.bootstrap_table_from_parquet(
+        catalog=catalog,
+        namespace="kafka",
+        table_name="ai_events",
+        parquet_s3_path="s3://b/foo.parquet",
+    )
+
+    assert result is raced_table
+    catalog.load_table.assert_called_once_with(("kafka", "ai_events"))
+
+
+def test_bootstrap_table_rejects_parquet_missing_partition_column(monkeypatch):
+    """A parquet without year/month/day/hour stamped on isn't safe to
+    bootstrap from — the partition_values dict the writer ships would
+    fail to map to any field in the resulting table. Fail loudly."""
+    import io
+    from unittest.mock import MagicMock
+
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    from icebox import iceberg as ib_mod
+
+    # Same shape as _stage_parquet_bytes but without the "hour" column.
+    table = pa.table({
+        "team_id": pa.array([1], type=pa.int64()),
+        "year": pa.array([2026], type=pa.int32()),
+        "month": pa.array([6], type=pa.int32()),
+        "day": pa.array([8], type=pa.int32()),
+        # NOTE: no "hour"
+    })
+    buf = pa.BufferOutputStream()
+    with pq.ParquetWriter(buf, table.schema) as w:
+        w.write_table(table)
+    parquet_bytes = buf.getvalue().to_pybytes()
+
+    fake_input = MagicMock()
+    fake_input.open.return_value.__enter__ = lambda self: io.BytesIO(parquet_bytes)
+    fake_input.open.return_value.__exit__ = lambda self, *a: None
+    fake_io = MagicMock()
+    fake_io.new_input.return_value = fake_input
+    monkeypatch.setattr(ib_mod, "load_file_io", lambda properties, location: fake_io)
+
+    catalog = MagicMock()
+    catalog.properties = {}
+
+    with pytest.raises(ValueError, match="hour"):
+        ib_mod.bootstrap_table_from_parquet(
+            catalog=catalog,
+            namespace="kafka",
+            table_name="ai_events",
+            parquet_s3_path="s3://b/foo.parquet",
+        )
+    catalog.create_table.assert_not_called()

--- a/tests/unit/test_icebox_postgres_sync.py
+++ b/tests/unit/test_icebox_postgres_sync.py
@@ -172,6 +172,30 @@ def test_update_heartbeat_executes_without_args():
     cur.execute.assert_called_once_with(ps.UPDATE_HEARTBEAT_SQL)
 
 
+def test_peek_oldest_pending_file_path_returns_path_when_row_exists():
+    conn, cur = _mock_conn_with_cursor()
+    cur.fetchone.return_value = ("s3://b/oldest.parquet",)
+    assert ps.peek_oldest_pending_file_path(conn) == "s3://b/oldest.parquet"
+    cur.execute.assert_called_once_with(ps.PEEK_OLDEST_PENDING_FILE_PATH_SQL)
+
+
+def test_peek_oldest_pending_file_path_returns_none_when_empty():
+    """No pending rows = the caller (daemon's bootstrap path) skips
+    table creation and waits for the next writer flush."""
+    conn, cur = _mock_conn_with_cursor()
+    cur.fetchone.return_value = None
+    assert ps.peek_oldest_pending_file_path(conn) is None
+
+
+def test_peek_oldest_pending_file_path_sql_filters_pending_and_orders():
+    """FIFO + result='pending' so we don't seed table bootstrap off a
+    row that's already been committed or failed."""
+    sql = ps.PEEK_OLDEST_PENDING_FILE_PATH_SQL.lower()
+    assert "result='pending'" in sql
+    assert re.search(r"order\s+by\s+inserted_at", sql)
+    assert "limit 1" in sql
+
+
 class TestEnsureDatabaseExists:
     """Tactical DB-create-if-missing bootstrap. Mocked at the
     psycopg.connect boundary; the integration test exercises the real

--- a/tests/unit/test_icebox_sink.py
+++ b/tests/unit/test_icebox_sink.py
@@ -54,6 +54,38 @@ def _valid_register_req():
 # ---------------------------------------------------------------------------
 
 
+def test_pg_client_pool_is_open_after_construction():
+    """Regression: __post_init__ used to construct the pool with
+    `open=False` "to fail loud on first use", but nothing else here
+    ever called `.open()`, so `register_file` immediately raised
+    `psycopg_pool.PoolClosed: the pool 'pool-1' is not open yet`
+    against real PG.
+
+    With min_size=0 there's no eager-connection hazard at boot, so
+    letting psycopg_pool's default (open=True) hold is correct.
+
+    `pool.closed` is True both before .open() and after .close();
+    asserting it's False right after construction pins the open state.
+    """
+    client = IceboxClient(
+        host="bogus.invalid",  # never contacted at min_size=0
+        port=5432,
+        database="icebox",
+        username="megaberg",
+        password="secret",
+        schema="icebox_events",
+        sslmode="require",
+    )
+    try:
+        assert client._pool is not None
+        assert client._pool.closed is False, (
+            "IceboxClient._pool must be open after construction — see "
+            "the PoolClosed regression in icebox_sink.py __post_init__"
+        )
+    finally:
+        client.close()
+
+
 def _pg_client_with_mock_pool():
     """Build an IceboxClient with its connection pool replaced by a
     MagicMock that surfaces the cursor's fetchone()."""


### PR DESCRIPTION
## Summary

Two prod issues surfaced on the mw-dev rollout of the polling daemon (#72):

**1. Writer-side `PoolClosed`.** `IceboxClient.__post_init__` constructed the psycopg_pool with `open=False` on the theory that it would "fail loud on first use", but nothing else ever called `.open()`. Every `register_file()` immediately raised `psycopg_pool.PoolClosed: the pool 'pool-1' is not open yet`. With `min_size=0` there's no eager-connection hazard at boot, so the concern that motivated `open=False` didn't actually apply. The integration test helper hid the bug by calling `.open()` manually. Fix: explicit `open=True` + drop the helper's manual `.open()` so it mirrors prod.

**2. `NoSuchTableError` on fresh consumers.** The daemon's `_load_table()` does `catalog.load_table(...)` with no fallback. On any consumer whose Iceberg table has never been registered with Lakekeeper, every tick raises and the `icebox_files` queue grows unbounded. (The pre-#72 HTTP path had the same shape — just invisible because nobody was promoting new icebox consumers.)

   Fix: lazy bootstrap on first `NoSuchTableError`. New `iceberg.bootstrap_table_from_parquet` reads the parquet footer for the oldest pending row via PyIceberg's FileIO (one ranged S3 GET), derives the Iceberg schema with the same `assign_fresh_schema_ids(_pyarrow_to_schema_without_ids(...))` call the writer uses (so field ids line up with the writer's `parquet_stats`), and creates the table with `year/month/day/hour` identity partition spec matching what `_add_metadata_columns` always stamps. Idempotent on `TableAlreadyExistsError` (replica race).

   `daemon_loop` catches `NoSuchTableError`, peeks the oldest pending `file_path` via a new `postgres_sync.peek_oldest_pending_file_path` helper, and calls `deps.bootstrap_table(file_path)`. No pending row → log + sleep; the next writer flush materialises one and the next tick bootstraps.

## Test plan

- [x] 1018 unit + integration pass locally (`+10` new unit tests on top of the prior 959)
- [x] Unit regression for the pool bug: `IceboxClient._pool.closed is False` after `__post_init__`
- [x] Unit coverage for the bootstrap helper: happy path, replica race (`TableAlreadyExistsError` → `load_table`), and missing-partition-column rejection
- [x] Unit coverage for the daemon's `NoSuchTableError` branch: with-pending-row → calls `bootstrap_table`; no-pending-rows → skips; `deps.bootstrap_table=None` → WARNING, no crash
- [x] Unit coverage for `peek_oldest_pending_file_path`: returns path / returns None / SQL filters on `result='pending'` + orders by `inserted_at`
- [ ] Validate on mw-dev: after deploying, the 5 newly-promoted `*-icebox` consumers should self-heal — writer flushes register, daemon bootstraps the table on the next tick, files start committing