### PR TITLE
Compaction: env-tunable threads/memory and a per-run file cap

### DIFF
--- a/tests/unit/test_ducklake_maintenance.py
+++ b/tests/unit/test_ducklake_maintenance.py
@@ -161,11 +161,32 @@ class TestArgparse:
         args = self.parser.parse_args(["compact", "--tier", "1"])
         assert args.threads == 2
         assert args.memory_limit == "4GB"
+        assert args.max_compacted_files == 100000
 
     def test_compact_threads_memory_override(self):
-        args = self.parser.parse_args(["compact", "--tier", "2", "--threads", "8", "--memory-limit", "16GB"])
+        args = self.parser.parse_args(
+            ["compact", "--tier", "2", "--threads", "8", "--memory-limit", "16GB", "--max-compacted-files", "5000"]
+        )
         assert args.threads == 8
         assert args.memory_limit == "16GB"
+        assert args.max_compacted_files == 5000
+
+    def test_compact_tuning_env_overrides(self, monkeypatch):
+        """The K8s CronJob passes no CLI args; chart values tune via env."""
+        monkeypatch.setenv("COMPACTION_THREADS", "4")
+        monkeypatch.setenv("COMPACTION_MEMORY_LIMIT", "16GB")
+        monkeypatch.setenv("COMPACTION_MAX_FILES", "50000")
+        parser = ducklake_maintenance.build_parser()
+        args = parser.parse_args(["compact", "--tier", "1"])
+        assert args.threads == 4
+        assert args.memory_limit == "16GB"
+        assert args.max_compacted_files == 50000
+
+    def test_compact_cli_beats_env(self, monkeypatch):
+        monkeypatch.setenv("COMPACTION_MEMORY_LIMIT", "16GB")
+        parser = ducklake_maintenance.build_parser()
+        args = parser.parse_args(["compact", "--tier", "1", "--memory-limit", "8GB"])
+        assert args.memory_limit == "8GB"
 
 
 # ---------------------------------------------------------------------------
@@ -290,6 +311,40 @@ class TestSetCompactionTuning:
             ducklake_maintenance._set_compaction_tuning(conn, threads=2, memory_limit="4GB'; DROP TABLE x; --")
         # Sanitization happens before any execute; conn must not have been touched.
         conn.execute.assert_not_called()
+
+
+class TestCompactSql:
+    """compact() must pass the per-run file cap through to the merge CALL."""
+
+    def test_merge_call_includes_max_compacted_files(self):
+        conn = MagicMock()
+        result = MagicMock()
+        # candidate-count read, then ducklake_options read for target_file_size restore
+        result.fetchone.side_effect = [(614342, 242861636470), ("128MiB",)]
+        result.fetchall.return_value = []
+        conn.execute.return_value = result
+
+        ducklake_maintenance.compact(
+            conn, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=100000
+        )
+
+        merge_calls = [c.args[0] for c in conn.execute.call_args_list if "ducklake_merge_adjacent_files" in c.args[0]]
+        assert len(merge_calls) == 1
+        assert "max_compacted_files => 100000" in merge_calls[0]
+        assert "max_file_size =>" in merge_calls[0]
+
+    def test_dry_run_does_not_merge(self):
+        conn = MagicMock()
+        result = MagicMock()
+        result.fetchone.return_value = (614342, 242861636470)
+        conn.execute.return_value = result
+
+        ducklake_maintenance.compact(
+            conn, tier=1, table=None, dry_run=True, threads=2, memory_limit="16GB", max_compacted_files=100000
+        )
+
+        merge_calls = [c.args[0] for c in conn.execute.call_args_list if "ducklake_merge_adjacent_files" in c.args[0]]
+        assert not merge_calls
 
 
 class TestScopedTargetFileSize:

--- a/tools/ducklake_maintenance.py
+++ b/tools/ducklake_maintenance.py
@@ -704,6 +704,7 @@ def compact(
     dry_run: bool,
     threads: int,
     memory_limit: str,
+    max_compacted_files: int,
 ) -> None:
     """Compact files in tier N (1, 2, or 3) for the catalog or one table."""
     spec = TIERS[tier]
@@ -711,11 +712,12 @@ def compact(
     scope = f"table '{table}'" if table else "catalog-wide"
     range_str = f"[{min_b or 0}, {max_b}) bytes"
     log.info(
-        "Compact tier %d (%s): merge files %s into ~%s targets (dry_run=%s)",
+        "Compact tier %d (%s): merge files %s into ~%s targets, max %d files/run (dry_run=%s)",
         tier,
         scope,
         range_str,
         target,
+        max_compacted_files,
         dry_run,
     )
 
@@ -745,7 +747,12 @@ def compact(
         log.info("compact tier-%d: nothing to do, skipping merge", tier)
         return
 
-    args = [f"max_file_size => {max_b}"]
+    # Bound each run: the prod backlog (600k+ tier-1 candidates) is far too
+    # large for one merge transaction — it would blow the cron pod's
+    # activeDeadlineSeconds and produce one giant catalog commit. A capped
+    # run finishes in bounded time and the cron schedule grinds the backlog
+    # down incrementally.
+    args = [f"max_file_size => {max_b}", f"max_compacted_files => {max_compacted_files}"]
     if min_b is not None:
         args.append(f"min_file_size => {min_b}")
     if table:
@@ -863,16 +870,25 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--tier", type=int, choices=[1, 2, 3], required=True)
     p.add_argument("--table", default="", help="Limit to one table; empty = catalog-wide")
     p.add_argument("--dry-run", action="store_true")
+    # Defaults are env-overridable so the K8s CronJob (which runs the bare
+    # `just compact-all-tiers` recipe with no CLI args) can be tuned per
+    # environment from chart values without an image rebuild.
     p.add_argument(
         "--threads",
         type=_positive_int,
-        default=2,
-        help="DuckDB threads during the merge (default 2; raise cautiously, see DuckLake bug c8)",
+        default=_positive_int(os.environ.get("COMPACTION_THREADS", "2")),
+        help="DuckDB threads during the merge (default $COMPACTION_THREADS or 2; raise cautiously, see bug c8)",
     )
     p.add_argument(
         "--memory-limit",
-        default="4GB",
-        help="DuckDB memory_limit during the merge (default 4GB)",
+        default=os.environ.get("COMPACTION_MEMORY_LIMIT", "4GB"),
+        help="DuckDB memory_limit during the merge (default $COMPACTION_MEMORY_LIMIT or 4GB)",
+    )
+    p.add_argument(
+        "--max-compacted-files",
+        type=_positive_int,
+        default=_positive_int(os.environ.get("COMPACTION_MAX_FILES", "100000")),
+        help="Cap on files merged per run (default $COMPACTION_MAX_FILES or 100000)",
     )
 
     # compact-probe
@@ -948,7 +964,15 @@ def main(argv: list[str] | None = None) -> None:
             case "checkpoint":
                 checkpoint(conn)
             case "compact":
-                compact(conn, args.tier, args.table or None, args.dry_run, args.threads, args.memory_limit)
+                compact(
+                    conn,
+                    args.tier,
+                    args.table or None,
+                    args.dry_run,
+                    args.threads,
+                    args.memory_limit,
+                    args.max_compacted_files,
+                )
             case "compact-probe":
                 compact_probe(conn, args.table, args.max_compacted_files)
     except Exception:


### PR DESCRIPTION
## Summary
- Prod tier-1 compaction OOMs before merging anything: enumerating 614k candidates out of a 12.5M-row `ducklake_data_file` table needs more than the hardcoded 4GB DuckDB `memory_limit` (`Failed to get compaction file list ... 3.7 GiB/3.7 GiB used`).
- The K8s CronJob runs `just compact-all-tiers` with no CLI args, so the tuning flags were unreachable from chart values. `--threads` / `--memory-limit` defaults are now env-overridable (`COMPACTION_THREADS`, `COMPACTION_MEMORY_LIMIT`); CLI flags still take precedence.
- New `--max-compacted-files` (default 100000, env `COMPACTION_MAX_FILES`) bounds each merge call. The prod backlog is far too large for one transaction — a capped run finishes in bounded time and the 15-min cron grinds the backlog down incrementally instead of blowing `activeDeadlineSeconds` on one giant catalog commit.

## Notes
- The 2-thread/4GB defaults stay as-is (the bug-c8 safe floor); prod will set `COMPACTION_MEMORY_LIMIT=16GB` via chart values — 8Gi of unaccounted-allocation headroom on the 24Gi pod at threads=2.
- Companion charts change adds `compaction.extraEnv` and sets the prod value; inert until this image is promoted to the `prod` tag.

## Test plan
- [x] New unit tests: env overrides land in parsed args, CLI beats env, `max_compacted_files => N` reaches the merge CALL, dry-run never merges
- [x] 398 unit tests pass, ruff clean on changed paths

## Rollback
- Revert this PR; without the env vars set, behavior is identical to before except merges are capped at 100k files/run