### PR TITLE
Compaction: heartbeat with merge progress, ETA, and process RSS

### DIFF
--- a/tests/unit/test_ducklake_maintenance.py
+++ b/tests/unit/test_ducklake_maintenance.py
@@ -304,6 +304,9 @@ class TestSetCompactionTuning:
         assert "SET memory_limit = '8GB'" in executed
         assert "SET preserve_insertion_order = false" in executed
         assert "SET http_timeout = 600000" in executed
+        # progress tracking is only computed when the progress bar is enabled
+        assert "SET enable_progress_bar = true" in executed
+        assert "SET enable_progress_bar_print = false" in executed
 
     def test_rejects_injection_in_memory_limit(self):
         conn = MagicMock()
@@ -313,8 +316,75 @@ class TestSetCompactionTuning:
         conn.execute.assert_not_called()
 
 
+class TestHeartbeat:
+    """Heartbeat line formatting and degradation; no real threads or sleeps."""
+
+    def test_midway_progress_with_eta_and_rss(self, monkeypatch):
+        monkeypatch.setattr(ducklake_maintenance, "_progress_poll_warned", False)
+        monkeypatch.setattr(ducklake_maintenance, "_rss_bytes", lambda: 35.7 * 1024**3)
+        conn = MagicMock()
+        conn.query_progress.return_value = 25.0
+        # 25% in 600s -> 1800s -> 30m remaining
+        line = ducklake_maintenance._heartbeat_line(conn, "compact tier-1 merge", 600.0)
+        assert line == "compact tier-1 merge: 600s elapsed, ~25% merged, est. 30m remaining, rss=35.7GiB"
+
+    def test_no_query_running_elapsed_only(self, monkeypatch):
+        monkeypatch.setattr(ducklake_maintenance, "_rss_bytes", lambda: None)
+        conn = MagicMock()
+        conn.query_progress.return_value = -1.0
+        assert ducklake_maintenance._heartbeat_line(conn, "x", 60.0) == "x: 60s elapsed"
+
+    def test_sub_one_percent_suppressed(self, monkeypatch):
+        """Fractional early readings must not render '~0%' with a noise ETA."""
+        monkeypatch.setattr(ducklake_maintenance, "_rss_bytes", lambda: None)
+        conn = MagicMock()
+        conn.query_progress.return_value = 0.3
+        assert "%" not in ducklake_maintenance._heartbeat_line(conn, "x", 60.0)
+
+    def test_complete_has_no_eta(self, monkeypatch):
+        monkeypatch.setattr(ducklake_maintenance, "_rss_bytes", lambda: None)
+        conn = MagicMock()
+        conn.query_progress.return_value = 100.0
+        line = ducklake_maintenance._heartbeat_line(conn, "x", 60.0)
+        assert "~100% merged" in line
+        assert "remaining" not in line
+
+    def test_poll_failure_warns_once_and_degrades(self, monkeypatch, caplog):
+        monkeypatch.setattr(ducklake_maintenance, "_progress_poll_warned", False)
+        monkeypatch.setattr(ducklake_maintenance, "_rss_bytes", lambda: None)
+        conn = MagicMock()
+        conn.query_progress.side_effect = RuntimeError("gone")
+        with caplog.at_level(logging.WARNING, logger="maintenance"):
+            assert ducklake_maintenance._heartbeat_line(conn, "x", 60.0) == "x: 60s elapsed"
+            assert ducklake_maintenance._heartbeat_line(conn, "x", 120.0) == "x: 120s elapsed"
+        assert len([r for r in caplog.records if "query_progress" in r.message]) == 1
+
+    def test_rss_bytes_returns_positive_or_none(self):
+        rss = ducklake_maintenance._rss_bytes()
+        assert rss is None or rss > 0
+
+
 class TestCompactSql:
     """compact() must pass the per-run file cap through to the merge CALL."""
+
+    def test_merge_runs_under_heartbeat(self, monkeypatch):
+        """The heartbeat must wrap the merge call and be stopped afterwards."""
+        hb = MagicMock()
+        start = MagicMock(return_value=hb)
+        monkeypatch.setattr(ducklake_maintenance, "_start_heartbeat", start)
+
+        conn = MagicMock()
+        result = MagicMock()
+        result.fetchone.side_effect = [(100, 1000), ("128MiB",)]
+        result.fetchall.return_value = []
+        conn.execute.return_value = result
+
+        ducklake_maintenance.compact(
+            conn, tier=1, table=None, dry_run=False, threads=1, memory_limit="16GB", max_compacted_files=25000
+        )
+
+        start.assert_called_once_with(conn, "compact tier-1 merge")
+        hb.set.assert_called_once()
 
     def test_merge_call_includes_max_compacted_files(self):
         conn = MagicMock()

--- a/tools/ducklake_maintenance.py
+++ b/tools/ducklake_maintenance.py
@@ -23,6 +23,7 @@ import logging
 import os
 import re
 import sys
+import threading
 import time
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
@@ -690,11 +691,92 @@ def _set_compaction_tuning(conn: duckdb.DuckDBPyConnection, threads: int, memory
     # Default 30s is too tight for the multi-MB GETs/PUTs that compaction
     # drives; 10 min covers the worst-case S3 hiccup without livelocking.
     conn.execute("SET http_timeout = 600000")
+    # DuckDB only computes query progress when the progress bar is enabled;
+    # print-off keeps it out of the logs. This is what lets the heartbeat's
+    # cross-thread query_progress() poll return a percentage instead of -1.
+    conn.execute("SET enable_progress_bar = true")
+    conn.execute("SET enable_progress_bar_print = false")
     log.info(
         "compaction tuning: threads=%d memory_limit=%s preserve_insertion_order=false http_timeout=600000ms",
         threads,
         memory_limit,
     )
+
+
+def _rss_bytes() -> int | None:
+    """Current process RSS, or None if unreadable.
+
+    Reads /proc/self/status (the prod container is Linux); falls back to
+    getrusage peak RSS elsewhere (macOS dev — note: peak, not current).
+    RSS is the number that matters for compaction OOMs: DuckLake's merge
+    keeps a large working set OUTSIDE DuckDB's memory accounting (bug c8),
+    so the cgroup kills the pod while duckdb's own gauge looks healthy.
+    """
+    try:
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import resource
+
+        peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        return peak if sys.platform == "darwin" else peak * 1024
+    except Exception:
+        return None
+
+
+_progress_poll_warned = False
+
+
+def _heartbeat_line(conn: duckdb.DuckDBPyConnection, label: str, elapsed: float) -> str:
+    """One heartbeat log line: elapsed, merge percentage + ETA when DuckDB
+    reports one (sub-1% readings are noise on huge merges), and process RSS.
+
+    query_progress() failures degrade to elapsed-only (warned once): the
+    heartbeat is decoration and must never kill the operation it watches.
+    """
+    global _progress_poll_warned
+    parts = [f"{label}: {elapsed:.0f}s elapsed"]
+    try:
+        pct = float(conn.query_progress())
+    except Exception:
+        pct = -1.0
+        if not _progress_poll_warned:
+            _progress_poll_warned = True
+            log.warning("query_progress() poll failed; heartbeat continues without percentages", exc_info=True)
+    if pct >= 100:
+        parts.append("~100% merged")
+    elif pct >= 1:
+        eta = elapsed * (100.0 - pct) / pct
+        parts.append(f"~{pct:.0f}% merged, est. {eta / 60:.0f}m remaining")
+    rss = _rss_bytes()
+    if rss is not None:
+        parts.append(f"rss={rss / 1024**3:.1f}GiB")
+    return ", ".join(parts)
+
+
+def _start_heartbeat(conn: duckdb.DuckDBPyConnection, label: str, interval_s: float = 60.0) -> threading.Event:
+    """Log a heartbeat line every `interval_s` while a long blocking call runs
+    on `conn` from the main thread. Returns the Event to .set() when done
+    (use try/finally). Daemon thread; safe to leak on crash.
+
+    Cross-thread query_progress() is a lock-free atomic read of executor
+    state (it's how Jupyter's progress bar works) — worst case is a stale
+    reading, never corruption. The connection's single query slot belongs to
+    the watched call, so the percentage can't be someone else's query.
+    """
+    stop = threading.Event()
+    start_t = time.monotonic()
+
+    def _tick() -> None:
+        while not stop.wait(timeout=interval_s):
+            log.info("%s", _heartbeat_line(conn, label, time.monotonic() - start_t))
+
+    threading.Thread(target=_tick, daemon=True).start()
+    return stop
 
 
 def compact(
@@ -761,8 +843,12 @@ def compact(
         sql = f"CALL ducklake_merge_adjacent_files('{ATTACH_NAME}', {', '.join(args)})"
 
     _set_compaction_tuning(conn, threads, memory_limit)
-    with _scoped_target_file_size(conn, target):
-        result = conn.execute(sql).fetchall()
+    heartbeat = _start_heartbeat(conn, f"compact tier-{tier} merge")
+    try:
+        with _scoped_target_file_size(conn, target):
+            result = conn.execute(sql).fetchall()
+    finally:
+        heartbeat.set()
     for row in result:
         log.info("compact tier-%d: %s", tier, row)
 


### PR DESCRIPTION
## Summary
- `ducklake_merge_adjacent_files` runs in total silence for up to the 6h deadline — today's prod debugging meant kubectl-spelunking pod memory to learn anything. A daemon heartbeat thread now logs once a minute during the merge: elapsed, DuckDB's merge percentage + linear ETA, and process RSS.
- Verified empirically that DuckDB's cross-thread `query_progress()` API reports a clean monotone curve through `merge_adjacent_files` (it requires `enable_progress_bar=true`, now set in `_set_compaction_tuning` with print disabled).
- RSS comes from `/proc/self/status` (getrusage-peak fallback off-Linux) and is the number that actually matters for compaction OOMs: DuckLake's merge keeps a large working set outside DuckDB's memory accounting (bug c8) — measured ~20Gi untracked on prod's tier-1 backlog — so the cgroup kills the pod while duckdb's own gauge looks healthy. Today's incident would have been diagnosable from the first failed run's logs: `compact tier-1 merge: 300s elapsed, ~12% merged, est. 37m remaining, rss=35.7GiB`.

## Notes
- Heartbeat is decoration: `query_progress()` failures warn once and degrade to elapsed-only; sub-1% readings are suppressed (noise ETA); the thread is daemon and stopped via try/finally.
- Cross-thread `query_progress()` is a lock-free atomic read of executor state; the connection's single query slot belongs to the merge, so the percentage can't be another query's.

## Test plan
- [x] 6 unit tests on line formatting/degradation (midway+ETA+RSS, -1, sub-1%, 100%, warn-once, RSS sanity) + wiring test (merge runs under a started-then-stopped heartbeat)
- [x] 405 unit tests pass, ruff clean
- [x] Live local run over a real 300-file DuckLake merge: percentages/ETA/RSS ticked correctly

## Rollback
- Revert this PR; the merge runs silently as before