### PR TITLE
Heartbeat: render sub-1% progress verbatim instead of suppressing

### DIFF
--- a/tests/unit/test_ducklake_maintenance.py
+++ b/tests/unit/test_ducklake_maintenance.py
@@ -331,15 +331,25 @@ class TestHeartbeat:
     def test_no_query_running_elapsed_only(self, monkeypatch):
         monkeypatch.setattr(ducklake_maintenance, "_rss_bytes", lambda: None)
         conn = MagicMock()
-        conn.query_progress.return_value = -1.0
+        conn.query_progress.return_value = -0.5  # anything < 0
         assert ducklake_maintenance._heartbeat_line(conn, "x", 60.0) == "x: 60s elapsed"
 
-    def test_sub_one_percent_suppressed(self, monkeypatch):
-        """Fractional early readings must not render '~0%' with a noise ETA."""
+    def test_sub_one_percent_shown_without_eta(self, monkeypatch):
+        """Sub-1% is rendered verbatim (liveness signal) but without an ETA."""
         monkeypatch.setattr(ducklake_maintenance, "_rss_bytes", lambda: None)
         conn = MagicMock()
         conn.query_progress.return_value = 0.3
-        assert "%" not in ducklake_maintenance._heartbeat_line(conn, "x", 60.0)
+        line = ducklake_maintenance._heartbeat_line(conn, "x", 60.0)
+        assert "~0.3% merged" in line
+        assert "remaining" not in line
+
+    def test_negative_progress_elapsed_only(self, monkeypatch):
+        """True -1 (no query running) produces elapsed-only — no % noise."""
+        monkeypatch.setattr(ducklake_maintenance, "_rss_bytes", lambda: None)
+        conn = MagicMock()
+        conn.query_progress.return_value = -1.0
+        line = ducklake_maintenance._heartbeat_line(conn, "x", 60.0)
+        assert "%" not in line
 
     def test_complete_has_no_eta(self, monkeypatch):
         monkeypatch.setattr(ducklake_maintenance, "_rss_bytes", lambda: None)

--- a/tools/ducklake_maintenance.py
+++ b/tools/ducklake_maintenance.py
@@ -752,6 +752,15 @@ def _heartbeat_line(conn: duckdb.DuckDBPyConnection, label: str, elapsed: float)
     elif pct >= 1:
         eta = elapsed * (100.0 - pct) / pct
         parts.append(f"~{pct:.0f}% merged, est. {eta / 60:.0f}m remaining")
+    elif pct >= 0:
+        # Sub-1% readings are rendered verbatim rather than suppressed: when the
+        # merge cap is much smaller than the total file population, DuckLake's
+        # progress denominator may cover the full catalog rather than the capped
+        # subset, so the reading stays <1% for the whole run. A slowly climbing
+        # "~0.4% merged" is still a liveness signal and distinguishes a live
+        # merge from a hung one. No ETA: extrapolating from a fraction-of-percent
+        # would produce absurdly large numbers.
+        parts.append(f"~{pct:.1f}% merged (sub-1%; ETA unavailable)")
     rss = _rss_bytes()
     if rss is not None:
         parts.append(f"rss={rss / 1024**3:.1f}GiB")


### PR DESCRIPTION
## Summary

When `max_compacted_files` is much smaller than the total file population, DuckLake's progress denominator likely covers the full catalog rather than the capped subset — so the percentage stays <1% for the whole run. The previous suppression (borrowed from viaduck's scan-ETA logic where sub-1% was genuine noise) rendered these as silence, indistinguishable from a hung merge. Sub-1% readings are now shown as `~0.4% merged (sub-1%; ETA unavailable)` — a real liveness signal. No ETA since extrapolating from a fraction-of-a-percent produces absurd numbers. True `-1` (no query running) is still elapsed-only.

## Test plan
- [x] `test_sub_one_percent_shown_without_eta`: 0.3% renders with value, no ETA
- [x] `test_negative_progress_elapsed_only`: -1 still elapsed-only
- [x] 406 unit tests pass, ruff clean

## Rollback
- Revert this PR; merges run silently below 1% as before