### PR TITLE
Heartbeat: add network I/O rate and cover compact_probe

### DIFF
--- a/tests/unit/test_ducklake_maintenance.py
+++ b/tests/unit/test_ducklake_maintenance.py
@@ -319,49 +319,94 @@ class TestSetCompactionTuning:
 class TestHeartbeat:
     """Heartbeat line formatting and degradation; no real threads or sleeps."""
 
+    def _line(self, conn, label, elapsed, prev_net=None, interval_s=60.0):
+        """Helper: call _heartbeat_line and return just the string."""
+        line, _ = ducklake_maintenance._heartbeat_line(conn, label, elapsed, prev_net, interval_s)
+        return line
+
     def test_midway_progress_with_eta_and_rss(self, monkeypatch):
         monkeypatch.setattr(ducklake_maintenance, "_progress_poll_warned", False)
         monkeypatch.setattr(ducklake_maintenance, "_rss_bytes", lambda: 35.7 * 1024**3)
+        monkeypatch.setattr(ducklake_maintenance, "_net_bytes", lambda: None)
         conn = MagicMock()
         conn.query_progress.return_value = 25.0
         # 25% in 600s -> 1800s -> 30m remaining
-        line = ducklake_maintenance._heartbeat_line(conn, "compact tier-1 merge", 600.0)
-        assert line == "compact tier-1 merge: 600s elapsed, ~25% merged, est. 30m remaining, rss=35.7GiB"
+        assert self._line(conn, "compact tier-1 merge", 600.0) == \
+            "compact tier-1 merge: 600s elapsed, ~25% merged, est. 30m remaining, rss=35.7GiB"
 
     def test_no_query_running_elapsed_only(self, monkeypatch):
         monkeypatch.setattr(ducklake_maintenance, "_rss_bytes", lambda: None)
+        monkeypatch.setattr(ducklake_maintenance, "_net_bytes", lambda: None)
         conn = MagicMock()
         conn.query_progress.return_value = -1.0
-        assert ducklake_maintenance._heartbeat_line(conn, "x", 60.0) == "x: 60s elapsed"
+        assert self._line(conn, "x", 60.0) == "x: 60s elapsed"
 
-    def test_sub_one_percent_suppressed(self, monkeypatch):
-        """Fractional early readings must not render '~0%' with a noise ETA."""
+    def test_sub_one_percent_shown_without_eta(self, monkeypatch):
+        """Sub-1% is rendered verbatim (liveness signal) but without an ETA."""
         monkeypatch.setattr(ducklake_maintenance, "_rss_bytes", lambda: None)
+        monkeypatch.setattr(ducklake_maintenance, "_net_bytes", lambda: None)
         conn = MagicMock()
         conn.query_progress.return_value = 0.3
-        assert "%" not in ducklake_maintenance._heartbeat_line(conn, "x", 60.0)
+        line = self._line(conn, "x", 60.0)
+        assert "~0.3% merged" in line
+        assert "remaining" not in line
 
     def test_complete_has_no_eta(self, monkeypatch):
         monkeypatch.setattr(ducklake_maintenance, "_rss_bytes", lambda: None)
+        monkeypatch.setattr(ducklake_maintenance, "_net_bytes", lambda: None)
         conn = MagicMock()
         conn.query_progress.return_value = 100.0
-        line = ducklake_maintenance._heartbeat_line(conn, "x", 60.0)
+        line = self._line(conn, "x", 60.0)
         assert "~100% merged" in line
         assert "remaining" not in line
 
     def test_poll_failure_warns_once_and_degrades(self, monkeypatch, caplog):
         monkeypatch.setattr(ducklake_maintenance, "_progress_poll_warned", False)
         monkeypatch.setattr(ducklake_maintenance, "_rss_bytes", lambda: None)
+        monkeypatch.setattr(ducklake_maintenance, "_net_bytes", lambda: None)
         conn = MagicMock()
         conn.query_progress.side_effect = RuntimeError("gone")
         with caplog.at_level(logging.WARNING, logger="maintenance"):
-            assert ducklake_maintenance._heartbeat_line(conn, "x", 60.0) == "x: 60s elapsed"
-            assert ducklake_maintenance._heartbeat_line(conn, "x", 120.0) == "x: 120s elapsed"
+            assert self._line(conn, "x", 60.0) == "x: 60s elapsed"
+            assert self._line(conn, "x", 120.0) == "x: 120s elapsed"
         assert len([r for r in caplog.records if "query_progress" in r.message]) == 1
+
+    def test_network_rate_shown_when_prev_net_available(self, monkeypatch):
+        monkeypatch.setattr(ducklake_maintenance, "_rss_bytes", lambda: None)
+        monkeypatch.setattr(ducklake_maintenance, "_net_bytes", lambda: (2_000_000_000, 500_000_000))
+        conn = MagicMock()
+        conn.query_progress.return_value = -1.0
+        prev_net = (1_000_000_000, 300_000_000)  # 1GB rx, 300MB tx before
+        # over 10s: rx=(2G-1G)/10/1024^2=95.4MiB/s, tx=(500M-300M)/10/1024^2=19.1MiB/s
+        line = self._line(conn, "x", 60.0, prev_net=prev_net, interval_s=10.0)
+        assert "↓95.4/↑19.1 MiB/s" in line
+
+    def test_network_rate_wrap_shows_zero_not_negative(self, monkeypatch):
+        """32-bit counter wrap must not produce a negative rate in the log."""
+        monkeypatch.setattr(ducklake_maintenance, "_rss_bytes", lambda: None)
+        monkeypatch.setattr(ducklake_maintenance, "_net_bytes", lambda: (100, 100))
+        conn = MagicMock()
+        conn.query_progress.return_value = -1.0
+        prev_net = (2**32 - 1, 2**32 - 1)  # just before wrap
+        line = self._line(conn, "x", 60.0, prev_net=prev_net, interval_s=10.0)
+        assert "↓0.0/↑0.0 MiB/s" in line
+        assert "-" not in line.split("net=")[-1]
+
+    def test_network_rate_absent_without_prev_net(self, monkeypatch):
+        monkeypatch.setattr(ducklake_maintenance, "_rss_bytes", lambda: None)
+        monkeypatch.setattr(ducklake_maintenance, "_net_bytes", lambda: (1_000_000, 1_000_000))
+        conn = MagicMock()
+        conn.query_progress.return_value = -1.0
+        line = self._line(conn, "x", 60.0, prev_net=None)
+        assert "MiB/s" not in line
 
     def test_rss_bytes_returns_positive_or_none(self):
         rss = ducklake_maintenance._rss_bytes()
         assert rss is None or rss > 0
+
+    def test_net_bytes_returns_tuple_or_none(self):
+        net = ducklake_maintenance._net_bytes()
+        assert net is None or (isinstance(net, tuple) and len(net) == 2 and all(v >= 0 for v in net))
 
 
 class TestCompactSql:

--- a/tools/ducklake_maintenance.py
+++ b/tools/ducklake_maintenance.py
@@ -736,15 +736,42 @@ def _rss_bytes() -> int | None:
         return None
 
 
+def _net_bytes() -> tuple[int, int] | None:
+    """Current cumulative (rx_bytes, tx_bytes) for eth0, or None if unreadable.
+
+    Reads /proc/self/net/dev (Linux only). The heartbeat diffs two readings
+    across the interval to compute MB/s — distinguishes the S3 read phase
+    (high RX, rising RSS) from the catalog-scan phase (low network, flat RSS)
+    without manual pod exec sampling.
+    """
+    try:
+        with open("/proc/self/net/dev") as f:
+            for line in f:
+                if "eth0:" in line:
+                    fields = line.split()
+                    return int(fields[1]), int(fields[9])
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
 _progress_poll_warned = False
 
 
-def _heartbeat_line(conn: duckdb.DuckDBPyConnection, label: str, elapsed: float) -> str:
-    """One heartbeat log line: elapsed, merge percentage + ETA when DuckDB
-    reports one (sub-1% readings are noise on huge merges), and process RSS.
+def _heartbeat_line(
+    conn: duckdb.DuckDBPyConnection,
+    label: str,
+    elapsed: float,
+    prev_net: tuple[int, int] | None,
+    interval_s: float,
+) -> tuple[str, tuple[int, int] | None]:
+    """One heartbeat log line: elapsed, merge percentage + ETA, RSS, network rate.
 
-    query_progress() failures degrade to elapsed-only (warned once): the
-    heartbeat is decoration and must never kill the operation it watches.
+    Returns (line, current_net) so the caller can pass current_net back as
+    prev_net on the next tick to compute the per-interval rate.
+
+    query_progress() failures degrade gracefully (warned once): the heartbeat
+    is decoration and must never kill the operation it watches.
     """
     global _progress_poll_warned
     parts = [f"{label}: {elapsed:.0f}s elapsed"]
@@ -760,10 +787,19 @@ def _heartbeat_line(conn: duckdb.DuckDBPyConnection, label: str, elapsed: float)
     elif pct >= 1:
         eta = elapsed * (100.0 - pct) / pct
         parts.append(f"~{pct:.0f}% merged, est. {eta / 60:.0f}m remaining")
+    elif pct >= 0:
+        parts.append(f"~{pct:.1f}% merged (sub-1%; ETA unavailable)")
     rss = _rss_bytes()
     if rss is not None:
         parts.append(f"rss={rss / 1024**3:.1f}GiB")
-    return ", ".join(parts)
+    cur_net = _net_bytes()
+    if cur_net is not None and prev_net is not None and interval_s > 0:
+        # max(0, ...) guards against 32-bit counter wrap (~4 GiB rolls over at
+        # ~200 MB/s in 20s); a negative delta produces a misleading log line.
+        rx_mbs = max(0, cur_net[0] - prev_net[0]) / interval_s / 1024**2
+        tx_mbs = max(0, cur_net[1] - prev_net[1]) / interval_s / 1024**2
+        parts.append(f"net=↓{rx_mbs:.1f}/↑{tx_mbs:.1f} MiB/s")
+    return ", ".join(parts), cur_net
 
 
 def _start_heartbeat(conn: duckdb.DuckDBPyConnection, label: str, interval_s: float = 60.0) -> threading.Event:
@@ -780,8 +816,10 @@ def _start_heartbeat(conn: duckdb.DuckDBPyConnection, label: str, interval_s: fl
     start_t = time.monotonic()
 
     def _tick() -> None:
+        prev_net = _net_bytes()
         while not stop.wait(timeout=interval_s):
-            log.info("%s", _heartbeat_line(conn, label, time.monotonic() - start_t))
+            line, prev_net = _heartbeat_line(conn, label, time.monotonic() - start_t, prev_net, interval_s)
+            log.info("%s", line)
 
     threading.Thread(target=_tick, daemon=True).start()
     return stop
@@ -866,10 +904,20 @@ def compact_probe(conn: duckdb.DuckDBPyConnection, table: str, max_compacted_fil
     if not _SETTING_VALUE_RE.match(table):
         raise ValueError(f"Illegal character in table name: {table!r}")
     log.info("compact-probe: table=%s max_compacted_files=%d", table, max_compacted_files)
-    result = conn.execute(
-        f"CALL ducklake_merge_adjacent_files('{ATTACH_NAME}', '{table}', "
-        f"max_compacted_files => {max_compacted_files})"
-    ).fetchall()
+    # Enable progress tracking so the heartbeat's query_progress() poll returns
+    # a real percentage rather than -1. Only the bar settings are needed here;
+    # the full _set_compaction_tuning is intentionally skipped (no memory/thread
+    # changes — compact_probe is a lightweight single-table probe).
+    conn.execute("SET enable_progress_bar = true")
+    conn.execute("SET enable_progress_bar_print = false")
+    heartbeat = _start_heartbeat(conn, f"compact-probe {table}")
+    try:
+        result = conn.execute(
+            f"CALL ducklake_merge_adjacent_files('{ATTACH_NAME}', '{table}', "
+            f"max_compacted_files => {max_compacted_files})"
+        ).fetchall()
+    finally:
+        heartbeat.set()
     for row in result:
         log.info("compact-probe: %s", row)
 


### PR DESCRIPTION
## Summary
- `compact_probe` was silent (no heartbeat) — now wrapped with `_start_heartbeat` like `compact`. Added `enable_progress_bar` settings so the percentage poll works.
- Heartbeat lines now include per-interval S3 throughput: `net=↓128.4/↑24.1 MiB/s`, diffed across the 60s tick. This directly answers "are we in the catalog-scan phase (near-zero network) or the S3-merge phase (high RX)" without manual pod exec sampling.
- Counter wrap guarded with `max(0, delta)` for 32-bit `/proc/net/dev` kernels.

## Changes
- `_net_bytes()`: reads `/proc/self/net/dev` for eth0 cumulative RX/TX bytes; returns `None` on any error.
- `_heartbeat_line()`: signature updated to accept `prev_net` + `interval_s`, returns `(str, cur_net)`. Caller threads the net state between ticks.
- `compact_probe()`: progress bar enabled, heartbeat started/stopped via try/finally.

## Test plan
- [x] Network rate shown when `prev_net` available; absent when not
- [x] Counter wrap (32-bit rollover) renders `↓0.0/↑0.0` not negative
- [x] 409 tests pass, ruff clean

## Rollback
- Revert this PR; heartbeat reverts to RSS-only, `compact_probe` runs silently as before