### PR TITLE
Tiers: target 128MiB for all tiers

### DIFF
--- a/tools/ducklake_maintenance.py
+++ b/tools/ducklake_maintenance.py
@@ -54,8 +54,8 @@ _SETTING_VALUE_RE = re.compile(r"^[a-zA-Z0-9_.:/\-@+=]+$")
 # higher tier. Targets are MiB (binary) so they line up with the byte literals.
 _MIB = 1024 * 1024
 TIERS = {
-    1: {"min": None, "max": 1 * _MIB, "target": "5MiB"},  # < 1 MiB    -> ~5 MiB
-    2: {"min": 1 * _MIB, "max": 10 * _MIB, "target": "32MiB"},  # [1, 10) MiB -> ~32 MiB
+    1: {"min": None, "max": 1 * _MIB, "target": "128MiB"},  # < 1 MiB    -> ~128 MiB
+    2: {"min": 1 * _MIB, "max": 10 * _MIB, "target": "128MiB"},  # [1, 10) MiB -> ~128 MiB
     3: {"min": 10 * _MIB, "max": 64 * _MIB, "target": "128MiB"},  # [10, 64) MiB -> ~128 MiB
 }
 


### PR DESCRIPTION
## Summary
All three compaction tiers now target 128MiB output files. The previous 5MiB tier-1 and 32MiB tier-2 targets produced too many small output files — a partition with 300 × 390KB files would merge into ~30 × 5MiB files rather than 1 × 128MiB file, leaving fragmentation ratios of 30 instead of 1. Since the real goal is one file per closed hour partition, 128MiB is the right target across all tiers.

## Test plan
- [x] 409 tests pass, ruff clean

## Rollback
- Revert this PR