### PR TITLE
ci: pin pages workflow actions to latest SHAs

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -24,12 +24,12 @@ jobs:
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-    - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+    - uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v5
 
-    - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+    - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v3
       with:
         path: tools/
 
     - name: Deploy
       id: deploy
-      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Summary
The pages workflow was failing with `actions/upload-artifact@v4 is not allowed — all actions must be pinned to a full-length commit SHA`. The `upload-pages-artifact@56afc609` was pulling in `upload-artifact@v4` as an unpinned transitive dependency. Updated to latest SHAs for `configure-pages`, `upload-pages-artifact`, and `deploy-pages` which fix the transitive pinning.

## Rollback
- Revert this PR