### PR TITLE
consumer: make Kafka auto.offset.reset configurable

### DIFF
--- a/millpond/config.py
+++ b/millpond/config.py
@@ -42,6 +42,11 @@ class Config:
     fetch_max_wait_ms: int
     consume_batch_size: int
     stats_interval_ms: int
+    # Applied only when no offset is committed for (group_id, partition).
+    # "earliest" replays the whole retention window — appropriate for catch-up
+    # / backfill consumers. "latest" starts at the head — appropriate for NRT
+    # consumers (filter-keep workflows) where backlog replay is wasted I/O.
+    auto_offset_reset: str
 
     # Broker source label for metrics (e.g. "msk", "warpstream")
     broker_source: str
@@ -209,6 +214,22 @@ def _load_sort_by() -> tuple[str, ...] | None:
     return fields
 
 
+_VALID_AUTO_OFFSET_RESET = ("earliest", "latest")
+
+
+def _load_auto_offset_reset() -> str:
+    """Parse KAFKA_AUTO_OFFSET_RESET (default: 'earliest' for back-compat).
+
+    librdkafka also accepts 'error', but for a streaming sink that's never
+    what you want — every fresh consumer group would crash. Restrict to the
+    two policies that make sense in this codebase.
+    """
+    raw = os.environ.get("KAFKA_AUTO_OFFSET_RESET", "earliest").strip().lower()
+    if raw not in _VALID_AUTO_OFFSET_RESET:
+        raise RuntimeError(f"KAFKA_AUTO_OFFSET_RESET={raw!r} must be one of {_VALID_AUTO_OFFSET_RESET}")
+    return raw
+
+
 def _load_ducklake_fields() -> dict[str, str | None]:
     ducklake_table = _require("DUCKLAKE_TABLE")
     if not _SAFE_TABLE_NAME.match(ducklake_table):
@@ -269,6 +290,17 @@ def load() -> Config:
         for k, v in os.environ.items()
         if k.startswith(_KAFKA_CONSUMER_PREFIX)
     )
+    # auto.offset.reset has a dedicated env var with validation + an
+    # earliest/latest allowlist. The KAFKA_CONSUMER_* passthrough would
+    # silently lose to consumer.create()'s explicit `cfg.auto_offset_reset`
+    # write, so an operator setting KAFKA_CONSUMER_AUTO_OFFSET_RESET=latest
+    # would deploy thinking it set the policy and instead get the default.
+    # Refuse the ambiguous configuration loudly at startup.
+    if any(k == "auto.offset.reset" for k, _ in kafka_overrides):
+        raise RuntimeError(
+            "KAFKA_CONSUMER_AUTO_OFFSET_RESET is not honored — use KAFKA_AUTO_OFFSET_RESET "
+            "(allowed: earliest, latest) so the value gets validated."
+        )
 
     filter_keep_field, filter_drop_field, filter_values = _load_filter_fields()
     sort_by = _load_sort_by()
@@ -286,6 +318,7 @@ def load() -> Config:
         fetch_max_wait_ms=int(os.environ.get("FETCH_MAX_WAIT_MS", "500")),
         consume_batch_size=int(os.environ.get("CONSUME_BATCH_SIZE", "1000")),
         stats_interval_ms=int(os.environ.get("STATS_INTERVAL_MS", "5000")),
+        auto_offset_reset=_load_auto_offset_reset(),
         broker_source=os.environ.get("BROKER_SOURCE", "").strip().lower(),
         filter_keep_field=filter_keep_field,
         filter_drop_field=filter_drop_field,

--- a/millpond/consumer.py
+++ b/millpond/consumer.py
@@ -124,7 +124,7 @@ def create(cfg: Config) -> Consumer:
     consumer_config = {
         **_base_kafka_config(cfg),
         "group.id": cfg.group_id,
-        "auto.offset.reset": "earliest",
+        "auto.offset.reset": cfg.auto_offset_reset,
         "enable.auto.commit": False,
         "enable.auto.offset.store": False,
         "fetch.min.bytes": cfg.fetch_min_bytes,
@@ -140,7 +140,9 @@ def create(cfg: Config) -> Consumer:
     consumer = Consumer(consumer_config)
 
     # OFFSET_STORED: resume from committed offset in __consumer_offsets.
-    # Falls back to auto.offset.reset (earliest) if no offset committed.
+    # Falls back to auto.offset.reset (cfg.auto_offset_reset) if no offset
+    # committed — set this to "latest" for fresh NRT consumers so they don't
+    # replay the entire retention window before catching up.
     # Critical for replica count changes — new pods must resume from offsets
     # committed by whichever pod previously owned each partition.
     consumer.assign([TopicPartition(cfg.topic, p, OFFSET_STORED) for p in my_partitions])

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -58,6 +58,7 @@ class TestLoad:
         assert cfg.fetch_max_wait_ms == 500
         assert cfg.consume_batch_size == 1000
         assert cfg.stats_interval_ms == 5000
+        assert cfg.auto_offset_reset == "earliest"
         # PostHog Logs export: off by default.
         assert cfg.posthog_project_token is None
         assert cfg.posthog_logs_endpoint == "https://us.i.posthog.com/i/v1/logs"
@@ -145,6 +146,38 @@ class TestLoad:
     def test_kafka_consumer_overrides_default_empty(self):
         cfg = load()
         assert cfg.kafka_config_overrides == ()
+
+    def test_auto_offset_reset_latest(self, monkeypatch):
+        monkeypatch.setenv("KAFKA_AUTO_OFFSET_RESET", "latest")
+        cfg = load()
+        assert cfg.auto_offset_reset == "latest"
+
+    def test_auto_offset_reset_is_case_and_whitespace_insensitive(self, monkeypatch):
+        monkeypatch.setenv("KAFKA_AUTO_OFFSET_RESET", "  LATEST ")
+        cfg = load()
+        assert cfg.auto_offset_reset == "latest"
+
+    def test_auto_offset_reset_invalid_rejected(self, monkeypatch):
+        monkeypatch.setenv("KAFKA_AUTO_OFFSET_RESET", "error")
+        with pytest.raises(RuntimeError, match="KAFKA_AUTO_OFFSET_RESET"):
+            load()
+
+    def test_auto_offset_reset_empty_string_rejected(self, monkeypatch):
+        """Empty string fails validation rather than falling back to default.
+
+        Fail-loud matches the rest of the validation philosophy in this file —
+        an unintentionally-empty env var (e.g. unset chart value rendering as
+        "") is a config bug, not a silent default trigger."""
+        monkeypatch.setenv("KAFKA_AUTO_OFFSET_RESET", "")
+        with pytest.raises(RuntimeError, match="KAFKA_AUTO_OFFSET_RESET"):
+            load()
+
+    def test_auto_offset_reset_collision_with_kafka_consumer_passthrough(self, monkeypatch):
+        """KAFKA_CONSUMER_AUTO_OFFSET_RESET would silently lose to the explicit
+        cfg.auto_offset_reset write in consumer.create(); refuse the ambiguity."""
+        monkeypatch.setenv("KAFKA_CONSUMER_AUTO_OFFSET_RESET", "latest")
+        with pytest.raises(RuntimeError, match="KAFKA_CONSUMER_AUTO_OFFSET_RESET is not honored"):
+            load()
 
     def test_table_label(self):
         cfg = load()

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -150,6 +150,7 @@ def _make_cfg(**overrides) -> Config:
         fetch_max_wait_ms=500,
         consume_batch_size=1000,
         stats_interval_ms=5000,
+        auto_offset_reset="earliest",
         broker_source="",
         filter_keep_field=None,
         filter_drop_field=None,
@@ -352,13 +353,23 @@ class TestCreate:
 
     @patch("millpond.consumer.Consumer")
     @patch("millpond.consumer.discover_partition_count", return_value=8)
-    def test_auto_offset_reset_is_earliest(self, mock_discover, mock_consumer_cls):
-        """Verify auto.offset.reset=earliest for partitions with no committed offset."""
+    def test_auto_offset_reset_defaults_earliest(self, mock_discover, mock_consumer_cls):
+        """Verify auto.offset.reset is plumbed through from cfg.auto_offset_reset (default earliest)."""
         cfg = _make_cfg()
         create(cfg)
 
         consumer_config = mock_consumer_cls.call_args[0][0]
         assert consumer_config["auto.offset.reset"] == "earliest"
+
+    @patch("millpond.consumer.Consumer")
+    @patch("millpond.consumer.discover_partition_count", return_value=8)
+    def test_auto_offset_reset_latest_is_plumbed(self, mock_discover, mock_consumer_cls):
+        """NRT consumers set auto_offset_reset=latest so a fresh group skips the retention backlog."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        create(cfg)
+
+        consumer_config = mock_consumer_cls.call_args[0][0]
+        assert consumer_config["auto.offset.reset"] == "latest"
 
     @patch("millpond.consumer.Consumer")
     @patch("millpond.consumer.discover_partition_count", return_value=2)

--- a/tests/unit/test_millpond_logging_config.py
+++ b/tests/unit/test_millpond_logging_config.py
@@ -2,6 +2,7 @@
 setup_stdout() / attach_posthog_otlp() flow and the resource-attr
 taxonomy.
 """
+
 from __future__ import annotations
 
 import dataclasses
@@ -55,6 +56,7 @@ def _minimal_config() -> Config:
         fetch_max_wait_ms=500,
         consume_batch_size=1000,
         stats_interval_ms=5000,
+        auto_offset_reset="earliest",
         broker_source="warpstream",
         filter_keep_field=None,
         filter_drop_field=None,


### PR DESCRIPTION
## Summary

millpond hardcoded `auto.offset.reset: \"earliest\"`. A fresh consumer group with no committed offsets falls back to this — which is right for catch-up / backfill consumers but wrong for NRT consumers that filter ~99% of events. Those should start at the topic head rather than replay the entire retention window before reaching real-time.

## Changes

- New env var `KAFKA_AUTO_OFFSET_RESET` (default \"earliest\" for back-compat).
- Validated against \`(\"earliest\", \"latest\")\` only — librdkafka also accepts \"error\" but that crashes any fresh consumer group, which is never what a streaming sink wants.
- Wired through to \`consumer.create()\` via \`cfg.auto_offset_reset\`.
- Rejects \`KAFKA_CONSUMER_AUTO_OFFSET_RESET\` at startup: would land in \`kafka_config_overrides\` and silently lose to the explicit write in \`consumer.create()\`, so an operator setting it would deploy thinking they'd picked a policy and get the default. Fail loud instead.

## Test plan

- [x] \`uv run pytest tests/unit tests/integration\` — 435 passed, 1 xfailed
- [ ] Chart change in follow-up PR to expose \`consumer.autoOffsetReset\` per consumer
- [ ] Set \`events-nrt\` to \"latest\" so it doesn't replay days of clickhouse_events_json on first deploy