### PR TITLE
consumer: recover stale committed offsets at startup

### DIFF
--- a/millpond/consumer.py
+++ b/millpond/consumer.py
@@ -2,8 +2,8 @@ import logging
 import os
 
 import orjson
-from confluent_kafka import OFFSET_STORED, Consumer, TopicPartition
-from confluent_kafka.admin import AdminClient
+from confluent_kafka import OFFSET_INVALID, OFFSET_STORED, Consumer, KafkaException, TopicPartition
+from confluent_kafka.admin import AdminClient, OffsetSpec
 
 from millpond import metrics
 from millpond.config import Config
@@ -108,6 +108,182 @@ def compute_assignment(partition_count: int, replica_count: int, ordinal: int) -
     return [p for p in range(partition_count) if p % replica_count == ordinal]
 
 
+_RECOVERY_TIMEOUT_S = 10.0
+
+
+def _query_watermarks(admin: AdminClient, tps: list[TopicPartition]) -> dict[int, tuple[int, int]]:
+    """Batched watermark fetch via AdminClient.list_offsets.
+
+    Returns dict[partition_id, (low, high)]. Partitions whose
+    per-partition future raises are silently absent from the result — the
+    caller treats "no watermark" as "skip this partition" so a per-leader
+    metadata blip doesn't take down the whole recovery sweep.
+
+    Two RPCs total (one OffsetSpec.earliest, one OffsetSpec.latest), each
+    fan-out at the broker side; with 128+ partitions this is ~2-3s vs the
+    >20min worst case of per-partition consumer.get_watermark_offsets().
+    """
+    if not tps:
+        return {}
+
+    try:
+        earliest_futs = admin.list_offsets(
+            {tp: OffsetSpec.earliest() for tp in tps},
+            request_timeout=_RECOVERY_TIMEOUT_S,
+        )
+        latest_futs = admin.list_offsets(
+            {tp: OffsetSpec.latest() for tp in tps},
+            request_timeout=_RECOVERY_TIMEOUT_S,
+        )
+    except KafkaException:
+        log.warning(
+            "Skipping stale-offset recovery: AdminClient.list_offsets dispatch failed",
+            exc_info=True,
+        )
+        return {}
+
+    out: dict[int, tuple[int, int]] = {}
+    for tp in tps:
+        try:
+            low = earliest_futs[tp].result().offset
+            high = latest_futs[tp].result().offset
+        except Exception:
+            log.warning("Skipping watermark for %s [%d]", tp.topic, tp.partition, exc_info=True)
+            continue
+        out[tp.partition] = (low, high)
+    return out
+
+
+def _recover_stale_committed_offsets(consumer: Consumer, cfg: Config, partitions: list[int]) -> None:
+    """Eagerly bring committed offsets within retention for assigned partitions.
+
+    Without this, partitions whose stored offset is below the broker's
+    log-start-offset only "recover" the next time librdkafka actually fetches a
+    message from them: `auto.offset.reset` seeks the local position to
+    EARLIEST/LATEST, but millpond's offsets dict (and therefore the next
+    commit) is only advanced by *delivered* messages (main.py:_main_loop). On
+    quiet partitions that receive zero messages during a pod's lifetime, no
+    commit ever happens and the stale offset re-trips `offset_out_of_range` on
+    every restart and reports inflated `millpond_consumer_lag` for those
+    partitions until something delivers — see PostHog/millpond docs from
+    2026-06-16.
+
+    The recovery is a one-shot at startup:
+
+      1. Query committed offsets for every assigned partition. Partitions that
+         have never been committed (OFFSET_INVALID) are skipped — letting
+         `auto.offset.reset` apply normally on first fetch is the correct
+         fresh-consumer behaviour. Partitions whose committed-query carries an
+         error are skipped (we'd otherwise read garbage from `.offset`).
+      2. Batched query of [low, high] watermarks for every remaining partition
+         via AdminClient.list_offsets (two RPCs, not 1-per-partition).
+      3. If committed >= low the offset is still within retention; do nothing.
+      4. Committed < low: stale. Commit the `auto.offset.reset` target —
+         `low` for "earliest", `high` for "latest". This is the same position
+         librdkafka would seek to on first fetch, just made durable across
+         restarts. `low` is the next-to-fetch (first available record) and
+         `high` is the next-to-be-produced; both match Kafka commit semantics
+         where the committed value IS the next-to-fetch.
+
+    We intentionally drop `leader_epoch` on the recovered TopicPartition. The
+    epoch reported alongside the stale committed offset refers to a leader era
+    in which our target offset (low or high *now*) didn't exist; carrying it
+    would be semantically wrong. Modern brokers accept `-1`/None and resolve
+    the current epoch from metadata on next fetch.
+
+    Bails gracefully on per-partition errors (logs and continues) and on the
+    overall commit (logs warning). The auto.offset.reset fallback still works
+    if this function fails entirely — it's an optimization, not a correctness
+    requirement.
+    """
+    if not partitions:
+        return
+
+    tps = [TopicPartition(cfg.topic, p) for p in partitions]
+    try:
+        committed = consumer.committed(tps, timeout=_RECOVERY_TIMEOUT_S)
+    except KafkaException:
+        log.warning("Skipping stale-offset recovery: failed to query committed offsets", exc_info=True)
+        return
+
+    # Filter to partitions that actually need a watermark check.
+    needs_watermark: list[TopicPartition] = []
+    n_fresh = 0
+    n_error = 0
+    for tp in committed:
+        if tp.error is not None:
+            log.warning(
+                "Stale-offset recovery: committed() returned error for %s [%d]: %s",
+                tp.topic,
+                tp.partition,
+                tp.error,
+            )
+            n_error += 1
+            continue
+        if tp.offset == OFFSET_INVALID:
+            n_fresh += 1
+            continue
+        needs_watermark.append(tp)
+
+    admin = AdminClient(_base_kafka_config(cfg))
+    watermarks = _query_watermarks(admin, [TopicPartition(tp.topic, tp.partition) for tp in needs_watermark])
+
+    to_recover: list[TopicPartition] = []
+    n_in_retention = 0
+    n_no_watermark = 0
+    for tp in needs_watermark:
+        if tp.partition not in watermarks:
+            n_no_watermark += 1
+            continue
+        low, high = watermarks[tp.partition]
+        if tp.offset >= low:
+            n_in_retention += 1
+            continue
+        # Stale: records at tp.offset are gone from the broker. Commit the
+        # auto.offset.reset target so OFFSET_STORED resolves to something
+        # in-range. Per-partition WARNING so an operator triaging weird lag can
+        # see exactly which partition recovered and from where.
+        target = high if cfg.auto_offset_reset == "latest" else low
+        log.warning(
+            "Stale committed offset on %s [%d]: committed=%d, low=%d, high=%d, recovering to %d (%s)",
+            tp.topic,
+            tp.partition,
+            tp.offset,
+            low,
+            high,
+            target,
+            cfg.auto_offset_reset,
+        )
+        to_recover.append(TopicPartition(tp.topic, tp.partition, target))
+
+    if not to_recover:
+        log.info(
+            "Committed offsets healthy at startup (fresh=%d, in_retention=%d, errored=%d, no_watermark=%d)",
+            n_fresh,
+            n_in_retention,
+            n_error,
+            n_no_watermark,
+        )
+        return
+
+    log.info(
+        "Recovering %d stale committed offsets (target=%s, fresh=%d, in_retention=%d, errored=%d, no_watermark=%d)",
+        len(to_recover),
+        cfg.auto_offset_reset,
+        n_fresh,
+        n_in_retention,
+        n_error,
+        n_no_watermark,
+    )
+    try:
+        consumer.commit(offsets=to_recover, asynchronous=False)
+    except KafkaException:
+        log.warning(
+            "Failed to commit recovered offsets; auto.offset.reset fallback still applies",
+            exc_info=True,
+        )
+
+
 def create(cfg: Config) -> Consumer:
     """Create and configure the Kafka consumer with static partition assignment."""
     partition_count = discover_partition_count(cfg)
@@ -138,6 +314,14 @@ def create(cfg: Config) -> Consumer:
     consumer_config.setdefault("queued.max.messages.kbytes", 16384)
 
     consumer = Consumer(consumer_config)
+
+    # Recover stale committed offsets BEFORE assign() so the OFFSET_STORED
+    # resolution below picks up the fresh committed value rather than the
+    # ancient out-of-retention one. Without this, quiet partitions whose
+    # committed offset is below the broker's log-start-offset stay logging
+    # `offset_out_of_range` on every restart and report misleading lag in
+    # millpond_consumer_lag.
+    _recover_stale_committed_offsets(consumer, cfg, my_partitions)
 
     # OFFSET_STORED: resume from committed offset in __consumer_offsets.
     # Falls back to auto.offset.reset (cfg.auto_offset_reset) if no offset

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -2,13 +2,14 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
-from confluent_kafka import OFFSET_STORED
+from confluent_kafka import OFFSET_INVALID, OFFSET_STORED, KafkaException
 
 from millpond.config import Config
 from millpond.consumer import (
     _base_kafka_config,
     _maybe_attach_oauth_cb,
     _on_stats,
+    _recover_stale_committed_offsets,
     compute_assignment,
     create,
     discover_partition_count,
@@ -377,3 +378,247 @@ class TestCreate:
         cfg = _make_cfg(ordinal=3, replica_count=4)
         with pytest.raises(RuntimeError, match="No partitions assigned"):
             create(cfg)
+
+
+class _FakeAdminContext:
+    """Patches AdminClient inside millpond.consumer so list_offsets returns
+    the watermarks the test wants. Use via the helper below; AdminClient is
+    constructed by the SUT, not the test, so we can't pass a Mock directly."""
+
+    def __init__(self, watermarks, raise_on_dispatch=False, raise_on_partition=None):
+        self.watermarks = watermarks
+        self.raise_on_dispatch = raise_on_dispatch
+        self.raise_on_partition = raise_on_partition or set()
+
+    def __enter__(self):
+        self._patcher = patch("millpond.consumer.AdminClient")
+        admin_cls = self._patcher.start()
+        admin_inst = admin_cls.return_value
+
+        def list_offsets(spec_dict, request_timeout=None):
+            if self.raise_on_dispatch:
+                raise KafkaException("dispatch failed")
+            # spec_dict is {TopicPartition: OffsetSpec}. We return per-tp
+            # futures whose .result().offset gives the watermark value.
+            from millpond.consumer import OffsetSpec
+
+            futures = {}
+            for tp, spec in spec_dict.items():
+                fut = MagicMock()
+                if tp.partition in self.raise_on_partition:
+                    fut.result.side_effect = KafkaException("partition error")
+                else:
+                    info = MagicMock()
+                    low, high = self.watermarks[tp.partition]
+                    info.offset = low if isinstance(spec, OffsetSpec.earliest().__class__) else high
+                    fut.result.return_value = info
+                futures[tp] = fut
+            return futures
+
+        admin_inst.list_offsets.side_effect = list_offsets
+        return admin_inst
+
+    def __exit__(self, *a):
+        self._patcher.stop()
+
+
+class TestRecoverStaleCommittedOffsets:
+    """Recovery runs BEFORE assign() — queries committed offsets via the
+    consumer, watermarks via AdminClient.list_offsets (batched), then
+    commits the auto.offset.reset target for any partition whose committed
+    offset has aged out of retention."""
+
+    def _make_consumer(self, committed_offsets, *, errors=None):
+        """Build a Mock consumer responding to .committed() and .commit().
+
+        committed_offsets: dict[int, int]   partition -> committed offset
+                                             (OFFSET_INVALID for never-committed)
+        errors:            dict[int, str]   partition -> error string for
+                                             that partition's committed entry
+
+        Note: real TopicPartition.error is a read-only C attribute, so the
+        fake uses SimpleNamespace with the four fields the SUT reads
+        (.topic, .partition, .offset, .error). Functionally identical for
+        our recovery code's purposes.
+        """
+        from types import SimpleNamespace
+
+        errors = errors or {}
+        consumer = MagicMock()
+
+        def fake_committed(tps, timeout=None):
+            return [
+                SimpleNamespace(
+                    topic=tp.topic,
+                    partition=tp.partition,
+                    offset=committed_offsets.get(tp.partition, OFFSET_INVALID),
+                    error=errors.get(tp.partition),
+                )
+                for tp in tps
+            ]
+
+        consumer.committed.side_effect = fake_committed
+        return consumer
+
+    def test_no_committed_offsets_makes_no_commit(self):
+        """Fresh consumer group (OFFSET_INVALID everywhere) — recovery is a no-op.
+        auto.offset.reset handles fresh subscriptions correctly on first fetch."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        consumer = self._make_consumer(
+            committed_offsets={0: OFFSET_INVALID, 1: OFFSET_INVALID},
+        )
+        with _FakeAdminContext(watermarks={0: (100, 200), 1: (100, 200)}):
+            _recover_stale_committed_offsets(consumer, cfg, [0, 1])
+        consumer.commit.assert_not_called()
+
+    def test_in_retention_offsets_make_no_commit(self):
+        """All committed offsets are within [low, high] — nothing to recover."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        consumer = self._make_consumer(committed_offsets={0: 150, 1: 180})
+        with _FakeAdminContext(watermarks={0: (100, 200), 1: (100, 200)}):
+            _recover_stale_committed_offsets(consumer, cfg, [0, 1])
+        consumer.commit.assert_not_called()
+
+    def test_stale_offsets_commit_high_for_latest_policy(self):
+        """Committed below low + auto.offset.reset=latest → commit the high watermark."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        consumer = self._make_consumer(committed_offsets={0: 50, 1: 50})  # below low=100 for both
+        with _FakeAdminContext(watermarks={0: (100, 200), 1: (100, 250)}):
+            _recover_stale_committed_offsets(consumer, cfg, [0, 1])
+
+        consumer.commit.assert_called_once()
+        committed = consumer.commit.call_args[1]["offsets"]
+        committed_by_partition = {tp.partition: tp.offset for tp in committed}
+        assert committed_by_partition == {0: 200, 1: 250}
+        assert consumer.commit.call_args[1]["asynchronous"] is False
+
+    def test_stale_offsets_commit_low_for_earliest_policy(self):
+        """Committed below low + auto.offset.reset=earliest → commit the low
+        watermark. "low" is itself a record we haven't read — but it's the
+        first available, matching what auto.offset.reset=earliest would seek to."""
+        cfg = _make_cfg(auto_offset_reset="earliest")
+        consumer = self._make_consumer(committed_offsets={0: 50})
+        with _FakeAdminContext(watermarks={0: (100, 200)}):
+            _recover_stale_committed_offsets(consumer, cfg, [0])
+
+        consumer.commit.assert_called_once()
+        committed = consumer.commit.call_args[1]["offsets"]
+        assert committed[0].offset == 100
+
+    def test_mixed_partitions_only_stale_recovered(self):
+        """Stale + in-retention + never-committed → only the stale partition
+        is committed; the others are left to auto.offset.reset / current consumer
+        position. A partial sweep must not blow away healthy commits."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        consumer = self._make_consumer(
+            committed_offsets={
+                0: 50,  # stale
+                1: 150,  # in retention
+                2: OFFSET_INVALID,  # never committed
+            },
+        )
+        with _FakeAdminContext(watermarks={0: (100, 200), 1: (100, 200), 2: (100, 200)}):
+            _recover_stale_committed_offsets(consumer, cfg, [0, 1, 2])
+
+        consumer.commit.assert_called_once()
+        committed = consumer.commit.call_args[1]["offsets"]
+        partitions = [tp.partition for tp in committed]
+        assert partitions == [0], f"Expected only partition 0 to be recovered, got {partitions}"
+        assert committed[0].offset == 200
+
+    def test_committed_query_failure_skips_recovery(self):
+        """KafkaException on .committed() bails out without raising — the
+        auto.offset.reset fallback in librdkafka still works.
+
+        Recovery is an optimization. If it can't run, fail open."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        consumer = MagicMock()
+        consumer.committed.side_effect = KafkaException("broker unreachable")
+
+        _recover_stale_committed_offsets(consumer, cfg, [0, 1])
+        consumer.commit.assert_not_called()
+
+    def test_watermark_dispatch_failure_skips_recovery(self):
+        """KafkaException on AdminClient.list_offsets dispatch bails out.
+        Recovery is best-effort; the auto.offset.reset path still kicks in."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        consumer = self._make_consumer(committed_offsets={0: 50, 1: 50})
+        with _FakeAdminContext(watermarks={}, raise_on_dispatch=True):
+            _recover_stale_committed_offsets(consumer, cfg, [0, 1])
+        consumer.commit.assert_not_called()
+
+    def test_per_partition_watermark_failure_skips_that_partition(self):
+        """A per-partition future raising mid-batch logs and continues;
+        recovery still commits for partitions whose futures succeeded."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        consumer = self._make_consumer(committed_offsets={0: 50, 1: 50})
+        with _FakeAdminContext(
+            watermarks={0: (100, 200), 1: (100, 200)},
+            raise_on_partition={0},
+        ):
+            _recover_stale_committed_offsets(consumer, cfg, [0, 1])
+
+        consumer.commit.assert_called_once()
+        committed = consumer.commit.call_args[1]["offsets"]
+        partitions = [tp.partition for tp in committed]
+        assert partitions == [1], f"Expected only partition 1 (watermark succeeded), got {partitions}"
+
+    def test_commit_failure_does_not_raise(self):
+        """If the final .commit() fails, log warning and return — librdkafka's
+        auto.offset.reset still triggers on first fetch. Don't crash the pod."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        consumer = self._make_consumer(committed_offsets={0: 50})
+        consumer.commit.side_effect = KafkaException("group coordinator unavailable")
+        with _FakeAdminContext(watermarks={0: (100, 200)}):
+            # Should not raise
+            _recover_stale_committed_offsets(consumer, cfg, [0])
+
+    def test_committed_equal_to_low_is_in_retention(self):
+        """Boundary: committed == low is the earliest *available* record. Not stale."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        consumer = self._make_consumer(committed_offsets={0: 100})
+        with _FakeAdminContext(watermarks={0: (100, 200)}):
+            _recover_stale_committed_offsets(consumer, cfg, [0])
+        consumer.commit.assert_not_called()
+
+    def test_empty_partition_low_equals_high(self):
+        """Empty partition: low == high == 0. A committed value of 0 is
+        "in retention" (committed == low). No commit fires."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        consumer = self._make_consumer(committed_offsets={0: 0})
+        with _FakeAdminContext(watermarks={0: (0, 0)}):
+            _recover_stale_committed_offsets(consumer, cfg, [0])
+        consumer.commit.assert_not_called()
+
+    def test_empty_partitions_list_is_noop(self):
+        """If the caller passes [] (e.g. ordinal owns no partitions, which
+        actually raises in create() — but defensive), recovery does nothing.
+        Don't hit the broker, don't log a confusing "Recovering 0" line."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        consumer = MagicMock()
+        # AdminClient must not even be constructed in this path.
+        with patch("millpond.consumer.AdminClient") as admin_cls:
+            _recover_stale_committed_offsets(consumer, cfg, [])
+        consumer.committed.assert_not_called()
+        consumer.commit.assert_not_called()
+        admin_cls.assert_not_called()
+
+    def test_committed_partition_error_skipped(self):
+        """consumer.committed() returns per-partition entries with an `error`
+        attribute. If set, `.offset` may be garbage from librdkafka — must not
+        feed it into the watermark check. Skip with a warning instead."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        consumer = self._make_consumer(
+            # Without the error skip, partition 0's offset 50 would look "stale"
+            # against low=100 and trigger a spurious commit. The error must
+            # short-circuit before that.
+            committed_offsets={0: 50, 1: 50},
+            errors={0: "UNKNOWN_TOPIC_OR_PARTITION"},
+        )
+        with _FakeAdminContext(watermarks={0: (100, 200), 1: (100, 200)}):
+            _recover_stale_committed_offsets(consumer, cfg, [0, 1])
+
+        consumer.commit.assert_called_once()
+        committed = consumer.commit.call_args[1]["offsets"]
+        partitions = [tp.partition for tp in committed]
+        assert partitions == [1], f"Expected only partition 1 (no error), got {partitions}"


### PR DESCRIPTION
## Problem

Two related symptoms in millpond consumer groups whose committed offset has aged out of broker retention:

1. **Recurring `offset_out_of_range` log noise on every pod restart.** librdkafka's `auto.offset.reset` seeks the local position to LATEST/EARLIEST when it discovers the stored offset is no longer available, but millpond's offsets dict (and therefore its next commit) is only advanced by *delivered* messages (`main.py:372`). On quiet partitions that receive zero messages during a pod's lifetime, the stored offset stays at the original ancient value across restarts.

2. **Misleading `millpond_consumer_lag` metric.** Lag = `high_watermark - committed_offset`. With the committed offset frozen at the ancient value (~426M for events-nrt) and the high watermark drifting to ~500M, the gauge reports ~74M of "lag" that doesn't actually represent any unconsumed work — the consumer is sitting at the head.

Most visible on `events-nrt` (filter-keep, ~99% records dropped → many partitions deliver zero matching records over a pod lifetime), but the same path can hit non-filtered consumers on long downtime / retention shrink / partition recreate.

## Fix

`_recover_stale_committed_offsets()` runs once at startup, **before** `consumer.assign(...)`:

1. Query `consumer.committed(tps)` for all assigned partitions. Skip `OFFSET_INVALID` (fresh-consumer semantics) and skip entries with `tp.error` set.
2. Batched `AdminClient.list_offsets(... OffsetSpec.earliest())` + `... OffsetSpec.latest()` to fetch `[low, high]` watermarks for all remaining partitions in two RPCs total (vs the 128× sequential `consumer.get_watermark_offsets()` worst case of ~20 min).
3. If `committed >= low`, the offset is in retention — do nothing.
4. If `committed < low`, the records at that offset are gone from the broker. Commit the `auto.offset.reset` target — `low` for `"earliest"`, `high` for `"latest"`. This matches the position librdkafka would seek to, just durable across restarts.

Per-partition WARNING log on every stale partition with `committed`, `low`, `high`, `target`, and policy fields. Bails on any KafkaException (logs warning, returns) — recovery is an optimization, not a correctness requirement; librdkafka's auto.offset.reset still kicks in.

## Why this is safe

Reviewed in depth with two independent agents against both the filter-keep and non-filtered consumers. Findings (all CLEAN unless noted):

- **No data loss.** Records in `[committed, low)` are gone from the broker regardless; both recovery and librdkafka's auto.offset.reset skip them identically.
- **No new duplicates.** Both paths resume at `low`; same first record delivered → same first sink write. At-least-once preserved.
- **Idempotent.** Converges in ≤1 recovery commit per "retention rolled past the recovered offset" event.
- **Semantically equivalent to librdkafka's fallback.** `low` is precisely what librdkafka seeks to for `earliest` (no `+1`); `high` for `latest`. The fix only differs in *when* the committed offset durably advances — at startup, before first fetch.
- **Pre-assign committed()/list_offsets() supported** by confluent-kafka-python 2.x.

Known race not introduced by this PR but worth noting: two pods coming up with the same ordinal under static `assign(...)` would race on commits the same way they always have; recovery participates in that race, doesn't create it. Fix the pod identity (e.g., StatefulSet ordinal drift), not the recovery.

## What got dropped from the recovered TopicPartition

`leader_epoch`. The epoch reported alongside the stale committed offset refers to a leader era in which the recovery target (`low`/`high` *now*) didn't exist. Carrying it would be semantically wrong. Modern brokers accept `-1`/None and resolve the current epoch from metadata on next fetch.

## Test plan

- [x] 13 new unit tests under `TestRecoverStaleCommittedOffsets` cover: no-op for fresh group, no-op for in-retention, commit-high for latest policy, commit-low for earliest policy, mixed (stale + healthy + fresh) only-stale-recovered, committed query failure → no-op, watermark dispatch failure → no-op, per-partition watermark failure → skip that partition, commit failure → no raise, boundary `committed == low` → in retention, empty partition (`low == high == 0`) → in retention, empty `partitions` list → no broker calls, `tp.error` on committed() → skip that partition.
- [x] Full suite: 423 unit + 21 integration + 4 e2e = 448 passing + 1 pre-existing xfail.
- [x] `ruff check` and `ruff format` clean on touched files.
- [ ] After deploy: confirm events-nrt startup logs show 0 stale offsets after first run; verify `millpond_consumer_lag` drops to ~0 for previously-stuck partitions.