### PR TITLE
consumer: seed lag/offset gauges at startup so quiet partitions report truth

### DIFF
--- a/millpond/consumer.py
+++ b/millpond/consumer.py
@@ -256,7 +256,26 @@ def _recover_stale_committed_offsets(consumer: Consumer, cfg: Config, partitions
         )
         to_recover.append(TopicPartition(tp.topic, tp.partition, target))
 
-    if not to_recover:
+    if to_recover:
+        log.info(
+            "Recovering %d stale committed offsets (target=%s, fresh=%d, in_retention=%d, errored=%d, no_watermark=%d)",
+            len(to_recover),
+            cfg.auto_offset_reset,
+            n_fresh,
+            n_in_retention,
+            n_error,
+            n_no_watermark,
+        )
+        commit_ok = True
+        try:
+            consumer.commit(offsets=to_recover, asynchronous=False)
+        except KafkaException:
+            log.warning(
+                "Failed to commit recovered offsets; auto.offset.reset fallback still applies",
+                exc_info=True,
+            )
+            commit_ok = False
+    else:
         log.info(
             "Committed offsets healthy at startup (fresh=%d, in_retention=%d, errored=%d, no_watermark=%d)",
             n_fresh,
@@ -264,24 +283,66 @@ def _recover_stale_committed_offsets(consumer: Consumer, cfg: Config, partitions
             n_error,
             n_no_watermark,
         )
-        return
+        commit_ok = True
 
-    log.info(
-        "Recovering %d stale committed offsets (target=%s, fresh=%d, in_retention=%d, errored=%d, no_watermark=%d)",
-        len(to_recover),
-        cfg.auto_offset_reset,
-        n_fresh,
-        n_in_retention,
-        n_error,
-        n_no_watermark,
-    )
-    try:
-        consumer.commit(offsets=to_recover, asynchronous=False)
-    except KafkaException:
-        log.warning(
-            "Failed to commit recovered offsets; auto.offset.reset fallback still applies",
-            exc_info=True,
-        )
+    # Seed gauges unconditionally so the dashboard isn't haunted by stale
+    # values from prior pod runs. See _seed_startup_gauges docstring.
+    _seed_startup_gauges(cfg, committed, watermarks, to_recover if commit_ok else [])
+
+
+def _seed_startup_gauges(
+    cfg: Config,
+    committed: list,
+    watermarks: dict[int, tuple[int, int]],
+    recovered: list[TopicPartition],
+) -> None:
+    """Set `millpond_consumer_lag` and `millpond_last_committed_offset` for every
+    assigned partition with a known position so the dashboard isn't haunted by
+    stale gauge values from prior pod runs.
+
+    main.py's _update_lag_metrics / _flush only set these gauges for partitions
+    that delivered messages in *this* pod's lifetime. For quiet partitions
+    (zero deliveries during a run) the gauges retain whatever previous pods
+    last set — which for the stale-offset case is an inflated lag value that
+    keeps showing on the dashboard well after recovery has fixed
+    __consumer_offsets. Seed here so the gauges read truth at startup.
+
+    For each partition with a known [low, high]:
+      - Just recovered → position = recovered target (lag is 0 for "latest"
+        policy, high-low for "earliest").
+      - In retention (committed offset valid + within range) → position =
+        committed offset.
+      - Fresh (OFFSET_INVALID), errored committed, or stale-but-not-recovered
+        (recovery commit failed) → position = the auto.offset.reset target.
+        That's where OFFSET_STORED resolves to via librdkafka's fallback on
+        first fetch, so seeding to it matches what the next delivery will
+        confirm.
+
+    Partitions without a watermark are skipped — we can't compute lag without
+    `high`, and we shouldn't overwrite the gauge with a wrong value.
+    """
+    recovered_by_partition = {tp.partition: tp.offset for tp in recovered}
+    committed_by_partition = {tp.partition: tp for tp in committed}
+
+    n_seeded = 0
+    for partition_id, (low, high) in watermarks.items():
+        if partition_id in recovered_by_partition:
+            position = recovered_by_partition[partition_id]
+        else:
+            tp = committed_by_partition.get(partition_id)
+            if tp is not None and tp.error is None and tp.offset != OFFSET_INVALID and tp.offset >= low:
+                position = tp.offset
+            else:
+                # Fresh, errored, or stale-but-not-recovered: use the
+                # auto.offset.reset target librdkafka will seek to.
+                position = high if cfg.auto_offset_reset == "latest" else low
+
+        metrics.consumer_lag.labels(partition=str(partition_id)).set(high - position)
+        metrics.last_committed_offset.labels(partition=str(partition_id)).set(position)
+        n_seeded += 1
+
+    if n_seeded:
+        log.info("Seeded startup lag/offset gauges for %d partitions", n_seeded)
 
 
 def create(cfg: Config) -> Consumer:

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -2,7 +2,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
-from confluent_kafka import OFFSET_INVALID, OFFSET_STORED, KafkaException
+from confluent_kafka import OFFSET_INVALID, OFFSET_STORED, KafkaException, TopicPartition
 
 from millpond.config import Config
 from millpond.consumer import (
@@ -10,6 +10,7 @@ from millpond.consumer import (
     _maybe_attach_oauth_cb,
     _on_stats,
     _recover_stale_committed_offsets,
+    _seed_startup_gauges,
     compute_assignment,
     create,
     discover_partition_count,
@@ -622,3 +623,254 @@ class TestRecoverStaleCommittedOffsets:
         committed = consumer.commit.call_args[1]["offsets"]
         partitions = [tp.partition for tp in committed]
         assert partitions == [1], f"Expected only partition 1 (no error), got {partitions}"
+
+    @patch("millpond.consumer._seed_startup_gauges")
+    def test_seeding_called_after_successful_recovery(self, mock_seed):
+        """Recovery committed successfully → seeding gets the to_recover list as
+        `recovered`, so the seeder uses the recovery target (not the pre-recovery
+        stale committed value) when computing the gauge."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        consumer = self._make_consumer(committed_offsets={0: 50})  # stale
+        with _FakeAdminContext(watermarks={0: (100, 200)}):
+            _recover_stale_committed_offsets(consumer, cfg, [0])
+
+        mock_seed.assert_called_once()
+        _cfg, _committed, watermarks, recovered = mock_seed.call_args[0]
+        assert watermarks == {0: (100, 200)}
+        assert [tp.partition for tp in recovered] == [0]
+        assert recovered[0].offset == 200  # high (latest policy)
+
+    @patch("millpond.consumer._seed_startup_gauges")
+    def test_seeding_called_with_empty_recovered_when_commit_fails(self, mock_seed):
+        """commit() raised → recovery couldn't persist. Seed with recovered=[]
+        so the seeder falls back to the auto.offset.reset target rather than
+        falsely claiming the partition is "at the recovery position".
+
+        librdkafka's STORED fallback will land at that same position on first
+        fetch, so the gauge stays correct without us having to pretend recovery
+        succeeded."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        consumer = self._make_consumer(committed_offsets={0: 50})  # stale
+        consumer.commit.side_effect = KafkaException("group coordinator unavailable")
+        with _FakeAdminContext(watermarks={0: (100, 200)}):
+            _recover_stale_committed_offsets(consumer, cfg, [0])
+
+        mock_seed.assert_called_once()
+        _cfg, _committed, _watermarks, recovered = mock_seed.call_args[0]
+        assert recovered == []
+
+    @patch("millpond.consumer._seed_startup_gauges")
+    def test_seeding_called_when_no_recovery_needed(self, mock_seed):
+        """All offsets healthy → recovery is a no-op, but seeding still runs.
+        This is the steady-state case where a quiet partition's gauge would
+        otherwise be stuck at the previous pod's last reported lag."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        consumer = self._make_consumer(committed_offsets={0: 150})  # in retention
+        with _FakeAdminContext(watermarks={0: (100, 200)}):
+            _recover_stale_committed_offsets(consumer, cfg, [0])
+
+        consumer.commit.assert_not_called()
+        mock_seed.assert_called_once()
+        _cfg, _committed, _watermarks, recovered = mock_seed.call_args[0]
+        assert recovered == []
+
+
+def _make_committed(committed_offsets: dict, errors: dict | None = None) -> list:
+    """Build the `committed` list the seeder expects: SimpleNamespace entries
+    with topic/partition/offset/error. Mirrors what consumer.committed()
+    returns at runtime. Real TopicPartition.error is C-only and read-only,
+    so the test fake uses SimpleNamespace."""
+    from types import SimpleNamespace
+
+    errors = errors or {}
+    return [
+        SimpleNamespace(
+            topic="test-topic",
+            partition=p,
+            offset=offset,
+            error=errors.get(p),
+        )
+        for p, offset in committed_offsets.items()
+    ]
+
+
+class TestSeedStartupGauges:
+    """Direct tests for _seed_startup_gauges. Verifies the gauge values written
+    for each per-partition state: recovered, in-retention, fresh, errored, and
+    stale-but-not-recovered. The integration-level wiring (does the recovery
+    function call this?) is covered by TestRecoverStaleCommittedOffsets."""
+
+    @patch("millpond.consumer.metrics")
+    def test_recovered_partition_uses_target_offset_latest(self, mock_metrics):
+        """auto.offset.reset=latest → recovery target = high → gauge lag is 0
+        and last_committed_offset is high. After recovery, the consumer is
+        caught up by definition."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        committed = _make_committed({0: 50})  # the pre-recovery stale value
+        watermarks = {0: (100, 200)}
+        recovered = [TopicPartition("test-topic", 0, 200)]
+
+        _seed_startup_gauges(cfg, committed, watermarks, recovered)
+
+        mock_metrics.consumer_lag.labels.assert_called_once_with(partition="0")
+        mock_metrics.consumer_lag.labels.return_value.set.assert_called_once_with(0)
+        mock_metrics.last_committed_offset.labels.return_value.set.assert_called_once_with(200)
+
+    @patch("millpond.consumer.metrics")
+    def test_recovered_partition_uses_target_offset_earliest(self, mock_metrics):
+        """auto.offset.reset=earliest → recovery target = low → gauge lag is
+        high-low. The consumer has the full in-retention backlog ahead of it."""
+        cfg = _make_cfg(auto_offset_reset="earliest")
+        committed = _make_committed({0: 50})
+        watermarks = {0: (100, 200)}
+        recovered = [TopicPartition("test-topic", 0, 100)]
+
+        _seed_startup_gauges(cfg, committed, watermarks, recovered)
+
+        mock_metrics.consumer_lag.labels.return_value.set.assert_called_once_with(100)
+        mock_metrics.last_committed_offset.labels.return_value.set.assert_called_once_with(100)
+
+    @patch("millpond.consumer.metrics")
+    def test_in_retention_committed_uses_committed_offset(self, mock_metrics):
+        """committed value within [low, high] → use committed offset directly.
+        This is steady-state. Lag = high - committed."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        committed = _make_committed({0: 150})
+        watermarks = {0: (100, 200)}
+
+        _seed_startup_gauges(cfg, committed, watermarks, recovered=[])
+
+        mock_metrics.consumer_lag.labels.return_value.set.assert_called_once_with(50)
+        mock_metrics.last_committed_offset.labels.return_value.set.assert_called_once_with(150)
+
+    @patch("millpond.consumer.metrics")
+    def test_fresh_partition_uses_high_for_latest(self, mock_metrics):
+        """OFFSET_INVALID (never committed) + auto.offset.reset=latest →
+        position=high. librdkafka will seek to high on first fetch, so the
+        gauge starts at lag=0 matching where consumption will resume."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        committed = _make_committed({0: OFFSET_INVALID})
+        watermarks = {0: (100, 200)}
+
+        _seed_startup_gauges(cfg, committed, watermarks, recovered=[])
+
+        mock_metrics.consumer_lag.labels.return_value.set.assert_called_once_with(0)
+        mock_metrics.last_committed_offset.labels.return_value.set.assert_called_once_with(200)
+
+    @patch("millpond.consumer.metrics")
+    def test_fresh_partition_uses_low_for_earliest(self, mock_metrics):
+        """OFFSET_INVALID + auto.offset.reset=earliest → position=low. The
+        consumer will replay the full retention window, so lag starts at
+        high - low."""
+        cfg = _make_cfg(auto_offset_reset="earliest")
+        committed = _make_committed({0: OFFSET_INVALID})
+        watermarks = {0: (100, 200)}
+
+        _seed_startup_gauges(cfg, committed, watermarks, recovered=[])
+
+        mock_metrics.consumer_lag.labels.return_value.set.assert_called_once_with(100)
+        mock_metrics.last_committed_offset.labels.return_value.set.assert_called_once_with(100)
+
+    @patch("millpond.consumer.metrics")
+    def test_errored_committed_uses_auto_offset_reset_target(self, mock_metrics):
+        """tp.error set → tp.offset is unreliable. Use the auto.offset.reset
+        target, same as fresh. Without this the seeder would publish a gauge
+        built from a garbage offset."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        committed = _make_committed({0: 999_999}, errors={0: "UNKNOWN_TOPIC_OR_PARTITION"})
+        watermarks = {0: (100, 200)}
+
+        _seed_startup_gauges(cfg, committed, watermarks, recovered=[])
+
+        mock_metrics.consumer_lag.labels.return_value.set.assert_called_once_with(0)
+        mock_metrics.last_committed_offset.labels.return_value.set.assert_called_once_with(200)
+
+    @patch("millpond.consumer.metrics")
+    def test_stale_not_recovered_uses_auto_offset_reset_target(self, mock_metrics):
+        """Committed is stale (below low) AND recovered=[] (commit failed
+        upstream) → fall through to the auto.offset.reset target. That's where
+        librdkafka's STORED fallback will land on first fetch, so the seeded
+        gauge matches what the next delivery will confirm."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        committed = _make_committed({0: 50})  # below low
+        watermarks = {0: (100, 200)}
+
+        _seed_startup_gauges(cfg, committed, watermarks, recovered=[])
+
+        mock_metrics.consumer_lag.labels.return_value.set.assert_called_once_with(0)
+        mock_metrics.last_committed_offset.labels.return_value.set.assert_called_once_with(200)
+
+    @patch("millpond.consumer.metrics")
+    def test_committed_equal_to_low_is_in_retention(self, mock_metrics):
+        """Boundary: committed == low is still in retention (the earliest
+        available record). Match the recovery code's `tp.offset >= low` check
+        so the two stay consistent — a partition not flagged for recovery
+        must not be seeded as if it were."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        committed = _make_committed({0: 100})
+        watermarks = {0: (100, 200)}
+
+        _seed_startup_gauges(cfg, committed, watermarks, recovered=[])
+
+        mock_metrics.consumer_lag.labels.return_value.set.assert_called_once_with(100)
+        mock_metrics.last_committed_offset.labels.return_value.set.assert_called_once_with(100)
+
+    @patch("millpond.consumer.metrics")
+    def test_partition_without_watermark_skipped(self, mock_metrics):
+        """Watermark query failed for a partition → it's absent from `watermarks`.
+        Skip rather than guess: setting consumer_lag without a real `high` would
+        publish a wrong value, and overwriting last_committed_offset with the
+        raw committed value (without a verified `high`) is meaningless to the
+        dashboard's lag panel."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        committed = _make_committed({0: 150, 1: 150})
+        watermarks = {0: (100, 200)}  # partition 1 missing
+
+        _seed_startup_gauges(cfg, committed, watermarks, recovered=[])
+
+        # Only partition 0 should be seeded
+        assert mock_metrics.consumer_lag.labels.call_count == 1
+        mock_metrics.consumer_lag.labels.assert_called_with(partition="0")
+
+    @patch("millpond.consumer.metrics")
+    def test_empty_watermarks_no_gauge_calls(self, mock_metrics):
+        """No partitions in `watermarks` → no gauges set, no log spam.
+        Defensive against the all-watermark-queries-failed case."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+
+        _seed_startup_gauges(cfg, committed=[], watermarks={}, recovered=[])
+
+        mock_metrics.consumer_lag.labels.assert_not_called()
+        mock_metrics.last_committed_offset.labels.assert_not_called()
+
+    @patch("millpond.consumer.metrics")
+    def test_multiple_partitions_each_state(self, mock_metrics):
+        """Mixed bag in a single call: recovered, in-retention, fresh, and
+        errored. Each gets its own per-partition gauge with the right value.
+        Verifies the recovered-list lookup doesn't bleed across partitions."""
+        cfg = _make_cfg(auto_offset_reset="latest")
+        committed = _make_committed(
+            {
+                0: 50,  # stale, will be recovered
+                1: 150,  # in retention
+                2: OFFSET_INVALID,  # fresh
+                3: 999_999,  # errored
+            },
+            errors={3: "UNKNOWN_TOPIC_OR_PARTITION"},
+        )
+        watermarks = {0: (100, 200), 1: (100, 200), 2: (100, 200), 3: (100, 200)}
+        recovered = [TopicPartition("test-topic", 0, 200)]
+
+        _seed_startup_gauges(cfg, committed, watermarks, recovered)
+
+        # Collect per-partition .set() calls. Each .labels(partition=X) returns
+        # the same mock, so we inspect call_args_list on the chained .set.
+        lag_calls_by_partition = {}
+        offset_calls_by_partition = {}
+        for call in mock_metrics.consumer_lag.labels.call_args_list:
+            lag_calls_by_partition[call.kwargs["partition"]] = None
+        for call in mock_metrics.last_committed_offset.labels.call_args_list:
+            offset_calls_by_partition[call.kwargs["partition"]] = None
+
+        assert set(lag_calls_by_partition) == {"0", "1", "2", "3"}
+        assert set(offset_calls_by_partition) == {"0", "1", "2", "3"}


### PR DESCRIPTION
## Summary

After `_recover_stale_committed_offsets` runs, set `millpond_consumer_lag` and `millpond_last_committed_offset` for every assigned partition with a known watermark — not just the ones we just recovered. `main.py`'s lag updaters only touch partitions that deliver messages, so a partition that's been quiet since the pod started keeps whatever gauge value a prior pod last published. For the stale-offset case that's an inflated lag value that shows on the dashboard well after recovery has restored truth in `__consumer_offsets`.

## Why this matters

The managed-warehouse-prod-us Grafana dashboard ("Consumer Lag Per Partition") has been showing stacks of partitions parked at 10M-80M messages of lag with flat lines, while the corresponding aggregate "Records / sec" panel shows healthy throughput. That's the symptom this fix addresses — quiet partitions whose gauges still reflect a prior pod's last sample.

## Seeded position per partition

| State | Position seeded |
|---|---|
| Just recovered by `_recover_stale_committed_offsets` | recovery target (`high` for latest, `low` for earliest) |
| In retention (committed valid + within `[low, high]`) | committed offset |
| Fresh (`OFFSET_INVALID`), errored, or stale-but-not-recovered | `auto.offset.reset` target — matches where librdkafka's `STORED` fallback will land on first fetch |
| Watermark query failed for the partition | skipped — can't compute lag without `high`, and overwriting with a guess would publish a wrong value |

## Docstring/code mismatch fixed

The initial diff's docstring claimed "stale-but-not-recovered → skip" but the code path falls through to the `auto.offset.reset` target. The code is the more useful behavior (the seeded gauge matches what consumption will confirm on first delivery). Docstring updated to match.

## Test plan

- [x] 11 new unit tests in `TestSeedStartupGauges` covering each per-partition state, including `committed == low` boundary, no-watermark skip, empty-watermarks defensive case, and a multi-partition mixed-state scenario.
- [x] 3 new integration tests in `TestRecoverStaleCommittedOffsets` verifying the seeder is invoked with the right `recovered` arg after success, after commit-failure (recovered=[]), and when no recovery was needed (recovered=[]).
- [x] `ruff check` clean.
- [x] `ruff format --check` clean.
- [x] Full unit suite passes (446 tests, 1 preexisting xfail).
- [ ] Verify against the live dashboard after roll-out: partitions stuck at 10M-80M should drop to their real values once each pod restarts.