### PR TITLE
config: add DUCKLAKE_SCHEMA env var to select catalog schema

### DIFF
--- a/millpond/config.py
+++ b/millpond/config.py
@@ -23,6 +23,7 @@ class Config:
     ordinal: int
 
     # DuckLake destination
+    ducklake_schema: str
     ducklake_table: str
     ducklake_data_path: str
     ducklake_connection: str
@@ -237,6 +238,17 @@ def _load_ducklake_fields() -> dict[str, str | None]:
             f"DUCKLAKE_TABLE {ducklake_table!r} contains unsafe characters (must match [a-zA-Z_][a-zA-Z0-9_]*)"
         )
 
+    # Default `main` preserves the historical DuckDB schema for any
+    # millpond instance that doesn't set DUCKLAKE_SCHEMA. Schema
+    # identifiers follow the same DuckDB SQL-identifier rules as table
+    # names, so we reuse the table-name regex rather than introducing a
+    # second pattern.
+    ducklake_schema = os.environ.get("DUCKLAKE_SCHEMA", "").strip() or "main"
+    if not _SAFE_TABLE_NAME.match(ducklake_schema):
+        raise RuntimeError(
+            f"DUCKLAKE_SCHEMA {ducklake_schema!r} contains unsafe characters (must match [a-zA-Z_][a-zA-Z0-9_]*)"
+        )
+
     partition_by = os.environ.get("DUCKLAKE_PARTITION_BY", "").strip() or None
     if partition_by and not SAFE_PARTITION_EXPR.match(partition_by):
         raise RuntimeError(
@@ -244,6 +256,7 @@ def _load_ducklake_fields() -> dict[str, str | None]:
         )
 
     return {
+        "ducklake_schema": ducklake_schema,
         "ducklake_table": ducklake_table,
         "ducklake_data_path": _require("DUCKLAKE_DATA_PATH"),
         "ducklake_connection": _require("DUCKLAKE_CONNECTION"),
@@ -340,8 +353,9 @@ def load() -> Config:
     )
 
     log.info(
-        "Config: topic=%s table=%s ordinal=%d/%d group_id=%s",
+        "Config: topic=%s schema=%s table=%s ordinal=%d/%d group_id=%s",
         topic,
+        cfg.ducklake_schema,
         cfg.table_label,
         ordinal,
         replica_count,

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -130,12 +130,15 @@ def _validate_partition_expr(expr: str) -> str:
     return expr
 
 
-def _table_exists(conn: duckdb.DuckDBPyConnection, table_name: str) -> bool:
+def _table_exists(
+    conn: duckdb.DuckDBPyConnection,
+    table_name: str,
+    schema_name: str = "main",
+) -> bool:
     """Check if a table exists in the DuckLake catalog."""
     result = conn.execute(
-        "SELECT 1 FROM information_schema.tables "
-        "WHERE table_catalog = 'lake' AND table_schema = 'main' AND table_name = ?",
-        [table_name],
+        "SELECT 1 FROM information_schema.tables WHERE table_catalog = 'lake' AND table_schema = ? AND table_name = ?",
+        [schema_name, table_name],
     ).fetchone()
     return result is not None
 
@@ -146,6 +149,7 @@ def _ensure_table(
     batch: pa.Table,
     tables_ensured: set[str],
     partition_by: str | None = None,
+    schema_name: str = "main",
 ) -> None:
     """Create the DuckLake table if it doesn't exist. Caller-owned cache.
 
@@ -165,37 +169,42 @@ def _ensure_table(
     if table_name in tables_ensured:
         return
 
-    if _table_exists(conn, table_name):
-        log.info("Table %s already exists", table_name)
+    if _table_exists(conn, table_name, schema_name):
+        log.info("Table %s.%s already exists", schema_name, table_name)
         tables_ensured.add(table_name)
         return
 
     conn.register("_schema_batch", batch.slice(0, 0))  # empty batch, just schema
     try:
         conn.execute(
-            f"CREATE TABLE IF NOT EXISTS lake.main.{table_name} AS "
+            f"CREATE TABLE IF NOT EXISTS lake.{schema_name}.{table_name} AS "
             "SELECT *, NOW() AS _inserted_at FROM _schema_batch WHERE false"
         )
     except duckdb.Error as e:
         # Another pod may have created the table concurrently
-        if _table_exists(conn, table_name):
-            log.info("Table %s created by another pod, continuing", table_name)
+        if _table_exists(conn, table_name, schema_name):
+            log.info("Table %s.%s created by another pod, continuing", schema_name, table_name)
         else:
-            raise RuntimeError(f"Failed to create table {table_name}: {e}") from e
+            raise RuntimeError(f"Failed to create table {schema_name}.{table_name}: {e}") from e
     finally:
         conn.unregister("_schema_batch")
 
     if partition_by is not None:
         _validate_partition_expr(partition_by)
         try:
-            conn.execute(f"ALTER TABLE lake.main.{table_name} SET PARTITIONED BY ({partition_by})")
-            log.info("Table %s partitioned by: %s", table_name, partition_by)
+            conn.execute(f"ALTER TABLE lake.{schema_name}.{table_name} SET PARTITIONED BY ({partition_by})")
+            log.info("Table %s.%s partitioned by: %s", schema_name, table_name, partition_by)
         except duckdb.Error as e:
             # Another pod may have already set partitioning — verify table exists and continue
-            if _table_exists(conn, table_name):
-                log.info("Table %s partition may have been set by another pod, continuing: %s", table_name, e)
+            if _table_exists(conn, table_name, schema_name):
+                log.info(
+                    "Table %s.%s partition may have been set by another pod, continuing: %s",
+                    schema_name,
+                    table_name,
+                    e,
+                )
             else:
-                raise RuntimeError(f"Failed to partition table {table_name}: {e}") from e
+                raise RuntimeError(f"Failed to partition table {schema_name}.{table_name}: {e}") from e
 
     tables_ensured.add(table_name)
 
@@ -207,15 +216,18 @@ def write(
     tables_ensured: set[str],
     schema_mgr: schema.SchemaManager | None = None,
     partition_by: str | None = None,
+    schema_name: str = "main",
 ) -> None:
     """Write an Arrow table to DuckLake with _inserted_at timestamp."""
     check_reserved_collision(batch.schema, RESERVED_COLUMNS)
-    _ensure_table(conn, table_name, batch, tables_ensured, partition_by)
+    _ensure_table(conn, table_name, batch, tables_ensured, partition_by, schema_name)
     if schema_mgr is not None:
         schema_mgr.evolve(batch.schema)
     conn.register("_arrow_batch", batch)
     try:
-        conn.execute(f"INSERT INTO lake.main.{table_name} BY NAME (SELECT *, NOW() AS _inserted_at FROM _arrow_batch)")
+        conn.execute(
+            f"INSERT INTO lake.{schema_name}.{table_name} BY NAME (SELECT *, NOW() AS _inserted_at FROM _arrow_batch)"
+        )
     finally:
         conn.unregister("_arrow_batch")
 
@@ -243,6 +255,7 @@ class DuckLakeSink:
         # below are read either by connect() building the Postgres
         # connstring or by this constructor.
         for name in (
+            "ducklake_schema",
             "ducklake_table",
             "ducklake_connection",
             "ducklake_data_path",
@@ -256,13 +269,22 @@ class DuckLakeSink:
                 raise RuntimeError(f"DuckLakeSink requires cfg.{name}; config.load() should have enforced this")
         self._cfg = cfg
         self._conn = connect(cfg)
+        self._schema_name = cfg.ducklake_schema
         self._table_name = cfg.ducklake_table
         self._partition_by = cfg.partition_by
         self._tables_ensured: set[str] = set()
-        self._schema_mgr = schema.SchemaManager(self._conn, self._table_name)
+        self._schema_mgr = schema.SchemaManager(self._conn, self._table_name, self._schema_name)
 
     def write(self, batch: pa.Table) -> None:
-        write(self._conn, self._table_name, batch, self._tables_ensured, self._schema_mgr, self._partition_by)
+        write(
+            self._conn,
+            self._table_name,
+            batch,
+            self._tables_ensured,
+            self._schema_mgr,
+            self._partition_by,
+            self._schema_name,
+        )
 
     def reset_caches(self) -> None:
         self._tables_ensured.clear()

--- a/millpond/schema.py
+++ b/millpond/schema.py
@@ -82,9 +82,19 @@ def _normalize_duckdb_type(type_name: str) -> str:
 class SchemaManager:
     """Tracks the DuckLake table schema and evolves it as needed."""
 
-    def __init__(self, conn: duckdb.DuckDBPyConnection, table_name: str):
+    def __init__(
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        table_name: str,
+        schema_name: str = "main",
+    ):
+        # `schema_name` defaults to "main" so existing callers (and the
+        # in-process tests that hand-construct a SchemaManager) keep
+        # writing into DuckDB's default schema without changes.
+        # Production callers should set it from cfg.ducklake_schema.
         self._conn = conn
         self._table_name = table_name
+        self._schema_name = schema_name
         self._known_columns: dict[str, str] = {}  # column_name -> duckdb_type
         self._initialized = False
 
@@ -93,8 +103,8 @@ class SchemaManager:
         try:
             result = self._conn.execute(
                 "SELECT column_name, data_type FROM information_schema.columns "
-                "WHERE table_catalog = 'lake' AND table_schema = 'main' AND table_name = ?",
-                [self._table_name],
+                "WHERE table_catalog = 'lake' AND table_schema = ? AND table_name = ?",
+                [self._schema_name, self._table_name],
             ).fetchall()
             self._known_columns = {row[0]: _normalize_duckdb_type(row[1]) for row in result}
             self._initialized = True
@@ -130,7 +140,7 @@ class SchemaManager:
                 log.info("Schema evolution: adding column %s (%s)", field.name, duckdb_type)
                 try:
                     self._conn.execute(
-                        f"ALTER TABLE lake.main.{self._table_name} "
+                        f"ALTER TABLE lake.{self._schema_name}.{self._table_name} "
                         f'ADD COLUMN IF NOT EXISTS "{field.name}" {duckdb_type}'
                     )
                     self._known_columns[field.name] = duckdb_type
@@ -150,7 +160,7 @@ class SchemaManager:
                 )
                 try:
                     self._conn.execute(
-                        f"ALTER TABLE lake.main.{self._table_name} "
+                        f"ALTER TABLE lake.{self._schema_name}.{self._table_name} "
                         f'ALTER COLUMN "{field.name}" SET DATA TYPE {duckdb_type}'
                     )
                     self._known_columns[field.name] = duckdb_type

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -102,6 +102,30 @@ class TestLoad:
             cfg = load()
             assert cfg.ducklake_table == name
 
+    def test_ducklake_schema_default_main(self):
+        # When DUCKLAKE_SCHEMA is unset, fall back to DuckDB's default
+        # schema so existing deployments keep writing the same path.
+        cfg = load()
+        assert cfg.ducklake_schema == "main"
+
+    def test_ducklake_schema_empty_string_treated_as_main(self, monkeypatch):
+        # Helm-template gotcha: unset values render as "" rather than
+        # being absent. Treat empty/whitespace as fall-back to default
+        # rather than raising — symmetric with DUCKLAKE_PARTITION_BY.
+        monkeypatch.setenv("DUCKLAKE_SCHEMA", "")
+        cfg = load()
+        assert cfg.ducklake_schema == "main"
+
+    def test_ducklake_schema_explicit_value(self, monkeypatch):
+        monkeypatch.setenv("DUCKLAKE_SCHEMA", "posthog")
+        cfg = load()
+        assert cfg.ducklake_schema == "posthog"
+
+    def test_ducklake_schema_unsafe_rejected(self, monkeypatch):
+        monkeypatch.setenv("DUCKLAKE_SCHEMA", "posthog; DROP TABLE x")
+        with pytest.raises(RuntimeError, match="DUCKLAKE_SCHEMA.*unsafe characters"):
+            load()
+
     def test_partition_by_default_none(self):
         cfg = load()
         assert cfg.partition_by is None

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -137,6 +137,7 @@ def _make_cfg(**overrides) -> Config:
         group_id="test-group",
         replica_count=4,
         ordinal=1,
+        ducklake_schema="main",
         ducklake_table="events",
         ducklake_data_path="s3://bucket/data",
         ducklake_connection=":memory:",

--- a/tests/unit/test_ducklake_sink.py
+++ b/tests/unit/test_ducklake_sink.py
@@ -25,6 +25,7 @@ from millpond.ducklake import DuckLakeSink
 
 def _ducklake_cfg(**overrides) -> MagicMock:
     cfg = MagicMock()
+    cfg.ducklake_schema = "main"
     cfg.ducklake_table = "events"
     cfg.ducklake_connection = ":memory:"
     cfg.ducklake_data_path = "s3://bucket/data"
@@ -39,15 +40,16 @@ def _ducklake_cfg(**overrides) -> MagicMock:
     return cfg
 
 
-
 class TestDuckLakeSinkInit:
     def test_constructs_schema_manager_with_right_table(self):
-        with patch("millpond.ducklake.connect") as mock_connect, patch(
-            "millpond.ducklake.schema.SchemaManager"
-        ) as mock_sm:
+        with (
+            patch("millpond.ducklake.connect") as mock_connect,
+            patch("millpond.ducklake.schema.SchemaManager") as mock_sm,
+        ):
             mock_connect.return_value = MagicMock(name="conn")
             sink = DuckLakeSink(_ducklake_cfg())
-            mock_sm.assert_called_once_with(mock_connect.return_value, "events")
+            mock_sm.assert_called_once_with(mock_connect.return_value, "events", "main")
+            assert sink._schema_name == "main"
             assert sink._table_name == "events"
             assert sink._partition_by is None
             assert sink._tables_ensured == set()
@@ -55,6 +57,7 @@ class TestDuckLakeSinkInit:
     @pytest.mark.parametrize(
         "missing_field",
         [
+            "ducklake_schema",
             "ducklake_table",
             "ducklake_connection",
             "ducklake_data_path",
@@ -85,9 +88,10 @@ class TestDuckLakeSinkInit:
 
 class TestDuckLakeSinkResetCaches:
     def test_clears_tables_ensured_and_invalidates_schema_mgr(self):
-        with patch("millpond.ducklake.connect") as mock_connect, patch(
-            "millpond.ducklake.schema.SchemaManager"
-        ) as mock_sm:
+        with (
+            patch("millpond.ducklake.connect") as mock_connect,
+            patch("millpond.ducklake.schema.SchemaManager") as mock_sm,
+        ):
             mock_connect.return_value = MagicMock(name="conn")
             sink = DuckLakeSink(_ducklake_cfg())
             sink._tables_ensured.add("events")
@@ -104,4 +108,3 @@ class TestDuckLakeSinkClose:
             sink = DuckLakeSink(_ducklake_cfg())
             sink.close()
             mock_conn.close.assert_called_once()
-

--- a/tests/unit/test_millpond_logging_config.py
+++ b/tests/unit/test_millpond_logging_config.py
@@ -41,6 +41,7 @@ def _minimal_config() -> Config:
         group_id="millpond-test",
         replica_count=1,
         ordinal=0,
+        ducklake_schema="main",
         ducklake_table="events",
         ducklake_data_path="s3://bucket/data",
         ducklake_connection=":memory:",


### PR DESCRIPTION
## Summary

- New optional `DUCKLAKE_SCHEMA` env var (default `"main"`) threaded through `Config`, `DuckLakeSink`, `SchemaManager`, and the module-level `write` / `_ensure_table` / `_table_exists` helpers.
- All hardcoded `lake.main.*` references become `lake.<schema_name>.*` (3 sites in `ducklake.py`, 3 in `schema.py`).
- Schema-name identifiers validated against the same `_SAFE_TABLE_NAME` regex; empty/whitespace falls back to `"main"` (symmetric with `DUCKLAKE_PARTITION_BY`).
- Helper-function `schema_name` params default to `"main"` so existing in-process callers (tests, future callers) work unchanged.

## Why

Today millpond writes to DuckDB's default `main` schema in the attached DuckLake catalog. Standing up a new millpond instance that targets a non-default schema (e.g. `posthog` to match the layout that viaduck will eventually populate at `posthog.events_nrt`) is currently impossible — `DUCKLAKE_TABLE` is regex-validated to disallow dots, and there's no schema env var.

This change is the minimum-surface fix: one env var, threaded through; default keeps every existing deployment unaffected.

## Test plan

- [x] `just test` (`pytest tests/unit`) — **463 passed, 1 xfailed**
- [x] `just test-integration` — **16 passed**
- [x] `just test-e2e` — **4 passed**
- [x] `ruff check` clean on changed files
- [x] `ruff format --check` clean on changed files
- [x] New `test_config.py` cases cover: default `"main"`, empty-string falls back to `"main"`, explicit value passes through, unsafe value rejected
- [x] `test_ducklake_sink.py` parametrized missing-field guard now includes `ducklake_schema`; constructor test asserts `SchemaManager` is called with the schema