### PR TITLE
config: bump default ducklake_max_retry_count from 10 → 100

### DIFF
--- a/millpond/config.py
+++ b/millpond/config.py
@@ -34,6 +34,14 @@ class Config:
     rds_password: str
     partition_by: str | None  # e.g. "year(timestamp),month(timestamp),day(timestamp),hour(timestamp)"
 
+    # DuckLake commit-retry budget. DuckLake's default is 10, which is not
+    # enough when many writers commit against the same metadata catalog
+    # concurrently — losers of snapshot-id allocation races burn through
+    # 10 retries quickly and surface as PK collisions on
+    # ducklake_snapshot_pkey. Loaded from DUCKLAKE_MAX_RETRY_COUNT with a
+    # 100 default (the value DuckLake's own error message suggests).
+    ducklake_max_retry_count: int
+
     # Flush triggers
     flush_size: int  # bytes of accumulated Arrow data
     flush_interval_ms: int  # ms since last flush
@@ -255,6 +263,14 @@ def _load_ducklake_fields() -> dict[str, str | None]:
             f"DUCKLAKE_PARTITION_BY {partition_by!r} contains unsafe characters (must match [a-zA-Z0-9_(),\\s]+)"
         )
 
+    # Reject 0 explicitly — DuckLake itself accepts 0 (no retries), but in
+    # this codebase a 0 budget under multi-writer concurrency degenerates
+    # straight to the PK-collision crash the default was raised to avoid.
+    # An operator misrendering an unset env var as "0" should fail loudly.
+    ducklake_max_retry_count = int(os.environ.get("DUCKLAKE_MAX_RETRY_COUNT", "100"))
+    if ducklake_max_retry_count <= 0:
+        raise RuntimeError(f"DUCKLAKE_MAX_RETRY_COUNT={ducklake_max_retry_count!r} must be a positive integer")
+
     return {
         "ducklake_schema": ducklake_schema,
         "ducklake_table": ducklake_table,
@@ -266,6 +282,7 @@ def _load_ducklake_fields() -> dict[str, str | None]:
         "rds_username": os.environ.get("DUCKLAKE_RDS_USERNAME", "ducklake"),
         "rds_password": _require("DUCKLAKE_RDS_PASSWORD"),
         "partition_by": partition_by,
+        "ducklake_max_retry_count": ducklake_max_retry_count,
     }
 
 

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -93,6 +93,14 @@ def connect(cfg: Config) -> duckdb.DuckDBPyConnection:
     # Disabling insertion order allows DuckDB to process partitions sequentially.
     conn.execute("SET preserve_insertion_order = false")
 
+    # DuckLake retries failed commits up to ducklake_max_retry_count
+    # times before surfacing the error. Default is 10, which is too low
+    # for multi-writer deployments — losers of the snapshot-id allocation
+    # race burn 10 retries fast and surface as
+    # `ducklake_snapshot_pkey` duplicate-key violations. Loaded from
+    # DUCKLAKE_MAX_RETRY_COUNT env (default 100).
+    conn.execute(f"SET ducklake_max_retry_count = {int(cfg.ducklake_max_retry_count)}")
+
     # Build a libpq connection string for DuckLake.
     # The 'postgres:' prefix tells DuckLake to use the Postgres extension
     # for metadata storage rather than a local DuckDB file.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -126,6 +126,32 @@ class TestLoad:
         with pytest.raises(RuntimeError, match="DUCKLAKE_SCHEMA.*unsafe characters"):
             load()
 
+    def test_ducklake_max_retry_count_default_100(self):
+        # DuckLake's own default is 10; we bump to 100 to absorb
+        # snapshot-id allocation contention from multi-writer deployments
+        # (see PR description). Lock the default so a future env-loader
+        # refactor doesn't silently regress concurrency behaviour.
+        cfg = load()
+        assert cfg.ducklake_max_retry_count == 100
+
+    def test_ducklake_max_retry_count_explicit_value(self, monkeypatch):
+        monkeypatch.setenv("DUCKLAKE_MAX_RETRY_COUNT", "250")
+        cfg = load()
+        assert cfg.ducklake_max_retry_count == 250
+
+    def test_ducklake_max_retry_count_zero_rejected(self, monkeypatch):
+        # 0 disables retries entirely — under multi-writer load it
+        # degenerates straight to the PK-collision failure mode we're
+        # raising the default to avoid. Refuse loudly rather than accept.
+        monkeypatch.setenv("DUCKLAKE_MAX_RETRY_COUNT", "0")
+        with pytest.raises(RuntimeError, match="DUCKLAKE_MAX_RETRY_COUNT.*positive integer"):
+            load()
+
+    def test_ducklake_max_retry_count_negative_rejected(self, monkeypatch):
+        monkeypatch.setenv("DUCKLAKE_MAX_RETRY_COUNT", "-5")
+        with pytest.raises(RuntimeError, match="DUCKLAKE_MAX_RETRY_COUNT.*positive integer"):
+            load()
+
     def test_partition_by_default_none(self):
         cfg = load()
         assert cfg.partition_by is None

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -147,6 +147,7 @@ def _make_cfg(**overrides) -> Config:
         rds_username="ducklake",
         rds_password="pass",
         partition_by=None,
+        ducklake_max_retry_count=100,
         flush_size=100,
         flush_interval_ms=1000,
         fetch_min_bytes=1,

--- a/tests/unit/test_millpond_logging_config.py
+++ b/tests/unit/test_millpond_logging_config.py
@@ -51,6 +51,7 @@ def _minimal_config() -> Config:
         rds_username="ducklake",
         rds_password="pass",
         partition_by=None,
+        ducklake_max_retry_count=100,
         flush_size=104857600,
         flush_interval_ms=60000,
         fetch_min_bytes=1048576,


### PR DESCRIPTION
## Summary

DuckLake retries failed commits up to `ducklake_max_retry_count` times before surfacing the error. Its default is 10, which is not enough when many writers commit against the same metadata catalog concurrently — losers of snapshot-id allocation races burn through 10 retries fast and surface as duplicate-key violations on `ducklake_snapshot_pkey`.

Observed in prod on the new `millpond-portola` direct-to-duckling NRT path (16 replicas, one `duckling-portola` catalog): batches were failing after ~10 successful concurrent commits ran the unlucky pod's retry budget out. Trace:

```
TransactionContext Error: Failed to commit: Failed to commit DuckLake transaction.
Exceeded the maximum retry count of 10 set by the ducklake_max_retry_count setting.
...
ERROR:  duplicate key value violates unique constraint "ducklake_snapshot_pkey"
DETAIL:  Key (snapshot_id)=(202831) already exists.
```

Between two failed attempts on the same pod, the snapshot_id had advanced by 23 — meaning ~11 other writers had successfully committed in the gap. The slowest pod just keeps losing the race until the retry budget runs out.

## Change

- New `Config.ducklake_max_retry_count: int` field, loaded from `DUCKLAKE_MAX_RETRY_COUNT` env (default **100** — the value DuckLake's own error message suggests).
- Rejects `0` and negative values at load time so unset / misrendered env vars fail loudly rather than degenerate to "no retries".
- `ducklake.connect()` issues `SET ducklake_max_retry_count = <cfg.ducklake_max_retry_count>` alongside the existing `SET preserve_insertion_order = false`, so every session inherits it.

## What this isn't

A fix for the underlying contention. The catalog is a single-writer bottleneck regardless of `ducklake_max_retry_count`; this just buys more retries before the failure surfaces. Longer-term, the right structural answer is fewer concurrent writers (drop replicas) or partition-sharded commit (each pod owns a disjoint partition set so they never compete for snapshot IDs).

## Test plan

- [x] `just test` (`pytest tests/unit`) — **467 passed, 1 xfailed** (4 new cases on the env loader: default 100, explicit override, 0 rejected, negative rejected)
- [x] `just test-integration` — **16 passed**
- [x] `just test-e2e` — **4 passed**
- [x] `ruff check` clean on changed files
- [x] `ruff format --check` clean on changed files