### PR TITLE
metrics: split write-retry errors by DuckLake-contention vs other

### DIFF
--- a/millpond/main.py
+++ b/millpond/main.py
@@ -179,21 +179,45 @@ def _apply_sort(table: pa.Table, cfg: config.Config) -> pa.Table:
     return table.take(indices)
 
 
+def _is_commit_contention(exc: BaseException) -> bool:
+    """Detect DuckLake catalog-write contention from the exception text.
+
+    DuckLake's commit loop retries up to ducklake_max_retry_count times
+    on PK collisions and serialization conflicts; if that budget is
+    exhausted the surfaced exception carries either an explicit
+    "maximum retry count" sentinel (DuckLake-emitted) or the underlying
+    duplicate-key / serialization-failure text bubbled up from
+    Postgres. Anything else (S3 timeout, schema-evolution race,
+    OOM, etc.) is classed as plain write_retry.
+
+    Keep the substrings stable — they label a metric that an alert
+    may key on. Strings are sourced from:
+      - DuckLake: src/storage/ducklake_transaction_state.cpp:1748
+        "Exceeded the maximum retry count of ..."
+      - Postgres (libpq): "duplicate key value violates unique constraint"
+      - Postgres (libpq): "could not serialize access"
+    """
+    msg = str(exc)
+    return "maximum retry count" in msg or "duplicate key value" in msg or "could not serialize access" in msg
+
+
 def _write_with_retry(sink, consolidated):
     """Write to the sink with exponential backoff on transient failures."""
     for attempt in range(_WRITE_MAX_RETRIES):
         try:
             sink.write(consolidated)
             return
-        except Exception:
-            metrics.errors_total.labels(type="write_retry").inc()
+        except Exception as exc:
+            error_type = "ducklake_commit_contention" if _is_commit_contention(exc) else "write_retry"
+            metrics.errors_total.labels(type=error_type).inc()
             if attempt == _WRITE_MAX_RETRIES - 1:
                 raise
             delay = _WRITE_BASE_DELAY_S * (2**attempt)
             log.warning(
-                "Write failed (attempt %d/%d), retrying in %.1fs",
+                "Write failed (attempt %d/%d, type=%s), retrying in %.1fs",
                 attempt + 1,
                 _WRITE_MAX_RETRIES,
+                error_type,
                 delay,
                 exc_info=True,
             )

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -87,6 +87,78 @@ class TestWriteWithRetry:
         sink.reset_caches.assert_called_once()
 
 
+# DuckLake-contention strings the metric labeler must catch. Locking these
+# in so a future "improve error messages upstream" PR doesn't silently
+# break the alert-able signal.
+_DUCKLAKE_CONTENTION_MESSAGES = [
+    # DuckLake's own retry-budget-exhausted error (the one operators most
+    # often surface via `ducklake_max_retry_count` bumps)
+    "Failed to commit DuckLake transaction.\nExceeded the maximum retry count of 100 ...",
+    # Underlying Postgres unique-violation bubbled up before DuckLake
+    # gives up
+    'duplicate key value violates unique constraint "ducklake_snapshot_pkey"',
+    # Postgres serialization failure under SERIALIZABLE isolation —
+    # unlikely on duckling RDS today but cheap to classify
+    "ERROR: could not serialize access due to concurrent update",
+]
+
+
+class TestWriteWithRetryErrorLabels:
+    """The metric label distinguishes catalog-contention retries from
+    every other write failure. Without this split, an alert on
+    `millpond_errors_total{type="write_retry"}` lumps S3 timeouts in
+    with snapshot-id PK collisions and can't tell you which is which.
+    """
+
+    @pytest.mark.parametrize("msg", _DUCKLAKE_CONTENTION_MESSAGES)
+    def test_contention_message_labels_as_commit_contention(self, msg):
+        sink = _make_sink()
+        sink.write.side_effect = [duckdb.Error(msg), None]
+        table = pa.table({"a": [1]})
+        with patch("millpond.main.time"), patch("millpond.main.metrics") as mock_metrics:
+            _write_with_retry(sink, table)
+        # Exactly one increment, labeled ducklake_commit_contention.
+        calls = mock_metrics.errors_total.labels.call_args_list
+        assert len(calls) == 1
+        assert calls[0].kwargs == {"type": "ducklake_commit_contention"}
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            OSError("S3 timeout"),
+            duckdb.Error("schema mismatch"),
+            KafkaException("broker disconnect"),
+            RuntimeError("unexpected"),
+        ],
+    )
+    def test_non_contention_exception_labels_as_write_retry(self, exc):
+        sink = _make_sink()
+        sink.write.side_effect = [exc, None]
+        table = pa.table({"a": [1]})
+        with patch("millpond.main.time"), patch("millpond.main.metrics") as mock_metrics:
+            _write_with_retry(sink, table)
+        calls = mock_metrics.errors_total.labels.call_args_list
+        assert len(calls) == 1
+        assert calls[0].kwargs == {"type": "write_retry"}
+
+    def test_mixed_attempts_label_per_attempt(self):
+        """Each retry increments according to the exception that triggered
+        it — a contention failure then an S3 failure produces one of each
+        label, not "whichever exception was last."
+        """
+        sink = _make_sink()
+        sink.write.side_effect = [
+            duckdb.Error("Exceeded the maximum retry count of 100"),
+            OSError("S3 connection reset"),
+            None,
+        ]
+        table = pa.table({"a": [1]})
+        with patch("millpond.main.time"), patch("millpond.main.metrics") as mock_metrics:
+            _write_with_retry(sink, table)
+        labels = [c.kwargs["type"] for c in mock_metrics.errors_total.labels.call_args_list]
+        assert labels == ["ducklake_commit_contention", "write_retry"]
+
+
 class TestFlushErrorDistinction:
     """Offset commit failures must be distinguishable from write failures in metrics and logs."""
 
@@ -733,7 +805,6 @@ class TestApplySort:
         result = _apply_sort(table, self._cfg(sort_by=("region",)))
 
         assert result.column("region").to_pylist() == ["eu-central-1", "us-east-1", "us-west-2"]
-
 
 
 class TestFlushCommit:


### PR DESCRIPTION
## Summary

The existing `millpond_errors_total{type="write_retry"}` counter conflates DuckLake catalog-write contention (the snapshot-id PK collisions PR #92 is mitigating) with unrelated transient write failures (S3 timeouts, schema-evolution races, etc.). With one label, alerts can't tell *"duckling-portola is choking on catalog contention"* from *"S3 is having a moment"* — both look like "write_retry going up."

Splits the label at the `_write_with_retry` catch site. A new helper `_is_commit_contention(exc)` inspects the exception text for three sentinels:

| Sentinel | Source |
|---|---|
| `"maximum retry count"` | DuckLake retry-budget-exhausted message (`src/storage/ducklake_transaction_state.cpp:1748`) |
| `"duplicate key value"` | Postgres unique-violation bubbled up before DuckLake's budget ran out |
| `"could not serialize access"` | Postgres serialization failure under SERIALIZABLE isolation |

Matches emit `type="ducklake_commit_contention"`; everything else keeps `type="write_retry"`. The log line also carries the type so the surfaced warning is self-classifying.

## Why now

The snapshot-id PK collisions on the duckling-portola path (PR #92) bumped the DuckLake retry budget from 10 to 100 to absorb concurrent commits. We need a measurable signal for *"are we still burning that budget, and how fast?"* — and a way to alert on contention specifically without the alert firing every time S3 has a 30-second blip. This label is the precondition for any further work (semaphore / coordination / replica-count tuning).

## Why string-matching

Substring-matching the exception message is fragile in principle. In practice the message comes from a stable source in DuckLake's commit loop and from libpq, both of which have years-old strings. Vendoring a `duckdb.TransactionException` type check would be tighter but doesn't distinguish contention from other transaction errors. The function is small and isolated; if either upstream renames the string, the alert quietly stops firing and the test in this PR catches it in CI.

## Test plan

- [x] `just test` (`pytest tests/unit`) — **475 passed, 1 xfailed** (8 new cases: 3 contention messages × parametrize + 4 non-contention exception types + 1 mixed-attempts ordering test)
- [x] `just test-integration` — **16 passed**
- [x] `just test-e2e` — **4 passed**
- [x] `ruff check` clean
- [x] `ruff format --check` clean