### PR TITLE
image: install duckdb CLI from upstream binary; smoke-test at build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,16 +12,19 @@ ARG MILLPOND_VERSION=0.0.0.dev0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$MILLPOND_VERSION
 RUN uv sync --frozen --no-dev --extra msk-iam
 
-# Install DuckDB CLI (pinned to match the Python package version from pyproject.toml).
-# Install to /opt/uv-tools + /usr/local/bin (both world-readable) instead of the
-# uv default of /root/.local — that subtree is mode 700 on python:3.12-slim, so
-# the non-root `millpond` user in the final stage can't traverse it, and the
-# CLI shim fails with "bad interpreter: Permission denied". Pin to the system
-# python so uv doesn't install a managed interpreter into another /root subtree.
+# Install DuckDB CLI from the upstream GitHub release. duckdb-cli is a single
+# static binary, so we avoid `uv tool install` here: that path installs a full
+# Python venv just to PATH a self-contained C++ binary, and its default install
+# location (/root/.local, mode 700 on python:3.12-slim) is unreachable by the
+# non-root `millpond` runtime user. Pin the version from pyproject.toml so the
+# CLI tracks the duckdb Python package.
 RUN V=$(python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb'))['project']['dependencies']; print(next(x.split('==')[1] for x in d if x.startswith('duckdb==')))") \
-    && UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin \
-       uv tool install --python /usr/local/bin/python3.12 "duckdb-cli==$V" \
-    && chmod -R a+rX /opt/uv-tools
+    && apt-get update && apt-get install -y --no-install-recommends curl unzip \
+    && curl -fsSL "https://github.com/duckdb/duckdb/releases/download/v${V}/duckdb_cli-linux-amd64.zip" -o /tmp/duckdb.zip \
+    && unzip -d /usr/local/bin /tmp/duckdb.zip \
+    && chmod 0755 /usr/local/bin/duckdb \
+    && rm /tmp/duckdb.zip \
+    && apt-get remove -y curl unzip && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
 
 FROM python:3.12-slim
 
@@ -29,7 +32,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends just=1.40.0* &&
 
 COPY --from=builder /app/.venv /app/.venv
 COPY --from=builder /app/millpond /app/millpond
-COPY --from=builder /opt/uv-tools /opt/uv-tools
 COPY --from=builder /usr/local/bin/duckdb /usr/local/bin/duckdb
 COPY tools/justfile /justfile
 COPY tools/ducklake_maintenance.py /app/tools/ducklake_maintenance.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,12 @@ USER millpond
 # extension's build SHA at runtime so a drift trips in CI rather than in prod.
 RUN python -c "import duckdb; c = duckdb.connect(); c.execute('INSTALL httpfs'); c.execute('INSTALL ducklake'); c.execute('INSTALL postgres')"
 
+# Build-time smoke test for the duckdb CLI as the runtime user. Catches any
+# regression where the CLI is installed somewhere the `millpond` user can't
+# execute it (the failure mode we just patched). Cheap (~ms) and runs in the
+# same layer the regression would land in.
+RUN duckdb -c "SELECT 1;" >/dev/null
+
 # Health check for non-K8s environments (K8s uses liveness/readiness probes in statefulset.yaml).
 EXPOSE 8000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,19 @@ RUN uv sync --frozen --no-dev --extra msk-iam
 # location (/root/.local, mode 700 on python:3.12-slim) is unreachable by the
 # non-root `millpond` runtime user. Pin the version from pyproject.toml so the
 # CLI tracks the duckdb Python package.
-RUN V=$(python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb'))['project']['dependencies']; print(next(x.split('==')[1] for x in d if x.startswith('duckdb==')))") \
+#
+# TARGETARCH is set by buildx for each platform in the build matrix
+# (linux/amd64 → amd64, linux/arm64 → arm64). DuckDB names its release
+# assets with the same suffix, so this drops in directly. -j on unzip
+# extracts only the `duckdb` binary; the release zip also ships a LICENSE
+# we don't want polluting /usr/local/bin.
+ARG TARGETARCH
+RUN test -n "$TARGETARCH" \
+    && case "$TARGETARCH" in amd64|arm64) ;; *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; esac \
+    && V=$(python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb'))['project']['dependencies']; print(next(x.split('==')[1] for x in d if x.startswith('duckdb==')))") \
     && apt-get update && apt-get install -y --no-install-recommends curl unzip \
-    && curl -fsSL "https://github.com/duckdb/duckdb/releases/download/v${V}/duckdb_cli-linux-amd64.zip" -o /tmp/duckdb.zip \
-    && unzip -d /usr/local/bin /tmp/duckdb.zip \
+    && curl -fsSL "https://github.com/duckdb/duckdb/releases/download/v${V}/duckdb_cli-linux-${TARGETARCH}.zip" -o /tmp/duckdb.zip \
+    && unzip -j -d /usr/local/bin /tmp/duckdb.zip duckdb \
     && chmod 0755 /usr/local/bin/duckdb \
     && rm /tmp/duckdb.zip \
     && apt-get remove -y curl unzip && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,16 @@ ARG MILLPOND_VERSION=0.0.0.dev0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$MILLPOND_VERSION
 RUN uv sync --frozen --no-dev --extra msk-iam
 
-# Install DuckDB CLI (pinned to match the Python package version from pyproject.toml)
+# Install DuckDB CLI (pinned to match the Python package version from pyproject.toml).
+# Install to /opt/uv-tools + /usr/local/bin (both world-readable) instead of the
+# uv default of /root/.local — that subtree is mode 700 on python:3.12-slim, so
+# the non-root `millpond` user in the final stage can't traverse it, and the
+# CLI shim fails with "bad interpreter: Permission denied". Pin to the system
+# python so uv doesn't install a managed interpreter into another /root subtree.
 RUN V=$(python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb'))['project']['dependencies']; print(next(x.split('==')[1] for x in d if x.startswith('duckdb==')))") \
-    && uv tool install "duckdb-cli==$V"
+    && UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin \
+       uv tool install --python /usr/local/bin/python3.12 "duckdb-cli==$V" \
+    && chmod -R a+rX /opt/uv-tools
 
 FROM python:3.12-slim
 
@@ -22,7 +29,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends just=1.40.0* &&
 
 COPY --from=builder /app/.venv /app/.venv
 COPY --from=builder /app/millpond /app/millpond
-COPY --from=builder /root/.local/bin/duckdb /usr/local/bin/duckdb
+COPY --from=builder /opt/uv-tools /opt/uv-tools
+COPY --from=builder /usr/local/bin/duckdb /usr/local/bin/duckdb
 COPY tools/justfile /justfile
 COPY tools/ducklake_maintenance.py /app/tools/ducklake_maintenance.py
 COPY tools/ducklake_maintenance.sql /app/tools/ducklake_maintenance.sql


### PR DESCRIPTION
## Summary

`uv tool install duckdb-cli` defaults to `/root/.local/{bin,share/uv/tools}`. The shim at `/usr/local/bin/duckdb` (after our existing COPY) had a shebang pointing at the venv python under `/root/.local/share/uv/tools/duckdb-cli/bin/python`. `python:3.12-slim`'s `/root` is mode 700, so the non-root `millpond` runtime user can't traverse it, and the shim fails with:

```
bash: /usr/local/bin/duckdb: /root/.local/share/uv/tools/duckdb-cli/bin/python: bad interpreter: Permission denied
```

This breaks `just shell` (and any direct `duckdb` invocation) for the runtime user. Surfaced when spinning up a fresh `kubectl run` debug pod from this image to drive `ducklake_flush_inlined_data` against a tenant catalog.

**Production has been silently fine** because no prod codepath shells out to the `duckdb` CLI — every prod path uses the Python `duckdb` module from `/app/.venv`. The CLI is purely interactive (`just shell` via `tools/justfile`). So this is a debug/operations ergonomics bug, not a runtime regression.

## Commits

1. **First attempt** (kept for history): `UV_TOOL_DIR=/opt/uv-tools` + `--python /usr/local/bin/python3.12` override so uv installs to a world-readable path. Works, but inherits the full uv-tool venv (~52 MiB) just to PATH a static C++ binary.
2. **Replace `uv tool install` with the upstream standalone binary**. `duckdb-cli` is distributed as a single static binary on the GitHub releases page. Switching to `curl … releases/download/v${V}/duckdb_cli-linux-amd64.zip` eliminates the entire shebang-chain problem (no Python interpreter to traverse), drops the `--python` hardcode, drops the chmod ceremony, and removes ~52 MiB from the image. Version pin still comes from `pyproject.toml`'s `duckdb==` entry.
3. **Add a build-time smoke**: `RUN duckdb -c "SELECT 1;"` after `USER millpond`. Catches any future regression of "CLI is installed somewhere the runtime user can't execute it" at build time, not in a debug pod.

## Test plan

- [ ] CI image build passes (the new `RUN duckdb -c "SELECT 1;"` IS the test — it fails the build if perms regress)
- [ ] Pull the new image SHA explicitly: `kubectl run duckdb-shell --rm -it --image=ghcr.io/posthog/millpond@<sha> --image-pull-policy=Always --command -- /bin/bash`, then `duckdb --version` as the `millpond` user → prints a version, not "Permission denied"
- [ ] `just shell` works end-to-end as the `millpond` user in a fresh pod
- [ ] CronJobs / StatefulSets continue to work after rollout (Python module path is untouched)

## Notes

- Image size delta: **−~52 MiB** vs main (no `/opt/uv-tools`, no uv-tool venv)
- No call sites in millpond / charts / viaduck reference `/root/.local/bin/duckdb` or any specific duckdb binary path; PATH is the only contract