### PR TITLE
metrics: tenant label + broader catalog coverage

### DIFF
--- a/tests/integration/test_ducklake_metrics_integration.py
+++ b/tests/integration/test_ducklake_metrics_integration.py
@@ -43,13 +43,21 @@ def _http_get(url: str, timeout: float = 5.0) -> tuple[int, str]:
         return e.code, (e.read() or b"").decode()
 
 
+TENANT = "test"
+
+
 def _stub_full_catalog(c: duckdb.DuckDBPyConnection) -> None:
-    """Create the metadata schema and all five tables the built-ins query."""
+    """Create the metadata schema and every table the built-in queries touch."""
     c.execute("CREATE SCHEMA __ducklake_metadata_lake")
     c.execute(
         "CREATE TABLE __ducklake_metadata_lake.ducklake_data_file ("
         "data_file_id BIGINT, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, "
-        "path VARCHAR, file_size_bytes BIGINT, partition_id BIGINT)"
+        "path VARCHAR, file_size_bytes BIGINT, partition_id BIGINT, record_count BIGINT)"
+    )
+    c.execute(
+        "CREATE TABLE __ducklake_metadata_lake.ducklake_delete_file ("
+        "delete_file_id BIGINT, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, "
+        "path VARCHAR, file_size_bytes BIGINT)"
     )
     c.execute(
         "CREATE TABLE __ducklake_metadata_lake.ducklake_file_partition_value ("
@@ -66,12 +74,24 @@ def _stub_full_catalog(c: duckdb.DuckDBPyConnection) -> None:
         "CREATE TABLE __ducklake_metadata_lake.ducklake_metadata ("
         "key VARCHAR, value VARCHAR, scope VARCHAR, scope_id BIGINT)"
     )
+    c.execute(
+        "CREATE TABLE __ducklake_metadata_lake.ducklake_table ("
+        "table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT)"
+    )
+    c.execute(
+        "CREATE TABLE __ducklake_metadata_lake.ducklake_inlined_data_tables ("
+        "table_id BIGINT, schema_version BIGINT, table_name VARCHAR)"
+    )
     # Seed: enough rows that every metric has a non-zero value.
     c.execute(
         "INSERT INTO __ducklake_metadata_lake.ducklake_data_file VALUES "
-        "(1, 1, 0, NULL, 'a', 500000, 100),"
-        "(2, 1, 0, NULL, 'b', 50000000, 100),"
-        "(3, 1, 0, NULL, 'c', 200000000, 200)"
+        "(1, 1, 0, NULL, 'a', 500000, 100, 1000),"
+        "(2, 1, 0, NULL, 'b', 50000000, 100, 50000),"
+        "(3, 1, 0, NULL, 'c', 200000000, 200, 200000)"
+    )
+    c.execute(
+        "INSERT INTO __ducklake_metadata_lake.ducklake_delete_file VALUES "
+        "(1, 1, 0, NULL, 'd1', 1024)"
     )
     c.execute(
         "INSERT INTO __ducklake_metadata_lake.ducklake_file_partition_value VALUES "
@@ -88,8 +108,20 @@ def _stub_full_catalog(c: duckdb.DuckDBPyConnection) -> None:
         "VALUES ('s3://b/x'), ('s3://b/x'), ('s3://b/y')"
     )
     c.execute(
-        "INSERT INTO __ducklake_metadata_lake.ducklake_metadata "
-        "VALUES ('version', '0.4', NULL, NULL)"
+        "INSERT INTO __ducklake_metadata_lake.ducklake_metadata VALUES "
+        "('version', '0.4', NULL, NULL),"
+        "('auto_compact', 'true', NULL, NULL),"
+        "('data_inlining_row_limit', '0', NULL, NULL)"
+    )
+    c.execute(
+        "INSERT INTO __ducklake_metadata_lake.ducklake_table VALUES "
+        "(1, 0, NULL),"      # live
+        "(2, 0, 1)"          # dropped
+    )
+    c.execute(
+        "INSERT INTO __ducklake_metadata_lake.ducklake_inlined_data_tables VALUES "
+        "(1, 1, 'ducklake_inlined_data_1_1'),"   # parent live → reachable
+        "(99, 1, 'ducklake_inlined_data_99_1')"  # no parent ducklake_table row → unreachable
     )
 
 
@@ -128,11 +160,11 @@ class TestDaemonHTTP:
             # query at startup, so the first tick completes almost
             # immediately — no need to wait out the 1-minute interval.
             stop = threading.Event()
-            self_metrics.up.set(1)
+            self_metrics.up.labels(TENANT).set(1)
             srv.ready = True  # type: ignore[attr-defined]
             t = threading.Thread(
                 target=dm._scheduler_loop,
-                args=(conn, queries, gauges, self_metrics, stop),
+                args=(conn, queries, gauges, self_metrics, stop, TENANT),
                 name="scheduler",
                 daemon=True,
             )
@@ -168,23 +200,27 @@ class TestDaemonHTTP:
                 status, body = _http_get(f"http://127.0.0.1:{port}/metrics")
                 assert status == 200
                 expected = [
-                    # b4
                     "ducklake_pending_deletes_total",
                     "ducklake_pending_deletes_unique_paths",
                     "ducklake_pending_deletes_dup_rows",
-                    # b2
+                    "ducklake_data_files_files",
+                    "ducklake_data_files_bytes",
+                    "ducklake_data_files_rows",
+                    "ducklake_delete_files_files",
+                    "ducklake_delete_files_bytes",
                     "ducklake_files_per_band_count",
                     "ducklake_files_per_band_bytes",
-                    # b3
-                    "ducklake_compaction_candidates_count",
-                    # b5
                     "ducklake_snapshots_count",
                     "ducklake_snapshots_oldest_seconds_ago",
                     "ducklake_snapshots_newest_seconds_ago",
-                    # b6
+                    "ducklake_snapshots_oldest_id",
+                    "ducklake_snapshots_newest_id",
+                    "ducklake_inlined_data_tables_total",
+                    "ducklake_unreachable_inline_tables_total",
+                    "ducklake_tables_count",
                     "ducklake_files_per_partition_top20_count",
-                    # catalog version
                     "ducklake_catalog_format_version",
+                    "ducklake_config_value",
                     # self-metrics
                     "ducklake_metrics_up",
                     "ducklake_metrics_query_duration_seconds",
@@ -192,7 +228,7 @@ class TestDaemonHTTP:
                 ]
                 for name in expected:
                     assert name in body, f"{name!r} missing from /metrics output"
-                assert "ducklake_metrics_up 1.0" in body
+                assert f'ducklake_metrics_up{{tenant="{TENANT}"}} 1.0' in body
 
                 # 404 path — bare sanity that we didn't open random URLs.
                 status, _ = _http_get(f"http://127.0.0.1:{port}/anything-else")

--- a/tests/unit/test_ducklake_metrics.py
+++ b/tests/unit/test_ducklake_metrics.py
@@ -144,8 +144,20 @@ def registry():
     return CollectorRegistry()
 
 
+# All test invocations stamp the same synthetic tenant identity onto the
+# emitted samples; `_gauge_value` injects it automatically so individual
+# test bodies don't have to repeat the label.
+TENANT = "test"
+
+
+def _run(conn, q, gauges, sm):
+    """Shim around the underlying _run_query so test bodies don't carry the tenant arg."""
+    return dm.__dict__["_run_query"](conn, q, gauges, sm, TENANT)
+
+
 def _gauge_value(reg: CollectorRegistry, metric: str, labels: dict | None = None) -> float | None:
-    return reg.get_sample_value(metric, labels or {})
+    merged = {"tenant": TENANT, **(labels or {})}
+    return reg.get_sample_value(metric, merged)
 
 
 class TestRunQuery:
@@ -167,7 +179,7 @@ class TestRunQuery:
         gauges = dm._build_query_gauges([q], registry=registry)
         sm = dm._build_self_metrics(registry=registry)
 
-        dm._run_query(conn, q, gauges[q.name], sm)
+        _run(conn, q, gauges[q.name], sm)
 
         assert _gauge_value(registry, "t_pending_total") == 3
         assert _gauge_value(registry, "t_pending_unique_paths") == 2
@@ -197,12 +209,12 @@ class TestRunQuery:
 
         conn.execute("CREATE TABLE bands (band TEXT, n BIGINT)")
         conn.execute("INSERT INTO bands VALUES ('a', 10), ('b', 20)")
-        dm._run_query(conn, q, gauges[q.name], sm)
+        _run(conn, q, gauges[q.name], sm)
         assert _gauge_value(registry, "t_per_band_n", {"band": "a"}) == 10
         assert _gauge_value(registry, "t_per_band_n", {"band": "b"}) == 20
 
         conn.execute("DELETE FROM bands WHERE band = 'b'")
-        dm._run_query(conn, q, gauges[q.name], sm)
+        _run(conn, q, gauges[q.name], sm)
         assert _gauge_value(registry, "t_per_band_n", {"band": "a"}) == 10
         assert _gauge_value(registry, "t_per_band_n", {"band": "b"}) is None
 
@@ -213,7 +225,7 @@ class TestRunQuery:
         q = dm.Query(name="t_ok", help="t", sql="SELECT n FROM t", interval_seconds=60, labels=[], values=["n"])
         gauges = dm._build_query_gauges([q], registry=registry)
         sm = dm._build_self_metrics(registry=registry)
-        assert dm._run_query(conn, q, gauges[q.name], sm) is True
+        assert _run(conn, q, gauges[q.name], sm) is True
 
     def test_sql_error_increments_counter(self, conn, registry):
         q = dm.Query(
@@ -228,7 +240,7 @@ class TestRunQuery:
         sm = dm._build_self_metrics(registry=registry)
 
         # Must not raise — daemon stays up across catalog flap.
-        assert dm._run_query(conn, q, gauges[q.name], sm) is False
+        assert _run(conn, q, gauges[q.name], sm) is False
 
         assert _gauge_value(registry, "ducklake_metrics_query_errors_total", {"query": "t_broken"}) == 1
         # last_success not set on failure.
@@ -251,7 +263,7 @@ class TestRunQuery:
         gauges = dm._build_query_gauges([q], registry=registry)
         sm = dm._build_self_metrics(registry=registry)
 
-        dm._run_query(conn, q, gauges[q.name], sm)
+        _run(conn, q, gauges[q.name], sm)
 
         assert _gauge_value(registry, "ducklake_metrics_query_errors_total", {"query": "t_mismatch"}) == 1
 
@@ -277,7 +289,7 @@ class TestBuiltinPendingDeletes:
         q = next(q for q in dm.load_queries(None, set()) if q.name == "ducklake_pending_deletes")
         gauges = dm._build_query_gauges([q], registry=registry)
         sm = dm._build_self_metrics(registry=registry)
-        dm._run_query(conn, q, gauges[q.name], sm)
+        _run(conn, q, gauges[q.name], sm)
 
         assert _gauge_value(registry, "ducklake_pending_deletes_total") == 4
         assert _gauge_value(registry, "ducklake_pending_deletes_unique_paths") == 3
@@ -320,34 +332,35 @@ def _builtin(name):
 class TestBuiltinFilesPerBand:
     def test_buckets_live_files_only(self, conn, registry):
         _stub_catalog(conn)
-        # Live files (end_snapshot IS NULL) span four bands; one expired
-        # row must be filtered out.
+        # Live files (end_snapshot IS NULL) span all four bands; one expired
+        # row must be filtered out. Bands match ducklake_maintenance.py's
+        # TIERS: tier1 <1MiB, tier2 1-10MiB, tier3 10-64MiB, large >=64MiB.
         conn.execute(
             "INSERT INTO __ducklake_metadata_lake.ducklake_data_file VALUES "
-            "(1, 1, 0, NULL, 'a', 500000, 100),"        # lt1mib
-            "(2, 1, 0, NULL, 'b', 1500000, 100),"       # 1to5mib
-            "(3, 1, 0, NULL, 'c', 8000000, 200),"       # 5to10mib
-            "(4, 1, 0, NULL, 'd', 50000000, 200),"      # 32to64mib
-            "(5, 1, 0, NULL, 'e', 200000000, 300),"     # gt128mib
+            "(1, 1, 0, NULL, 'a', 500000, 100),"        # tier1 (<1MiB)
+            "(2, 1, 0, NULL, 'b', 1500000, 100),"       # tier2 (1-10MiB)
+            "(3, 1, 0, NULL, 'c', 8000000, 200),"       # tier2 (1-10MiB)
+            "(4, 1, 0, NULL, 'd', 50000000, 200),"      # tier3 (10-64MiB)
+            "(5, 1, 0, NULL, 'e', 200000000, 300),"     # large (>=64MiB)
             "(6, 1, 0, 5,    'f', 100, 300)"            # expired — must NOT be counted
         )
         q = _builtin("ducklake_files_per_band")
         gauges = dm._build_query_gauges([q], registry=registry)
         sm = dm._build_self_metrics(registry=registry)
-        dm._run_query(conn, q, gauges[q.name], sm)
+        _run(conn, q, gauges[q.name], sm)
 
-        assert _gauge_value(registry, "ducklake_files_per_band_count", {"band": "lt1mib"}) == 1
-        assert _gauge_value(registry, "ducklake_files_per_band_count", {"band": "1to5mib"}) == 1
-        assert _gauge_value(registry, "ducklake_files_per_band_count", {"band": "5to10mib"}) == 1
-        assert _gauge_value(registry, "ducklake_files_per_band_count", {"band": "32to64mib"}) == 1
-        assert _gauge_value(registry, "ducklake_files_per_band_count", {"band": "gt128mib"}) == 1
-        assert _gauge_value(registry, "ducklake_files_per_band_bytes", {"band": "lt1mib"}) == 500000
-        assert _gauge_value(registry, "ducklake_files_per_band_bytes", {"band": "gt128mib"}) == 200000000
+        assert _gauge_value(registry, "ducklake_files_per_band_count", {"band": "tier1"}) == 1
+        assert _gauge_value(registry, "ducklake_files_per_band_count", {"band": "tier2"}) == 2
+        assert _gauge_value(registry, "ducklake_files_per_band_count", {"band": "tier3"}) == 1
+        assert _gauge_value(registry, "ducklake_files_per_band_count", {"band": "large"}) == 1
+        assert _gauge_value(registry, "ducklake_files_per_band_bytes", {"band": "tier1"}) == 500000
+        assert _gauge_value(registry, "ducklake_files_per_band_bytes", {"band": "tier2"}) == 9500000
+        assert _gauge_value(registry, "ducklake_files_per_band_bytes", {"band": "large"}) == 200000000
 
     def test_band_boundaries_inclusive_lower_exclusive_upper(self, conn, registry):
-        # Exactly 1 MiB (1048576) must land in 1to5mib, not lt1mib —
+        # Exactly 1 MiB (1048576) must land in tier2, not tier1 —
         # matches DuckLake's own bin semantics (min inclusive, max
-        # exclusive) so this metric's bands compose with ducklake_maintenance.py's
+        # exclusive) so these bands compose with ducklake_maintenance.py's
         # tiered compaction.
         _stub_catalog(conn)
         conn.execute(
@@ -358,34 +371,10 @@ class TestBuiltinFilesPerBand:
         q = _builtin("ducklake_files_per_band")
         gauges = dm._build_query_gauges([q], registry=registry)
         sm = dm._build_self_metrics(registry=registry)
-        dm._run_query(conn, q, gauges[q.name], sm)
+        _run(conn, q, gauges[q.name], sm)
 
-        assert _gauge_value(registry, "ducklake_files_per_band_count", {"band": "lt1mib"}) == 1
-        assert _gauge_value(registry, "ducklake_files_per_band_count", {"band": "1to5mib"}) == 1
-
-
-class TestBuiltinCompactionCandidates:
-    def test_per_tier_plus_total(self, conn, registry):
-        _stub_catalog(conn)
-        conn.execute(
-            "INSERT INTO __ducklake_metadata_lake.ducklake_data_file VALUES "
-            "(1, 1, 0, NULL, 'a', 500000, 100),"        # tier1
-            "(2, 1, 0, NULL, 'b', 1500000, 100),"       # tier2
-            "(3, 1, 0, NULL, 'c', 8000000, 200),"       # tier2
-            "(4, 1, 0, NULL, 'd', 50000000, 200),"      # tier3
-            "(5, 1, 0, NULL, 'e', 200000000, 300),"     # large
-            "(6, 1, 0, 5,    'f', 100, 300)"            # expired
-        )
-        q = _builtin("ducklake_compaction_candidates")
-        gauges = dm._build_query_gauges([q], registry=registry)
-        sm = dm._build_self_metrics(registry=registry)
-        dm._run_query(conn, q, gauges[q.name], sm)
-
-        assert _gauge_value(registry, "ducklake_compaction_candidates_count", {"tier": "tier1"}) == 1
-        assert _gauge_value(registry, "ducklake_compaction_candidates_count", {"tier": "tier2"}) == 2
-        assert _gauge_value(registry, "ducklake_compaction_candidates_count", {"tier": "tier3"}) == 1
-        assert _gauge_value(registry, "ducklake_compaction_candidates_count", {"tier": "large"}) == 1
-        assert _gauge_value(registry, "ducklake_compaction_candidates_count", {"tier": "total"}) == 5
+        assert _gauge_value(registry, "ducklake_files_per_band_count", {"band": "tier1"}) == 1
+        assert _gauge_value(registry, "ducklake_files_per_band_count", {"band": "tier2"}) == 1
 
 
 class TestBuiltinSnapshots:
@@ -401,24 +390,30 @@ class TestBuiltinSnapshots:
         q = _builtin("ducklake_snapshots")
         gauges = dm._build_query_gauges([q], registry=registry)
         sm = dm._build_self_metrics(registry=registry)
-        dm._run_query(conn, q, gauges[q.name], sm)
+        _run(conn, q, gauges[q.name], sm)
 
         assert _gauge_value(registry, "ducklake_snapshots_count") == 2
         oldest = _gauge_value(registry, "ducklake_snapshots_oldest_seconds_ago")
         newest = _gauge_value(registry, "ducklake_snapshots_newest_seconds_ago")
         # oldest >= newest, both positive (now() > snapshot times in the past).
         assert oldest >= newest > 0
+        # newest_id / oldest_id come from MIN/MAX(snapshot_id); test fixture
+        # uses ids 0 and 1 → oldest_id=0, newest_id=1.
+        assert _gauge_value(registry, "ducklake_snapshots_oldest_id") == 0
+        assert _gauge_value(registry, "ducklake_snapshots_newest_id") == 1
 
     def test_empty_table_returns_zeros_not_errors(self, conn, registry):
         _stub_catalog(conn)
         q = _builtin("ducklake_snapshots")
         gauges = dm._build_query_gauges([q], registry=registry)
         sm = dm._build_self_metrics(registry=registry)
-        dm._run_query(conn, q, gauges[q.name], sm)
+        _run(conn, q, gauges[q.name], sm)
 
         assert _gauge_value(registry, "ducklake_snapshots_count") == 0
         assert _gauge_value(registry, "ducklake_snapshots_oldest_seconds_ago") == 0
         assert _gauge_value(registry, "ducklake_snapshots_newest_seconds_ago") == 0
+        assert _gauge_value(registry, "ducklake_snapshots_oldest_id") == 0
+        assert _gauge_value(registry, "ducklake_snapshots_newest_id") == 0
 
 
 class TestBuiltinFilesPerPartitionTop20:
@@ -444,7 +439,7 @@ class TestBuiltinFilesPerPartitionTop20:
         q = _builtin("ducklake_files_per_partition_top20")
         gauges = dm._build_query_gauges([q], registry=registry)
         sm = dm._build_self_metrics(registry=registry)
-        dm._run_query(conn, q, gauges[q.name], sm)
+        _run(conn, q, gauges[q.name], sm)
 
         assert _gauge_value(registry, "ducklake_files_per_partition_top20_count", {"partition": "2026-05-01"}) == 2
         assert _gauge_value(registry, "ducklake_files_per_partition_top20_count", {"partition": "2026-05-02"}) == 2
@@ -468,7 +463,7 @@ class TestBuiltinFilesPerPartitionTop20:
         q = _builtin("ducklake_files_per_partition_top20")
         gauges = dm._build_query_gauges([q], registry=registry)
         sm = dm._build_self_metrics(registry=registry)
-        dm._run_query(conn, q, gauges[q.name], sm)
+        _run(conn, q, gauges[q.name], sm)
 
         assert _gauge_value(registry, "ducklake_files_per_partition_top20_count", {"partition": "2026/05-01"}) == 1
 
@@ -508,7 +503,7 @@ class TestBuiltinCatalog:
         q = _builtin("ducklake_catalog")
         gauges = dm._build_query_gauges([q], registry=registry)
         sm = dm._build_self_metrics(registry=registry)
-        dm._run_query(conn, q, gauges[q.name], sm)
+        _run(conn, q, gauges[q.name], sm)
 
         assert (
             _gauge_value(registry, "ducklake_catalog_format_version", {"suffix": expected_suffix})
@@ -524,7 +519,7 @@ class TestBuiltinCatalog:
         q = _builtin("ducklake_catalog")
         gauges = dm._build_query_gauges([q], registry=registry)
         sm = dm._build_self_metrics(registry=registry)
-        dm._run_query(conn, q, gauges[q.name], sm)
+        _run(conn, q, gauges[q.name], sm)
 
         assert _gauge_value(registry, "ducklake_catalog_format_version", {"suffix": ""}) == 0.4
 
@@ -542,7 +537,7 @@ class TestBuiltinCatalog:
         q = _builtin("ducklake_catalog")
         gauges = dm._build_query_gauges([q], registry=registry)
         sm = dm._build_self_metrics(registry=registry)
-        dm._run_query(conn, q, gauges[q.name], sm)
+        _run(conn, q, gauges[q.name], sm)
 
         assert (
             _gauge_value(registry, "ducklake_metrics_query_errors_total", {"query": "ducklake_catalog"}) == 1
@@ -559,7 +554,7 @@ class TestBuiltinCatalog:
         sm = dm._build_self_metrics(registry=registry)
 
         self._seed(conn, "1.0")
-        dm._run_query(conn, q, gauges[q.name], sm)
+        _run(conn, q, gauges[q.name], sm)
         assert _gauge_value(registry, "ducklake_catalog_format_version", {"suffix": ""}) == 1.0
 
         conn.execute("DELETE FROM __ducklake_metadata_lake.ducklake_metadata WHERE key = 'version'")
@@ -567,7 +562,7 @@ class TestBuiltinCatalog:
             "INSERT INTO __ducklake_metadata_lake.ducklake_metadata VALUES "
             "('version', '1.1-dev1', NULL, NULL)"
         )
-        dm._run_query(conn, q, gauges[q.name], sm)
+        _run(conn, q, gauges[q.name], sm)
         assert _gauge_value(registry, "ducklake_catalog_format_version", {"suffix": "-dev1"}) == 1.1
         assert _gauge_value(registry, "ducklake_catalog_format_version", {"suffix": ""}) is None
 
@@ -600,7 +595,7 @@ class TestSchedulerReconnect:
         monkeypatch.setattr(dm, "_run_query", lambda *a, **kw: False)
         stop = threading.Event()
         with pytest.raises(dm._ReconnectNeeded):
-            dm._scheduler_loop(None, [q], gauges, sm, stop)
+            dm._scheduler_loop(None, [q], gauges, sm, stop, TENANT)
 
     def test_success_resets_counter(self, registry, monkeypatch):
         # Pattern: repeatedly fail (THRESHOLD-1) times then succeed once;
@@ -625,7 +620,7 @@ class TestSchedulerReconnect:
         monkeypatch.setattr(dm, "_run_query", fake_run)
         # Must not raise: each run of (THRESHOLD-1) failures is followed
         # by a success that resets the counter back to 0.
-        dm._scheduler_loop(None, [q], gauges, sm, stop)
+        dm._scheduler_loop(None, [q], gauges, sm, stop, TENANT)
 
 
 class TestConnectWithBackoff:
@@ -651,7 +646,7 @@ class TestConnectWithBackoff:
         monkeypatch.setattr(dm, "_BACKOFF_MAX_SECONDS", 0.001)
 
         stop = threading.Event()
-        result = dm._connect_with_backoff(stop, sm)
+        result = dm._connect_with_backoff(stop, sm, TENANT)
         assert result is sentinel
         assert attempts["n"] == 3
         # up was held at 0 throughout; the caller flips it to 1 once it
@@ -670,4 +665,4 @@ class TestConnectWithBackoff:
         monkeypatch.setattr(dm.ducklake_maintenance, "connect", fake_connect)
         monkeypatch.setattr(dm, "_BACKOFF_INITIAL_SECONDS", 0.001)
 
-        assert dm._connect_with_backoff(stop, sm) is None
+        assert dm._connect_with_backoff(stop, sm, TENANT) is None

--- a/tools/ducklake_metrics.py
+++ b/tools/ducklake_metrics.py
@@ -70,7 +70,13 @@ log = logging.getLogger("ducklake_metrics")
 BUILTIN_YAML = """
 queries:
   - name: ducklake_pending_deletes
-    help: Pending-deletion queue depth and duplicate-row pathology.
+    help: |
+      Pending-deletion queue depth. `total` is the row count
+      (`ducklake_files_scheduled_for_deletion`); each row references one file
+      path. `unique_paths` is the distinct file count (use this for "how many
+      files are queued"). `dup_rows = total - unique_paths` surfaces the
+      duplicate-row pathology that self-poisons the next cleanup
+      (DuckLake upstream bug c5).
     interval_mins: 1
     values: [total, unique_paths, dup_rows]
     sql: |
@@ -80,21 +86,54 @@ queries:
         COUNT(*) - COUNT(DISTINCT path) AS dup_rows
       FROM __ducklake_metadata_lake.ducklake_files_scheduled_for_deletion
 
+  - name: ducklake_data_files
+    help: |
+      Live data-file (parquet) totals. `files` = file count, `bytes` = total
+      on-disk size, `rows` = total records across all live files. "Live" =
+      `end_snapshot IS NULL`. Per-band breakdown lives in
+      `ducklake_files_per_band`; this is the rollup for "how big is the lake."
+    interval_mins: 1
+    values: [files, bytes, rows]
+    sql: |
+      SELECT
+        COUNT(*) AS files,
+        COALESCE(SUM(file_size_bytes), 0) AS bytes,
+        COALESCE(SUM(record_count), 0)    AS rows
+      FROM __ducklake_metadata_lake.ducklake_data_file
+      WHERE end_snapshot IS NULL
+
+  - name: ducklake_delete_files
+    help: |
+      Live delete-vector (puffin/parquet) totals. Same shape as
+      ducklake_data_files but for the delete side. Outsized vs.
+      ducklake_data_files_files = lots of unmerged deletes; ripe for
+      `ducklake_rewrite_data_files` maintenance.
+    interval_mins: 1
+    values: [files, bytes]
+    sql: |
+      SELECT
+        COUNT(*) AS files,
+        COALESCE(SUM(file_size_bytes), 0) AS bytes
+      FROM __ducklake_metadata_lake.ducklake_delete_file
+      WHERE end_snapshot IS NULL
+
   - name: ducklake_files_per_band
-    help: Live data files grouped into byte-size bands.
+    help: |
+      Live data files grouped into compaction-relevant size bands. Tiers
+      match `ducklake_maintenance.py`'s TIERS spec — `tier1` (<1 MiB),
+      `tier2` (1-10 MiB), `tier3` (10-64 MiB) are compaction targets;
+      `large` (>=64 MiB) is past the compaction threshold and is just
+      reported for shape. Sum across bands equals `ducklake_data_files_files`.
     interval_mins: 1
     labels: [band]
     values: [count, bytes]
     sql: |
       SELECT
         CASE
-          WHEN file_size_bytes < 1048576    THEN 'lt1mib'
-          WHEN file_size_bytes < 5242880    THEN '1to5mib'
-          WHEN file_size_bytes < 10485760   THEN '5to10mib'
-          WHEN file_size_bytes < 33554432   THEN '10to32mib'
-          WHEN file_size_bytes < 67108864   THEN '32to64mib'
-          WHEN file_size_bytes < 134217728  THEN '64to128mib'
-          ELSE 'gt128mib'
+          WHEN file_size_bytes < 1048576   THEN 'tier1'
+          WHEN file_size_bytes < 10485760  THEN 'tier2'
+          WHEN file_size_bytes < 67108864  THEN 'tier3'
+          ELSE 'large'
         END AS band,
         COUNT(*) AS count,
         COALESCE(SUM(file_size_bytes), 0) AS bytes
@@ -102,39 +141,82 @@ queries:
       WHERE end_snapshot IS NULL
       GROUP BY band
 
-  - name: ducklake_compaction_candidates
-    help: Live file counts bucketed to match ducklake_maintenance.py's TIERS spec.
-    interval_mins: 1
-    labels: [tier]
-    values: [count]
-    sql: |
-      SELECT tier, COUNT(*) AS count
-      FROM (
-        SELECT CASE
-          WHEN file_size_bytes < 1048576   THEN 'tier1'
-          WHEN file_size_bytes < 10485760  THEN 'tier2'
-          WHEN file_size_bytes < 67108864  THEN 'tier3'
-          ELSE 'large'
-        END AS tier
-        FROM __ducklake_metadata_lake.ducklake_data_file
-        WHERE end_snapshot IS NULL
-      ) t
-      GROUP BY tier
-      UNION ALL
-      SELECT 'total' AS tier, COUNT(*) AS count
-      FROM __ducklake_metadata_lake.ducklake_data_file
-      WHERE end_snapshot IS NULL
-
   - name: ducklake_snapshots
-    help: Snapshot count plus age of oldest/newest snapshot in seconds.
+    help: |
+      Snapshot population, ages (seconds), and id bounds. Expose the raw
+      `oldest_id`/`newest_id` (counter-like, monotonic) so PromQL can
+      derive the commit rate via `deriv(ducklake_snapshots_newest_id[5m])`
+      — no per-sample storage in the daemon.
     interval_mins: 1
-    values: [count, oldest_seconds_ago, newest_seconds_ago]
+    values: [count, oldest_seconds_ago, newest_seconds_ago, oldest_id, newest_id]
     sql: |
       SELECT
         COUNT(*) AS count,
         COALESCE(EXTRACT(EPOCH FROM (now() - MIN(CAST(snapshot_time AS TIMESTAMPTZ)))), 0) AS oldest_seconds_ago,
-        COALESCE(EXTRACT(EPOCH FROM (now() - MAX(CAST(snapshot_time AS TIMESTAMPTZ)))), 0) AS newest_seconds_ago
+        COALESCE(EXTRACT(EPOCH FROM (now() - MAX(CAST(snapshot_time AS TIMESTAMPTZ)))), 0) AS newest_seconds_ago,
+        COALESCE(MIN(snapshot_id), 0) AS oldest_id,
+        COALESCE(MAX(snapshot_id), 0) AS newest_id
       FROM __ducklake_metadata_lake.ducklake_snapshot
+
+  - name: ducklake_inlined_data_tables
+    help: |
+      Count of rows in `ducklake_inlined_data_tables` (the registry of
+      per-table inline-data tables that DuckLake creates when a write goes
+      through the inlining path). Should stay small in steady state;
+      runaway growth indicates `data_inlining_row_limit` isn't being
+      honored by writers, or writers are creating tables faster than
+      maintenance can drop them (see `ducklake_unreachable_inline_tables`).
+    interval_mins: 1
+    values: [total]
+    sql: |
+      SELECT COUNT(*) AS total
+      FROM __ducklake_metadata_lake.ducklake_inlined_data_tables
+
+  - name: ducklake_unreachable_inline_tables
+    help: |
+      Count of `ducklake_inlined_data_tables` entries whose parent
+      `ducklake_table` has no snapshot-reachable row. These are orphans
+      that DuckLake's own GC (DropEmptySupersededInlinedTables) won't
+      reach because it only acts on superseded-and-empty, not
+      parent-dropped. Should be 0 or near-0 after cleanup; growing trend
+      means the data_imports DROP+CREATE pattern is producing orphans.
+      Uses the range-overlap predicate (strict superset of "actually
+      reachable"; safe-conservative — won't false-positive an unreachable
+      table). See INCIDENT.md.
+    interval_mins: 5
+    values: [total]
+    sql: |
+      WITH bounds AS (
+        SELECT MIN(snapshot_id) AS lo, MAX(snapshot_id) AS hi
+        FROM __ducklake_metadata_lake.ducklake_snapshot
+      ),
+      reachable AS (
+        SELECT DISTINCT t.table_id
+        FROM __ducklake_metadata_lake.ducklake_table t, bounds
+        WHERE t.begin_snapshot <= bounds.hi
+          AND (t.end_snapshot IS NULL OR t.end_snapshot > bounds.lo)
+      )
+      SELECT COUNT(*) AS total
+      FROM __ducklake_metadata_lake.ducklake_inlined_data_tables idt
+      WHERE NOT EXISTS (SELECT 1 FROM reachable r WHERE r.table_id = idt.table_id)
+
+  - name: ducklake_tables
+    help: |
+      Count of `ducklake_table` rows split by lifecycle state.
+      `state="live"` = `end_snapshot IS NULL` (currently visible to the
+      latest snapshot). `state="dropped"` = `end_snapshot` set (still
+      readable by historical snapshots until expire+cleanup reaps them).
+      Imbalance — many dropped, few live — indicates DROP+CREATE churn
+      (data_imports anti-pattern).
+    interval_mins: 1
+    labels: [state]
+    values: [count]
+    sql: |
+      SELECT
+        CASE WHEN end_snapshot IS NULL THEN 'live' ELSE 'dropped' END AS state,
+        COUNT(*) AS count
+      FROM __ducklake_metadata_lake.ducklake_table
+      GROUP BY state
 
   - name: ducklake_files_per_partition_top20
     help: Twenty heaviest partitions by live data-file count (composite values joined with '/').
@@ -176,6 +258,35 @@ queries:
         regexp_replace(value, '^[0-9]+(\\.[0-9]+)?', '') AS suffix
       FROM __ducklake_metadata_lake.ducklake_metadata
       WHERE key = 'version' AND scope IS NULL
+
+  - name: ducklake_config
+    help: |
+      Operationally-relevant DuckLake catalog config values from
+      `ducklake_metadata`. Currently tracks `auto_compact` and
+      `data_inlining_row_limit` at every scope (global / schema / table) —
+      `auto_compact != 'true'` silently disables every maintenance
+      function call against the affected table, and a non-zero
+      `data_inlining_row_limit` is what generates the inline-table
+      backlog this daemon watches. Boolean strings ('true'/'false') map
+      to 1/0; numeric strings cast directly; anything else returns NULL
+      and the sample is dropped (error counter still ticks, surfacing
+      the bad value).
+    interval_mins: 5
+    labels: [key, scope, scope_id]
+    values: [value]
+    sql: |
+      SELECT
+        key,
+        COALESCE(scope, '') AS scope,
+        COALESCE(CAST(scope_id AS VARCHAR), '') AS scope_id,
+        CASE
+          WHEN value = 'true'  THEN 1.0
+          WHEN value = 'false' THEN 0.0
+          WHEN regexp_matches(value, '^-?[0-9]+(\\.[0-9]+)?$') THEN CAST(value AS DOUBLE)
+          ELSE NULL
+        END AS value
+      FROM __ducklake_metadata_lake.ducklake_metadata
+      WHERE key IN ('auto_compact', 'data_inlining_row_limit')
 """
 
 # Intervals are specified in whole minutes via the YAML field `interval_mins`
@@ -271,29 +382,37 @@ class SelfMetrics:
 
 
 def _build_self_metrics(registry: CollectorRegistry | None = None) -> SelfMetrics:
+    """Construct the daemon's own health metrics.
+
+    Every metric carries a ``tenant`` label (injected at sample time from
+    the daemon's resolved tenant identity, see main()) so a Prometheus
+    instance scraping many ducklake_metrics deployments can distinguish
+    series by catalog without relying on per-target relabeling.
+    """
     kwargs = {"registry": registry} if registry is not None else {}
     return SelfMetrics(
         duration=Gauge(
             "ducklake_metrics_query_duration_seconds",
             "Wall-clock duration of the most recent run for each query.",
-            ["query"],
+            ["tenant", "query"],
             **kwargs,
         ),
         errors=Counter(
             "ducklake_metrics_query_errors_total",
             "Cumulative count of failed query runs.",
-            ["query"],
+            ["tenant", "query"],
             **kwargs,
         ),
         last_success=Gauge(
             "ducklake_metrics_query_last_success_timestamp",
             "Unix timestamp of the most recent successful run for each query.",
-            ["query"],
+            ["tenant", "query"],
             **kwargs,
         ),
         up=Gauge(
             "ducklake_metrics_up",
             "1 while the daemon has a live catalog connection; 0 during reconnect.",
+            ["tenant"],
             **kwargs,
         ),
     )
@@ -305,16 +424,19 @@ def _build_query_gauges(
 ) -> dict[str, dict[str, Gauge]]:
     """For each query, register one Gauge per value column.
 
-    Metric name is ``<query_name>_<value>``. Labels come from ``query.labels``.
-    Always suffixes (no special-case for single-value queries) so the metric
-    name shape is uniform across the daemon.
+    Metric name is ``<query_name>_<value>``. Labels come from
+    ``["tenant"] + query.labels`` — ``tenant`` is prepended so every
+    series the daemon emits is tenant-scoped, matching PostHog's
+    per-team labeling convention. Always suffixes (no special-case for
+    single-value queries) so the metric name shape is uniform across
+    the daemon.
     """
     kwargs = {"registry": registry} if registry is not None else {}
     out: dict[str, dict[str, Gauge]] = {}
     for q in queries:
         gs: dict[str, Gauge] = {}
         for v in q.values:
-            gs[v] = Gauge(f"{q.name}_{v}", q.help, q.labels, **kwargs)
+            gs[v] = Gauge(f"{q.name}_{v}", q.help, ["tenant", *q.labels], **kwargs)
         out[q.name] = gs
     return out
 
@@ -335,8 +457,15 @@ def _run_query(
     q: Query,
     gauges: dict[str, Gauge],
     self_metrics: SelfMetrics,
+    tenant: str,
 ) -> bool:
     """Execute one query and update its gauges. Returns True on success.
+
+    ``tenant`` is prepended to every gauge sample's label tuple — see
+    _build_query_gauges / _build_self_metrics. The query's SQL itself
+    is tenant-agnostic; the daemon-level tenant identity gets stitched
+    on at emit time so user-supplied YAML doesn't need to know about
+    the multi-tenant deployment model.
 
     On success: clears each value gauge before re-populating so label
     combinations that drop out between runs don't linger as stale series.
@@ -358,30 +487,27 @@ def _run_query(
                 f"query {q.name}: SQL must return columns named in labels+values; "
                 f"got cols={cols} labels={q.labels} values={q.values}"
             ) from e
-        if q.labels:
-            # Only labeled gauges support clear(); for unlabeled the .set()
-            # below is itself the full state update.
-            for g in gauges.values():
-                g.clear()
+        # Always clear since every gauge has at least the tenant label
+        # — clear() drops all (tenant, ...) label combinations registered
+        # so far for this gauge, so per-run label set churn doesn't leak
+        # stale series.
+        for g in gauges.values():
+            g.clear()
         for row in rows:
             label_vals = [str(row[i]) if row[i] is not None else "" for i in label_idx]
             for v_name, v_i in zip(q.values, value_idx):
                 v = row[v_i]
                 if v is None:
                     continue
-                g = gauges[v_name]
-                if q.labels:
-                    g.labels(*label_vals).set(float(v))
-                else:
-                    g.set(float(v))
+                gauges[v_name].labels(tenant, *label_vals).set(float(v))
         elapsed = time.monotonic() - t0
-        self_metrics.duration.labels(q.name).set(elapsed)
-        self_metrics.last_success.labels(q.name).set_to_current_time()
+        self_metrics.duration.labels(tenant, q.name).set(elapsed)
+        self_metrics.last_success.labels(tenant, q.name).set_to_current_time()
         log.debug("query %s: %d rows in %.3fs", q.name, len(rows), elapsed)
         return True
     except Exception:
         log.exception("query %s failed", q.name)
-        self_metrics.errors.labels(q.name).inc()
+        self_metrics.errors.labels(tenant, q.name).inc()
         return False
 
 
@@ -391,6 +517,7 @@ def _scheduler_loop(
     gauges: dict[str, dict[str, Gauge]],
     self_metrics: SelfMetrics,
     stop: threading.Event,
+    tenant: str,
 ) -> None:
     """Run queries on per-query intervals until stop is set.
 
@@ -421,7 +548,7 @@ def _scheduler_loop(
             return
         heapq.heappop(heap)
         q = queries[idx]
-        ok = _run_query(conn, q, gauges[q.name], self_metrics)
+        ok = _run_query(conn, q, gauges[q.name], self_metrics, tenant)
         if ok:
             consecutive_failures = 0
         else:
@@ -489,6 +616,7 @@ _BACKOFF_MAX_SECONDS = 60.0
 def _connect_with_backoff(
     stop: threading.Event,
     self_metrics: SelfMetrics,
+    tenant: str,
 ) -> duckdb.DuckDBPyConnection | None:
     """Call ducklake_maintenance.connect() with exponential backoff until it succeeds or stop is set.
 
@@ -499,7 +627,7 @@ def _connect_with_backoff(
     sleeps that miss the recovery window.
     """
     delay = _BACKOFF_INITIAL_SECONDS
-    self_metrics.up.set(0)
+    self_metrics.up.labels(tenant).set(0)
     while not stop.is_set():
         try:
             conn = ducklake_maintenance.connect()
@@ -541,6 +669,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Comma-separated query names to skip from built-ins",
     )
     p.add_argument(
+        "--tenant",
+        default=os.environ.get("DUCKLAKE_TENANT"),
+        help=(
+            "Tenant identity stamped onto every emitted metric as the "
+            "`tenant` label. Required for the multi-tenant deployment "
+            "model — one daemon per tenant, distinguished in Prometheus "
+            "via this label. Falls back to DUCKLAKE_TENANT env."
+        ),
+    )
+    p.add_argument(
         "--list-queries",
         action="store_true",
         help="Print resolved query list and exit (validates config without connecting)",
@@ -560,6 +698,14 @@ def main(argv: list[str] | None = None) -> None:
         for q in queries:
             print(f"{q.name}\t{q.interval_seconds}s\t{q.help}")
         return
+
+    if not args.tenant:
+        sys.exit(
+            "tenant identity required: pass --tenant <name> or set DUCKLAKE_TENANT "
+            "env. Stamped onto every emitted metric as the `tenant` label."
+        )
+    tenant: str = args.tenant
+    log.info("Tenant: %s", tenant)
 
     self_metrics = _build_self_metrics()
     gauges = _build_query_gauges(queries)
@@ -583,17 +729,17 @@ def main(argv: list[str] | None = None) -> None:
     # and stays true thereafter — k8s shouldn't yank metrics traffic on
     # transient catalog flap, and there's no real "traffic" anyway.
     while not stop.is_set():
-        conn = _connect_with_backoff(stop, self_metrics)
+        conn = _connect_with_backoff(stop, self_metrics, tenant)
         if conn is None:
             break
-        self_metrics.up.set(1)
+        self_metrics.up.labels(tenant).set(1)
         srv.ready = True  # type: ignore[attr-defined]
         try:
-            _scheduler_loop(conn, queries, gauges, self_metrics, stop)
+            _scheduler_loop(conn, queries, gauges, self_metrics, stop, tenant)
         except _ReconnectNeeded as e:
             log.warning("%s", e)
         finally:
-            self_metrics.up.set(0)
+            self_metrics.up.labels(tenant).set(0)
             with contextlib.suppress(Exception):
                 conn.close()
 


### PR DESCRIPTION
## Summary

Two coupled changes to `tools/ducklake_metrics.py`:

1. **Tenant label everywhere.** A single Prometheus instance scraping many per-tenant deployments needs to distinguish series by catalog. Adds a required `tenant` label (resolved from `--tenant` / `DUCKLAKE_TENANT` at startup) to every metric the daemon emits, both catalog gauges and self-metrics. Daemon refuses to start without it — fail-loud beats silent series collision.

2. **Broader catalog coverage.** Existing built-ins missed several signals we have direct operational use for (inline-table backlog, config flips that silently disable maintenance, snapshot id bounds for PromQL-derived commit rate, total file/byte rollup). Folded in plus refactored the existing band/tier metrics so the buckets match `ducklake_maintenance.py`'s TIERS exactly.

### Catalog query delta

| Metric | Change |
|---|---|
| `ducklake_pending_deletes` | Help text clarifies row-vs-file split (`total` = rows; `unique_paths` = distinct files) |
| `ducklake_files_per_band` | Collapsed from 7 bands to 4 matching compaction TIERS (`tier1`/`tier2`/`tier3`/`large`) |
| `ducklake_compaction_candidates` | **Removed** — duplicated `_per_band` with a different label name |
| `ducklake_snapshots` | Adds `oldest_id` + `newest_id` so PromQL can derive snapshot commit rate via `deriv(...)` |
| `ducklake_data_files` (new) | Total live file count, bytes, rows |
| `ducklake_delete_files` (new) | Total live delete-vector count + bytes |
| `ducklake_inlined_data_tables` (new) | Registry-table row count |
| `ducklake_unreachable_inline_tables` (new) | Snapshot-reachability range-overlap predicate; surfaces parent-dropped orphans that DuckLake's own GC cannot reach |
| `ducklake_tables` (new) | Live/dropped split on `ducklake_table` |
| `ducklake_config` (new) | `auto_compact` + `data_inlining_row_limit` at every scope — a flip that silently disables maintenance is now alertable |

### Test plan

- [x] All 43 unit tests in `tests/unit/test_ducklake_metrics.py` pass (`.venv/bin/python -m pytest tests/unit/test_ducklake_metrics.py`)
- [ ] CI integration tests pass against a real lake fixture
- [ ] Manual: build image, run with `--tenant foo --list-queries` to confirm new queries parse
- [ ] Manual: scrape `/metrics` in a dev pod and confirm every series has the `tenant` label and no series is missing it

### Notes for reviewers

- The `tenant` label injection is done at sample time (`_run_query` / `_build_self_metrics` / `_build_query_gauges`) so user-supplied YAML queries don't need to know about the multi-tenant deployment model — their declared labels are preserved verbatim, `tenant` is prepended invisibly.
- `ducklake_unreachable_inline_tables` uses the range-overlap form of the reachability predicate (not the per-snapshot `EXISTS`) for query-plan reasons: the strict per-snapshot form materialises a many-million-row intermediate result; range-overlap is strictly more conservative (false-positives a few unreachable tables under sparse-snapshot conditions, but never false-negatives a reachable one) and is sub-second.
- Existing readers of `ducklake_compaction_candidates_count` will break — there are no callers in this repo. Dashboards/alerts that reference it need to migrate to `ducklake_files_per_band_count` (same data, same label values).
- Existing readers of any other metric will also break because of the new `tenant` label — that's intentional. Dashboards need to be updated to filter / template on `tenant`.