### PR TITLE
metrics: 5min built-in intervals + delete-file metrics index

### DIFF
--- a/tools/ducklake_metrics.py
+++ b/tools/ducklake_metrics.py
@@ -77,7 +77,7 @@ queries:
       files are queued"). `dup_rows = total - unique_paths` surfaces the
       duplicate-row pathology that self-poisons the next cleanup
       (DuckLake upstream bug c5).
-    interval_mins: 1
+    interval_mins: 5
     values: [total, unique_paths, dup_rows]
     sql: |
       SELECT
@@ -92,7 +92,7 @@ queries:
       on-disk size, `rows` = total records across all live files. "Live" =
       `end_snapshot IS NULL`. Per-band breakdown lives in
       `ducklake_files_per_band`; this is the rollup for "how big is the lake."
-    interval_mins: 1
+    interval_mins: 5
     values: [files, bytes, rows]
     sql: |
       SELECT
@@ -108,7 +108,7 @@ queries:
       ducklake_data_files but for the delete side. Outsized vs.
       ducklake_data_files_files = lots of unmerged deletes; ripe for
       `ducklake_rewrite_data_files` maintenance.
-    interval_mins: 1
+    interval_mins: 5
     values: [files, bytes]
     sql: |
       SELECT
@@ -124,7 +124,7 @@ queries:
       `tier2` (1-10 MiB), `tier3` (10-64 MiB) are compaction targets;
       `large` (>=64 MiB) is past the compaction threshold and is just
       reported for shape. Sum across bands equals `ducklake_data_files_files`.
-    interval_mins: 1
+    interval_mins: 5
     labels: [band]
     values: [count, bytes]
     sql: |
@@ -147,7 +147,7 @@ queries:
       `oldest_id`/`newest_id` (counter-like, monotonic) so PromQL can
       derive the commit rate via `deriv(ducklake_snapshots_newest_id[5m])`
       — no per-sample storage in the daemon.
-    interval_mins: 1
+    interval_mins: 5
     values: [count, oldest_seconds_ago, newest_seconds_ago, oldest_id, newest_id]
     sql: |
       SELECT
@@ -166,7 +166,7 @@ queries:
       runaway growth indicates `data_inlining_row_limit` isn't being
       honored by writers, or writers are creating tables faster than
       maintenance can drop them (see `ducklake_unreachable_inline_tables`).
-    interval_mins: 1
+    interval_mins: 5
     values: [total]
     sql: |
       SELECT COUNT(*) AS total
@@ -208,7 +208,7 @@ queries:
       readable by historical snapshots until expire+cleanup reaps them).
       Imbalance — many dropped, few live — indicates DROP+CREATE churn
       (data_imports anti-pattern).
-    interval_mins: 1
+    interval_mins: 5
     labels: [state]
     values: [count]
     sql: |
@@ -220,7 +220,7 @@ queries:
 
   - name: ducklake_files_per_partition_top20
     help: Twenty heaviest partitions by live data-file count (composite values joined with '/').
-    interval_mins: 1
+    interval_mins: 5
     labels: [partition]
     values: [count]
     sql: |

--- a/tools/justfile
+++ b/tools/justfile
@@ -290,6 +290,18 @@ bootstrap-index-delete-file-table:
     @echo ">>> ducklake_delete_file_table_idx"
     {{ _psql }} -c "CREATE INDEX CONCURRENTLY IF NOT EXISTS ducklake_delete_file_table_idx ON public.ducklake_delete_file USING btree (table_id, end_snapshot) WHERE (end_snapshot IS NULL);"
 
+# Lake-wide SUM(file_size_bytes) over live delete files (drives the
+# ducklake_metrics ducklake_delete_files_bytes panel). Partial-on-NULL
+# narrows the index to live rows only, so write-amp is bounded — one entry
+# added per live insert, removed on supersession. Mirrors the data_file
+# compaction index's shape on the delete side, where the existing
+# ducklake_delete_file_table_idx omits file_size_bytes and forces a heap
+# fetch for the SUM aggregate.
+[group('bootstrap')]
+bootstrap-index-delete-file-metrics:
+    @echo ">>> ducklake_delete_file_metrics_idx"
+    {{ _psql }} -c "CREATE INDEX CONCURRENTLY IF NOT EXISTS ducklake_delete_file_metrics_idx ON public.ducklake_delete_file USING btree (table_id, end_snapshot, file_size_bytes) WHERE (end_snapshot IS NULL);"
+
 # File-column-stats join key; drives per-file stat aggregation during compaction
 [group('bootstrap')]
 bootstrap-index-file-column-stats:
@@ -310,7 +322,7 @@ bootstrap-index-file-partition-value-table:
 
 # Create every DuckLake catalog btree, sequentially (same-relation builds serialize anyway)
 [group('bootstrap')]
-bootstrap-indexes: bootstrap-index-data-file-compaction bootstrap-index-data-file-compaction-order bootstrap-index-data-file-snapshot-read bootstrap-index-delete-file-snapshot-read bootstrap-index-delete-file-table bootstrap-index-file-column-stats bootstrap-index-file-partition-value-file bootstrap-index-file-partition-value-table
+bootstrap-indexes: bootstrap-index-data-file-compaction bootstrap-index-data-file-compaction-order bootstrap-index-data-file-snapshot-read bootstrap-index-delete-file-snapshot-read bootstrap-index-delete-file-table bootstrap-index-delete-file-metrics bootstrap-index-file-column-stats bootstrap-index-file-partition-value-file bootstrap-index-file-partition-value-table
 
 # ----------------------------------------------------------------------------
 # state-metrics daemon


### PR DESCRIPTION
## Summary

Single-thread scheduler in the metrics daemon was getting starved by the data-file aggregates. \`ducklake_data_files\` was clocking 41-48s per run on megaduck — eating most of every 60s window and squeezing the fast queries (snapshots, pending deletes) into the slivers between slow ones, which surfaced in Grafana as gappy series.

Two changes:

1. **Every built-in to 5min cadence.** Nothing on the DuckLake State dashboard needs better than 5-minute resolution; lake size doesn't move that fast. Catalog format version stays at 60min (only changes on a DuckLake upgrade).
2. **One new narrow partial index for the delete-file SUM(bytes) query.** Mirrors the existing \`ducklake_data_file_compaction_idx\` shape (\`(table_id, end_snapshot, file_size_bytes) WHERE end_snapshot IS NULL\`) on the delete side. Partial-on-NULL = live rows only, so write-amp is bounded the same way.

## What I deliberately didn't add

- No new index for \`SUM(record_count)\` on data_file — the only metric panel that's not already covered by the existing compaction index. On a heavily-compacted catalog this is fundamentally O(live_rows); adding an index for a single panel that's now refreshing every 5min isn't worth the write-amp. If it's still slow at 5min cadence, the right answer is a materialized counter, not a wider index.
- No new join indices for \`ducklake_unreachable_inline_tables\` — \`ducklake_table\` is a small table; the range-overlap join should be fast enough at 5min cadence. Revisit if it's still hot.

## Test plan

- [x] Full \`tests/\` suite green (508 passed, 1 xfailed)
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] \`just --justfile tools/justfile --summary\` lists the new recipe under \`bootstrap-indexes\` deps
- [ ] After merge + image promote: run \`just bootstrap-index-delete-file-metrics\` on megaduck-mw-prod-us catalog
- [ ] After deploy: verify the metrics-daemon "Query duration" panel for megaduck shows all queries < 5s; verify the lake-size / snapshot / pending-deletes panels in the dashboard are now continuous