### PR TITLE
fix(tools): tighten repair-partition-values pre-flight + default COMPACTION_MAX_FILES

### DIFF
--- a/tools/ducklake_maintenance.py
+++ b/tools/ducklake_maintenance.py
@@ -755,6 +755,22 @@ def _repair_partition_values_pre_flight_any_rot(conn: duckdb.DuckDBPyConnection)
     15-minute compaction cronjob: most invocations will be against clean
     catalogs and should exit before doing N per-table count queries.
     """
+    # Restrict to files a real _execute run would actually touch:
+    #   - Table must be PARTITIONED (has a live ducklake_partition_info row) —
+    #     otherwise events_nrt / other unpartitioned events*/persons* variants
+    #     produce COUNT(fpv)=0 and trip the HAVING <> 3 branch forever.
+    #   - Path must be S3-absolute — lake-relative files (ducklake-{uuid}.parquet
+    #     at the lake root) don't fit the hive layout the repair targets.
+    #   - Path must match the kind-specific hive layout _execute expects
+    #     (events: year/month/day; persons: year/month) — some persons files
+    #     were written under a legacy `/year=/month=/day=/…` path that this
+    #     tool can't currently parse (persons has no `day` partition column),
+    #     so they're out of _execute's scope and shouldn't fire pre-flight.
+    # Without these filters this always returns TRUE on any catalog with
+    # unpartitioned variants, lake-relative files, or those legacy paths,
+    # defeating the cron short-circuit.
+    events_path_shape = _repair_partition_values_path_shape_predicate("events", column="df.path")
+    persons_path_shape = _repair_partition_values_path_shape_predicate("persons", column="df.path")
     pre_flight_sql = (
         "SELECT EXISTS ( "
         "  SELECT 1 FROM ( "
@@ -765,15 +781,21 @@ def _repair_partition_values_pre_flight_any_rot(conn: duckdb.DuckDBPyConnection)
         f"    JOIN {PG_CATALOG_SCHEMA}.ducklake_table t USING (table_id) "
         f"    JOIN {PG_CATALOG_SCHEMA}.ducklake_schema sch "
         "      ON sch.schema_id = t.schema_id AND sch.end_snapshot IS NULL "
+        f"    JOIN {PG_CATALOG_SCHEMA}.ducklake_partition_info pi "
+        "      ON pi.table_id = t.table_id AND pi.end_snapshot IS NULL "
         f"    LEFT JOIN {PG_CATALOG_SCHEMA}.ducklake_file_partition_value fpv "
         "      ON fpv.data_file_id = df.data_file_id AND fpv.table_id = df.table_id "
         "    WHERE sch.schema_name = 'posthog' "
         "      AND t.end_snapshot IS NULL "
         "      AND df.end_snapshot IS NULL "
+        "      AND df.path LIKE 's3://%' "
         "      AND df.path NOT LIKE '%/full/%' "
-        "      AND (t.table_name IN ('events','persons') "
-        "           OR t.table_name LIKE 'events\\_%' ESCAPE '\\' "
-        "           OR t.table_name LIKE 'persons\\_%' ESCAPE '\\') "
+        "      AND ( "
+        f"        ((t.table_name = 'events' OR t.table_name LIKE 'events\\_%' ESCAPE '\\') "
+        f"          AND {events_path_shape}) "
+        f"        OR ((t.table_name = 'persons' OR t.table_name LIKE 'persons\\_%' ESCAPE '\\') "
+        f"          AND {persons_path_shape}) "
+        "      ) "
         "    GROUP BY df.data_file_id, df.table_id, t.table_name "
         "    HAVING (t.table_name LIKE 'events%' AND COUNT(fpv.partition_key_index) <> 3) "
         "        OR (t.table_name LIKE 'persons%' AND COUNT(fpv.partition_key_index) <> 2) "

--- a/tools/justfile
+++ b/tools/justfile
@@ -17,6 +17,10 @@ s3_url_style := env("DUCKDB_S3_URL_STYLE", "vhost")
 s3_use_ssl := env("DUCKDB_S3_USE_SSL", "true")
 data_path := env("DUCKLAKE_DATA_PATH", "")
 
+# Default compaction knobs — exported so child python processes inherit.
+# Override at the shell for one-off runs: COMPACTION_MAX_FILES=500 just compact-to-tier-3
+export COMPACTION_MAX_FILES := env("COMPACTION_MAX_FILES", "80")
+
 # DUCKDB_S3_USE_SSL must be a literal SQL boolean — it's interpolated into
 # both `SET s3_use_ssl = '<value>'` (a SQL string literal) and into
 # `CREATE OR REPLACE SECRET ... USE_SSL <value>` (an UNQUOTED bool, where


### PR DESCRIPTION
## Summary

Two small follow-ups after #99 landed:

### Pre-flight tightening

The `_repair_partition_values_pre_flight_any_rot` `EXISTS` check was returning TRUE forever on the duckling-posthog catalog even after the actual repair cleared all in-scope rot. Root cause: three sources of false-positives that the pre-flight query wasn't filtering out — files that `_execute` correctly skips but pre-flight was counting as "rot":

1. **Unpartitioned events*/persons* variants** (e.g. `events_nrt` with 19k files). LEFT JOIN on `ducklake_file_partition_value` produces `COUNT(fpv.partition_key_index) = 0`, which trips the `HAVING <> 3` branch.
2. **Lake-relative files** (`ducklake-{uuid}.parquet` at the DuckLake data root, no `s3://` prefix). Don't match the hive layout `_execute` operates on.
3. **Legacy persons paths with an extra `/day=/` segment** (~10+ Class A files on duckling-posthog). `_execute`'s persons path shape regex correctly excludes these (persons has no `day` partition column), but the pre-flight didn't apply that regex.

Fix: JOIN `ducklake_partition_info` (restricts to partitioned tables), require `s3://` path prefix, and apply the same kind-specific path shape regex `_execute` uses. Pre-flight now matches `_execute`'s target scope exactly and returns FALSE on clean catalogs — the intended short-circuit for the 15-minute cron.

### Default `COMPACTION_MAX_FILES=80` in justfile

Exports the value to child python via `export COMPACTION_MAX_FILES := env(...)` so it doesn't need to be set on the shell for each compaction run. Overrideable at invocation:

```bash
COMPACTION_MAX_FILES=500 just compact-to-tier-3
```

## Test plan

- [x] Lint: `ruff format` clean, `ruff check` no new errors
- [x] Parse: `ast.parse` clean
- [x] Smoke test tightened pre-flight against duckling-posthog (now-clean catalog): returns `FALSE`
- [x] Sample query confirmed the 10+ persons files at `/day=/` paths are the actual holdouts (see follow-up below)

## Follow-up (separate PR)

Some persons files (Class A, ~10+ on duckling-posthog) are at paths like `s3://.../backfill/persons/team_id=2/year=2026/month=02/day=12/xxx.parquet`. They have `partition_id IS NULL` and never got repaired because `_execute`'s persons path regex requires `/year=/month=/<file>.parquet$` — no intermediate `/day=/`. Persons is partitioned by `(year, month)` only, so the correct fpv rows would just be those two. Broadening the persons regex to accept an optional `/day=/` segment before the filename would let this tool repair them; queued as a follow-up.