### PR TITLE
Print target-catalog banner in interactive shells

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,14 @@ COPY tools/ducklake_maintenance.py /app/tools/ducklake_maintenance.py
 COPY tools/ducklake_maintenance.sql /app/tools/ducklake_maintenance.sql
 COPY tools/ducklake_metrics.py /app/tools/ducklake_metrics.py
 
+# Shell banner: interactive shells (kubectl exec) print which DuckLake
+# catalog the container targets, derived from DUCKLAKE_* env (override the
+# label with MILLPOND_SHELL_LABEL). Debian bash reads /etc/bash.bashrc for
+# interactive non-login shells; appended at build because the runtime
+# rootfs is read-only.
+COPY tools/shell-banner.bashrc /tmp/shell-banner.bashrc
+RUN cat /tmp/shell-banner.bashrc >> /etc/bash.bashrc && rm /tmp/shell-banner.bashrc
+
 ENV PATH="/app/.venv/bin:$PATH"
 
 RUN useradd --create-home --shell /bin/false millpond

--- a/tools/shell-banner.bashrc
+++ b/tools/shell-banner.bashrc
@@ -1,0 +1,23 @@
+# DuckLake target banner. Appended to /etc/bash.bashrc at image build
+# (Debian bash reads it for every interactive non-login shell, which is
+# what `kubectl exec -it ... -- bash` spawns; the runtime rootfs is
+# read-only and exec'd shells never touch PAM/motd, so this is the one
+# hook that reliably fires).
+#
+# Prints which DuckLake catalog this container is wired to, derived from
+# the standard DUCKLAKE_* env, so an operator can't mistake one catalog's
+# maintenance shell for another's before running expire/compact/delete.
+#
+# MILLPOND_SHELL_LABEL optionally overrides the derived label with a
+# deployment-specific name (set it in your pod spec).
+if [ -n "$DUCKLAKE_RDS_HOST" ] && [ -z "$MILLPOND_BANNER_SHOWN" ]; then
+    export MILLPOND_BANNER_SHOWN=1
+    _dl_label="${MILLPOND_SHELL_LABEL:-${DUCKLAKE_RDS_DATABASE:-${DUCKLAKE_RDS_HOST%%.*}}}"
+    printf '\n\033[1;33m=== DUCKLAKE MAINTENANCE SHELL ===\033[0m\n'
+    printf 'Catalog: %s\n' "$_dl_label"
+    printf 'RDS:     %s / %s\n' "$DUCKLAKE_RDS_HOST" "${DUCKLAKE_RDS_DATABASE:-?}"
+    printf 'Data:    %s\n' "${DUCKLAKE_DATA_PATH:-?}"
+    printf '\033[1;31mCheck the target above before any expire/compact/delete.\033[0m\n\n'
+    PS1="\[\033[1;33m\]${_dl_label}\[\033[0m\]|\w\$ "
+    unset _dl_label
+fi


### PR DESCRIPTION
## Problem

Maintenance operations (expire, compact, cleanup) run through interactive shells in the millpond image, and nothing in the shell identifies which DuckLake catalog the container is wired to. An operator with shells open into two deployments can run a destructive command against the wrong catalog with no visual cue.

## Changes

- `tools/shell-banner.bashrc`: on interactive shell start, print the target catalog, RDS host/database, and data path (derived from the standard `DUCKLAKE_*` env), plus a check-before-destructive-ops warning; set the prompt to carry the catalog label. `MILLPOND_SHELL_LABEL` optionally overrides the derived label with a deployment-specific name. Containers without `DUCKLAKE_RDS_HOST` skip the banner entirely, so non-shell consumers are unaffected.
- `Dockerfile`: append the snippet to `/etc/bash.bashrc` at build time — Debian bash reads it for interactive non-login shells (what `kubectl exec -it ... -- bash` spawns), and the runtime rootfs is read-only with no PAM/motd path, so build-time append is the only reliable hook.

## Testing

Sourced the snippet with representative env (label from database name, label from `MILLPOND_SHELL_LABEL` override, env absent → no output); `bash -n` clean; ruff pre-commit hooks pass.