### PR TITLE
Add purge-orphan-stats maintenance task

### DIFF
--- a/tests/unit/test_ducklake_maintenance.py
+++ b/tests/unit/test_ducklake_maintenance.py
@@ -120,6 +120,15 @@ class TestArgparse:
         args = self.parser.parse_args(["dedup-deletions"])
         assert args.dry_run is False
 
+    def test_purge_orphan_stats_dry_run(self):
+        args = self.parser.parse_args(["purge-orphan-stats", "--dry-run"])
+        assert args.command == "purge-orphan-stats"
+        assert args.dry_run is True
+
+    def test_purge_orphan_stats_real(self):
+        args = self.parser.parse_args(["purge-orphan-stats"])
+        assert args.dry_run is False
+
     def test_find_orphans(self):
         args = self.parser.parse_args(["find-orphans"])
         assert args.command == "find-orphans"
@@ -291,6 +300,102 @@ class TestExpireSnapshots:
 # ---------------------------------------------------------------------------
 # Tier B — orchestrators with mocked sub-calls
 # ---------------------------------------------------------------------------
+
+
+class TestPurgeOrphanStats:
+    """Verify purge_orphan_stats predicate shape, dry-run gating, and ordering."""
+
+    def _make_conn(self, before=(5, 120), after=(0, 0), lock_acquired=True):
+        """Mock conn: counts query returns `before` first, `after` afterwards."""
+        conn = MagicMock()
+        counts = iter([before, after, after])
+        executed = []
+
+        def fake_execute(sql, *args, **kwargs):
+            result = MagicMock()
+            if "postgres_query" in sql and "table_rows" in sql:
+                result.fetchone.return_value = next(counts)
+            elif "postgres_query" in sql and "pg_try_advisory_lock" in sql:
+                result.fetchone.return_value = (lock_acquired,)
+            elif "postgres_execute" in sql:
+                executed.append(sql)
+            return result
+
+        conn.execute.side_effect = fake_execute
+        conn._executed = executed
+        return conn
+
+    def test_dry_run_reports_without_deleting(self, caplog):
+        conn = self._make_conn(before=(5, 120))
+        with caplog.at_level(logging.INFO):
+            ducklake_maintenance.purge_orphan_stats(conn, dry_run=True)
+        assert conn._executed == []
+        assert "5 orphaned table-stats rows, 120 orphaned column-stats rows" in caplog.text
+
+    def test_zero_orphans_skips_lock_and_delete(self):
+        conn = self._make_conn(before=(0, 0))
+        ducklake_maintenance.purge_orphan_stats(conn, dry_run=False)
+        assert conn._executed == []
+        # advisory lock must not be taken when there is nothing to do
+        assert not any(
+            "pg_try_advisory_lock" in str(c) for c in conn.execute.call_args_list
+        )
+
+    def test_real_run_single_txn_table_stats_first(self, caplog):
+        """Both DELETEs must ship in ONE postgres_execute call (one REPEATABLE
+        READ transaction) with table_stats first. Two separate transactions
+        would expose a "table_stats present, column_stats gone" state that
+        crashes the commit path's conflict read (unguarded GetValue on the
+        NULL column_id the LEFT JOIN produces)."""
+        conn = self._make_conn(before=(5, 120), after=(0, 0))
+        with caplog.at_level(logging.INFO):
+            ducklake_maintenance.purge_orphan_stats(conn, dry_run=False)
+        assert len(conn._executed) == 1
+        sql = conn._executed[0]
+        assert "SET LOCAL statement_timeout" in sql
+        assert "SET LOCAL lock_timeout" in sql
+        ts_pos = sql.index("DELETE FROM public.ducklake_table_stats")
+        cs_pos = sql.index("DELETE FROM public.ducklake_table_column_stats")
+        assert ts_pos < cs_pos
+        assert "deleted ~5 table-stats and ~120 column-stats rows" in caplog.text
+
+    def test_lock_failure_aborts_before_any_delete(self):
+        conn = self._make_conn(before=(5, 120), lock_acquired=False)
+        with pytest.raises(RuntimeError, match="advisory lock"):
+            ducklake_maintenance.purge_orphan_stats(conn, dry_run=False)
+        assert conn._executed == []
+
+    def test_churn_during_run_clamps_deleted_at_zero(self, caplog):
+        """More orphans after than before (pathological churn) must not log
+        negative deleted counts."""
+        conn = self._make_conn(before=(5, 120), after=(7, 150))
+        with caplog.at_level(logging.INFO):
+            ducklake_maintenance.purge_orphan_stats(conn, dry_run=False)
+        assert "deleted ~0 table-stats and ~0 column-stats rows" in caplog.text
+        assert "7/150 orphans remain" in caplog.text
+
+    def test_predicate_uses_not_exists_never_not_in(self):
+        """NOT IN goes three-valued on NULL table_ids: it skips NULL-key rows
+        (metric/purge divergence) and deletes NOTHING if the live set ever
+        contained a NULL. The predicate must be NOT EXISTS."""
+        conn = self._make_conn(before=(1, 1), after=(0, 0))
+        ducklake_maintenance.purge_orphan_stats(conn, dry_run=False)
+        for sql in conn._executed:
+            assert "NOT EXISTS" in sql
+            assert "NOT IN" not in sql
+            assert "end_snapshot IS NULL" in sql
+
+    def test_large_purge_logs_vacuum_hint(self, caplog):
+        conn = self._make_conn(before=(1_000, 200_000), after=(0, 0))
+        with caplog.at_level(logging.INFO):
+            ducklake_maintenance.purge_orphan_stats(conn, dry_run=False)
+        assert "VACUUM (ANALYZE)" in caplog.text
+
+    def test_small_purge_no_vacuum_hint(self, caplog):
+        conn = self._make_conn(before=(5, 120), after=(0, 0))
+        with caplog.at_level(logging.INFO):
+            ducklake_maintenance.purge_orphan_stats(conn, dry_run=False)
+        assert "VACUUM" not in caplog.text
 
 
 class TestCleanupAllSafe:

--- a/tools/ducklake_maintenance.py
+++ b/tools/ducklake_maintenance.py
@@ -649,6 +649,127 @@ def dedup_deletions(conn: duckdb.DuckDBPyConnection, dry_run: bool) -> None:
     log.info("dedup-deletions: queue now has %d duplicate rows", after)
 
 
+# Bounds on the purge deletes so a blocked or runaway statement can't hold
+# the maintenance advisory lock forever. Same pattern as the
+# repair-partition-values timeout constants.
+_PURGE_ORPHAN_STATS_STATEMENT_TIMEOUT = "300s"
+_PURGE_ORPHAN_STATS_LOCK_TIMEOUT = "30s"
+
+
+def _orphan_stats_predicate(alias: str) -> str:
+    """WHERE fragment selecting stats rows whose table has no live version.
+
+    NOT EXISTS, never NOT IN: stats-table `table_id` is nullable and the
+    stats tables have no PK. NOT IN goes three-valued on NULLs — it skips
+    NULL-key rows (leaving permanent residue the monitoring counts as
+    orphaned), and if the live set ever contained a NULL table_id it would
+    silently delete NOTHING. NOT EXISTS treats NULL-key rows as orphaned,
+    which is correct: they are unreadable and pure commit-path weight.
+
+    Kept in lockstep with the `ducklake_stats_rows_orphaned` metric in
+    ducklake-metrics-daemon — metric and purge must count the same rows.
+    """
+    return (
+        f"NOT EXISTS ("
+        f"SELECT 1 FROM {PG_CATALOG_SCHEMA}.ducklake_table t "
+        f"WHERE t.table_id = {alias}.table_id AND t.end_snapshot IS NULL"
+        f")"
+    )
+
+
+def purge_orphan_stats(conn: duckdb.DuckDBPyConnection, dry_run: bool) -> None:
+    """Delete global-stats rows left behind by dropped tables.
+
+    DROP TABLE only end-snapshots the `ducklake_table` row; the table's rows
+    in `ducklake_table_stats` / `ducklake_table_column_stats` linger until
+    snapshot expiry deletes the last table version. The commit path reads
+    BOTH stats tables in full on every commit attempt, so on catalogs with
+    heavy DROP+CREATE churn the orphans directly inflate every writer's
+    commit latency (observed: a catalog at 99.3% orphaned column-stats rows
+    committed 30-50x slower until purged).
+
+    Safe to run at any time, concurrently with writers:
+      - Orphanhood is permanent — table_ids are allocated monotonically and
+        never reused, there is no undrop, and post-drop writes are rejected
+        at commit. Nothing can un-orphan a row.
+      - BOTH deletes run in ONE postgres_execute call = ONE REPEATABLE READ
+        transaction. This is load-bearing, not style: the commit path's
+        conflict read (GetSnapshotAndStatsAndChanges) does
+        `ducklake_table_stats LEFT JOIN ducklake_table_column_stats` with a
+        WHERE that only filters table_stats columns, and
+        TransformGlobalStatsRow does an UNGUARDED GetValue on column_id — a
+        reader-visible state of "table_stats row present, column_stats rows
+        gone" turns every contended commit into an InternalException. One
+        transaction means readers see either both tables purged or neither.
+        Within it, table_stats is deleted first to match the DeleteSnapshots
+        cascade order (same cross-table lock order → no lock-order-inversion
+        deadlock with concurrent expiry); the intermediate no-parent
+        column_stats state is invisible anyway (single txn) and harmless to
+        the LEFT JOIN even if it weren't.
+      - Live tables' stats rows are never touched, so concurrent stats
+        UPDATEs from committing writers don't contend with the deletes.
+      - A concurrent ducklake_expire_snapshots cascade (which does NOT take
+        our advisory lock) deleting the same rows can surface as a
+        serialization error or deadlock; the tool raises and a re-run is
+        fully convergent (rows already gone, predicate re-evaluates).
+
+    Column-stats rows are matched on table_id only: a row with NULL
+    column_id (observed in the wild) is still dead weight once its table is
+    gone. VACUUM cannot run here (postgres_execute wraps every call in a
+    transaction block), so after a large purge the commit path keeps
+    scanning dead pages until autovacuum catches up — for multi-100k purges
+    run `VACUUM (ANALYZE)` on both stats tables manually to realize the
+    full win immediately.
+    """
+    s = PG_CATALOG_SCHEMA
+    counts_sql = (
+        f"SELECT "
+        f"(SELECT COUNT(*) FROM {s}.ducklake_table_stats ts "
+        f" WHERE {_orphan_stats_predicate('ts')}) AS table_rows, "
+        f"(SELECT COUNT(*) FROM {s}.ducklake_table_column_stats cs "
+        f" WHERE {_orphan_stats_predicate('cs')}) AS column_rows"
+    )
+    table_rows, column_rows = _pg_query_one(conn, counts_sql)
+    log.info(
+        "purge-orphan-stats: %d orphaned table-stats rows, %d orphaned column-stats rows (dry_run=%s)",
+        table_rows,
+        column_rows,
+        dry_run,
+    )
+    if dry_run or (table_rows == 0 and column_rows == 0):
+        return
+
+    _acquire_advisory_lock(conn)
+    # One call = one transaction (see docstring); SET LOCAL bounds a blocked
+    # or runaway delete so the advisory lock can't be held forever — same
+    # pattern as repair-partition-values.
+    _pg_execute(
+        conn,
+        f"SET LOCAL statement_timeout = '{_PURGE_ORPHAN_STATS_STATEMENT_TIMEOUT}'; "
+        f"SET LOCAL lock_timeout = '{_PURGE_ORPHAN_STATS_LOCK_TIMEOUT}'; "
+        f"DELETE FROM {s}.ducklake_table_stats ts WHERE {_orphan_stats_predicate('ts')}; "
+        f"DELETE FROM {s}.ducklake_table_column_stats cs WHERE {_orphan_stats_predicate('cs')}",
+    )
+
+    after_table, after_column = _pg_query_one(conn, counts_sql)
+    log.info(
+        "purge-orphan-stats: deleted ~%d table-stats and ~%d column-stats rows "
+        "(%d/%d orphans remain from churn during the run)",
+        max(0, table_rows - after_table),
+        max(0, column_rows - after_column),
+        after_table,
+        after_column,
+    )
+    if table_rows + column_rows >= 100_000:
+        log.info(
+            "purge-orphan-stats: large purge — run VACUUM (ANALYZE) on "
+            "%s.ducklake_table_stats and %s.ducklake_table_column_stats to reclaim "
+            "dead pages now instead of waiting for autovacuum",
+            s,
+            s,
+        )
+
+
 # ---------------------------------------------------------------------------
 # repair-partition-values: recurring catalog cleanup
 # ---------------------------------------------------------------------------
@@ -1812,6 +1933,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--dry-run", action="store_true")
 
+    # purge-orphan-stats
+    p = sub.add_parser(
+        "purge-orphan-stats",
+        help="Delete global-stats rows for dropped tables (commit-path tax; see ducklake_stats_rows_orphaned metric)",
+    )
+    p.add_argument("--dry-run", action="store_true")
+
     # REMOVE-WHEN: upstream-ducklake-fix-deployed
     # repair-partition-values (one-shot per customer; remove with the upstream DuckLake source fix)
     p = sub.add_parser(
@@ -1956,6 +2084,8 @@ def main(argv: list[str] | None = None) -> None:
                 cleanup_all(conn, args.dry_run)
             case "dedup-deletions":
                 dedup_deletions(conn, args.dry_run)
+            case "purge-orphan-stats":
+                purge_orphan_stats(conn, args.dry_run)
             case "repair-partition-values":  # REMOVE-WHEN: upstream-ducklake-fix-deployed
                 repair_partition_values(conn, args.dry_run)
             case "find-orphans":

--- a/tools/justfile
+++ b/tools/justfile
@@ -136,6 +136,16 @@ dedup-deletions-dry-run:
 dedup-deletions:
     python {{ ducklake_maintenance }} dedup-deletions
 
+# Report orphaned global-stats rows (dropped tables' leftovers) without deleting
+[group('lifecycle')]
+purge-orphan-stats-dry-run:
+    python {{ ducklake_maintenance }} purge-orphan-stats --dry-run
+
+# Purge orphaned global-stats rows (dropped tables' leftovers tax every commit)
+[group('lifecycle')]
+purge-orphan-stats:
+    python {{ ducklake_maintenance }} purge-orphan-stats
+
 # REMOVE-WHEN: upstream-ducklake-fix-deployed
 # Preview repair-partition-values (counts only, no DML; one-shot per customer)
 [group('lifecycle')]


### PR DESCRIPTION
## What

New `purge-orphan-stats` subcommand in `tools/ducklake_maintenance.py` (+ `just purge-orphan-stats` / `purge-orphan-stats-dry-run` recipes): deletes global-stats rows whose `table_id` has no live `ducklake_table` row.

## Why

DROP TABLE only end-snapshots the `ducklake_table` row — the table's `ducklake_table_stats` / `ducklake_table_column_stats` rows linger until snapshot expiry reaps the last table version. The commit path reads both stats tables **in full on every commit attempt**, so on high-churn catalogs (DROP+CREATE import patterns) orphans directly tax every writer: one production catalog reached 99.3% orphaned column-stats rows and committed 30-50x slower until purged. Pairs with the `ducklake_stats_rows_{total,orphaned}` metric in ducklake-metrics-daemon — same predicate, same NULL semantics, so the gauge and the purge count the same rows.

## Design notes (Lead-QE + Principal-SQL reviewed)

- **One `postgres_execute` call = one REPEATABLE READ transaction, `table_stats` deleted first.** Load-bearing, found in review: the commit path's conflict read LEFT JOINs `table_stats` → `column_stats` with an unguarded `GetValue` on `column_id`, so a reader-visible "table_stats present, column_stats gone" state (the naive two-transaction, column-first version) turns every contended commit into an InternalException — and a crash between transactions would leave that state standing. Single txn = readers see both purged or neither; table_stats-first matches the `DeleteSnapshots` cascade lock order (no deadlock inversion with concurrent expiry). A test enshrines both properties.
- **`NOT EXISTS`, never `NOT IN`**: stats `table_id` is nullable and the tables have no PK; `NOT IN` skips NULL-key rows and would delete *nothing* if the live set ever contained a NULL.
- Safe concurrent with writers: orphanhood is permanent (table_ids monotonic/never reused, no undrop, post-drop writes rejected at commit); live rows are never touched. A concurrent `ducklake_expire_snapshots` cascade can surface a serialization error — re-run is convergent.
- `SET LOCAL statement_timeout/lock_timeout` per the repair-partition-values pattern; counts logged before/after (clamped at 0 under churn); dry-run and zero-orphan paths skip the advisory lock; VACUUM hint logged for ≥100k purges (VACUUM can't run inside postgres_execute's txn wrap).

## Testing

ruff clean; 525 unit tests pass (8 new: parser wiring, dry-run gating, zero-orphan lock skip, single-txn + delete-order enforcement, lock-failure aborts before DML, NOT-EXISTS predicate guard, churn clamp, vacuum-hint threshold).