### PR TITLE
bootstrap: covering index for the fpv-corruption integrity scan

### DIFF
--- a/tools/justfile
+++ b/tools/justfile
@@ -400,9 +400,18 @@ bootstrap-index-file-partition-value-table: _confirm-target
     @echo ">>> ducklake_file_partition_value_table_idx"
     @{{ _psql }} -c "CREATE INDEX CONCURRENTLY IF NOT EXISTS ducklake_file_partition_value_table_idx ON public.ducklake_file_partition_value USING btree (table_id);"
 
+# Covering index for the fpv-corruption integrity scan (ducklake-metrics-daemon's
+# ducklake_partition_value_corruption metric): a GROUP BY data_file_id
+# aggregation over (partition_key_index, partition_value). All three columns in
+# the index -> index-only scan, no heap fetches on this large table.
+[group('bootstrap')]
+bootstrap-index-file-partition-value-cover: _confirm-target
+    @echo ">>> ducklake_file_partition_value_cover_idx"
+    @{{ _psql }} -c "CREATE INDEX CONCURRENTLY IF NOT EXISTS ducklake_file_partition_value_cover_idx ON public.ducklake_file_partition_value USING btree (data_file_id, partition_key_index, partition_value);"
+
 # Create every DuckLake catalog btree, sequentially (same-relation builds serialize anyway)
 [group('bootstrap')]
-bootstrap-indexes: bootstrap-index-data-file-compaction bootstrap-index-data-file-compaction-order bootstrap-index-data-file-snapshot-read bootstrap-index-delete-file-snapshot-read bootstrap-index-delete-file-table bootstrap-index-delete-file-metrics bootstrap-index-file-column-stats bootstrap-index-file-partition-value-file bootstrap-index-file-partition-value-table
+bootstrap-indexes: bootstrap-index-data-file-compaction bootstrap-index-data-file-compaction-order bootstrap-index-data-file-snapshot-read bootstrap-index-delete-file-snapshot-read bootstrap-index-delete-file-table bootstrap-index-delete-file-metrics bootstrap-index-file-column-stats bootstrap-index-file-partition-value-file bootstrap-index-file-partition-value-table bootstrap-index-file-partition-value-cover
 
 # ----------------------------------------------------------------------------
 # state-metrics daemon


### PR DESCRIPTION
## What

Adds `ducklake_file_partition_value_cover_idx` on `(data_file_id, partition_key_index, partition_value)` to the `bootstrap-indexes` set.

## Why

The ducklake-metrics-daemon's new `ducklake_partition_value_corruption` metric (PostHog/ducklake-metrics-daemon#10) does a `GROUP BY data_file_id` aggregation over `partition_key_index` / `partition_value` across every partitioned table's live files. With all three referenced columns in one btree, that per-file aggregation is **index-only** — no heap fetches on `ducklake_file_partition_value`, which is one of the largest catalog tables. Combined with the metric's hourly cadence this keeps the integrity scan affordable even on big catalogs like megaduck.

## Notes

- `CREATE INDEX CONCURRENTLY IF NOT EXISTS`, idempotent, identical shape to the two existing fpv indexes; safe to re-run.
- Doesn't remove the join-side sort in the metric's query (the `ducklake_data_file` join still groups), but it eliminates the dominant per-row heap-fetch cost on the fpv leg.

## Testing

`just --justfile tools/justfile --list` parses; recipe is in the `bootstrap-indexes` umbrella. ruff pre-commit hooks pass.