### PR TITLE
fix(maintenance): per-table compaction isolation + repair pre-flight index-set predicate

### DIFF
--- a/tests/integration/test_compaction_isolation_integration.py
+++ b/tests/integration/test_compaction_isolation_integration.py
@@ -1,0 +1,145 @@
+"""Catalog-wide compaction must survive one poisoned table (real DuckLake).
+
+Builds a real local DuckLake (duckdb-file metadata + local data dir, stock
+ducklake extension), two hive-partitioned tables with several small files
+each, then rewrites half of one table's file paths in the metadata to a
+divergent hive directory — the `ducklake_add_data_files` foreign-path mix
+that aborted a production compactor with "DuckLakeCompactor: Files have
+different hive partition path" (the compactor groups candidates by logical
+partition_values, then asserts every file in a group shares one hive
+directory string).
+
+Asserts the per-table compact() loop:
+  * still merges the healthy table's files,
+  * reports (does NOT raise on) the poisoned table,
+  * leaves the poisoned table's files untouched,
+  * raises only when EVERY table fails (systemic).
+
+These tests also pin the load-bearing recovery property: the DuckDB
+connection survives the extension's InternalException, so the loop can keep
+going (verified on duckdb 1.5.2; a future duckdb that invalidates the
+instance on INTERNAL errors would fail here, loudly).
+
+Skips when the ducklake extension can't be installed (offline CI).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import duckdb
+import ducklake_maintenance
+import pytest
+
+pytestmark = pytest.mark.integration
+
+LAKE = ducklake_maintenance.ATTACH_NAME  # "lake" — compact() targets this name
+META_SCHEMA = ducklake_maintenance.METADATA_SCHEMA
+
+
+def _live_file_count(conn: duckdb.DuckDBPyConnection, table_name: str) -> int:
+    return conn.execute(
+        f"SELECT COUNT(*) FROM {META_SCHEMA}.ducklake_data_file df "
+        f"JOIN {META_SCHEMA}.ducklake_table t ON t.table_id = df.table_id "
+        "WHERE df.end_snapshot IS NULL AND t.end_snapshot IS NULL AND t.table_name = ?",
+        [table_name],
+    ).fetchone()[0]
+
+
+def _seed_partitioned_table(conn: duckdb.DuckDBPyConnection, table_name: str, n_files: int = 4) -> None:
+    """A hive-partitioned table with n single-row parquet files (every INSERT
+    is its own file; all well under the tier-1 1MiB ceiling). PARTITIONED BY
+    is set BEFORE the inserts so every file carries partition values and a
+    hive path — the preconditions for the compactor's hive-path check."""
+    conn.execute(f"CREATE TABLE {LAKE}.main.{table_name} (y INTEGER, v VARCHAR)")
+    conn.execute(f"ALTER TABLE {LAKE}.main.{table_name} SET PARTITIONED BY (y)")
+    for i in range(n_files):
+        conn.execute(f"INSERT INTO {LAKE}.main.{table_name} VALUES (2026, 'row{i}')")
+    assert _live_file_count(conn, table_name) == n_files
+
+
+def _poison_tables(conn: duckdb.DuckDBPyConnection, attach: str, table_names: tuple[str, ...]) -> None:
+    """Rewrite half of each table's file paths to a foreign hive directory
+    within the SAME logical partition (what add_data_files did in production —
+    different prefix AND different zero-padding, so neither directory string
+    is a substring of the other and the compactor's containment check fails
+    regardless of which file leads the group). Direct UPDATE on the metadata
+    duckdb file, with the lake detached."""
+    meta_path = conn.execute(f"SELECT path FROM duckdb_databases() WHERE database_name = '{META_SCHEMA}'").fetchone()[0]
+    conn.execute(f"DETACH {LAKE}")
+    meta_conn = duckdb.connect(meta_path)
+    for table_name in table_names:
+        meta_conn.execute(
+            "UPDATE ducklake_data_file "
+            "SET path = 'backfill/' || replace(path, 'y=2026', 'y=02026') "
+            "WHERE table_id = (SELECT table_id FROM ducklake_table "
+            f"                  WHERE table_name = '{table_name}' AND end_snapshot IS NULL) "
+            "  AND data_file_id % 2 = 0"
+        )
+    n_poisoned = meta_conn.execute("SELECT COUNT(*) FROM ducklake_data_file WHERE path LIKE 'backfill/%'").fetchone()[0]
+    meta_conn.close()
+    assert n_poisoned > 0, "poisoning must hit at least one live file"
+    conn.execute(attach)
+
+
+@pytest.fixture
+def lake(tmp_path):
+    conn = duckdb.connect()
+    try:
+        conn.execute("INSTALL ducklake; LOAD ducklake;")
+    except Exception:
+        pytest.skip("ducklake extension unavailable (offline?)")
+    meta = tmp_path / "meta.ducklake"
+    data = tmp_path / "data"
+    # DATA_INLINING_ROW_LIMIT 0: single-row INSERTs must land as real parquet
+    # files with hive paths + partition-value rows (inlined rows produce no
+    # ducklake_data_file entries and nothing for the compactor to merge).
+    attach = f"ATTACH 'ducklake:{meta}' AS {LAKE} (DATA_PATH '{data}', DATA_INLINING_ROW_LIMIT 0)"
+    conn.execute(attach)
+    yield conn, attach
+    conn.close()
+
+
+def _compact_tier1(conn) -> int:
+    return ducklake_maintenance.compact(
+        conn,
+        tier=1,
+        table=None,
+        dry_run=False,
+        threads=2,
+        memory_limit="1GB",
+        max_compacted_files=100,
+    )
+
+
+def test_poisoned_table_does_not_abort_catalog_compaction(lake, caplog):
+    conn, attach = lake
+    for t in ("good", "bad"):
+        _seed_partitioned_table(conn, t)
+    _poison_tables(conn, attach, ("bad",))
+
+    with caplog.at_level(logging.INFO, logger="maintenance"):
+        # Must NOT raise: partial failure is reported, healthy tables proceed.
+        n_failed = _compact_tier1(conn)
+
+    # Healthy table merged 4 small files down; poisoned table untouched.
+    assert n_failed == 1
+    assert _live_file_count(conn, "good") < 4
+    assert _live_file_count(conn, "bad") == 4
+    assert "main.bad failed" in caplog.text
+    assert "1/2 table(s) failed" in caplog.text
+    # The poisoned table failed with THE production error, not something
+    # incidental — this test reproduces the production incident end to end.
+    assert "Files have different hive partition path" in caplog.text
+
+
+def test_all_tables_poisoned_raises(lake):
+    """Every table failing is systemic and must surface as a run failure —
+    pinned against the real extension error, not a mock."""
+    conn, attach = lake
+    for t in ("bad1", "bad2"):
+        _seed_partitioned_table(conn, t)
+    _poison_tables(conn, attach, ("bad1", "bad2"))
+
+    with pytest.raises(RuntimeError, match="all 2 table"):
+        _compact_tier1(conn)

--- a/tests/unit/test_ducklake_maintenance.py
+++ b/tests/unit/test_ducklake_maintenance.py
@@ -9,6 +9,7 @@ in-process duckdb with stubbed schemas or the docker-compose stack.
 """
 
 import logging
+import re
 from unittest.mock import MagicMock, patch
 
 import duckdb
@@ -516,6 +517,48 @@ class TestRepairSqlEscaping:
         assert ("t.table_name = " + "'" * 2 + "events_o" + "'" * 4 + "brien" + "'" * 2) in sql
 
 
+class TestRepairPreFlightPredicate:
+    """The pre-flight must gate on the fpv INDEX SET, not the row count.
+
+    The collapsed shape (N rows all stacked on the top partition_key_index —
+    ducklake_add_data_files rot) has the RIGHT row count at the WRONG indexes.
+    A bare COUNT(...) <> N check passed it, so the pre-flight short-circuited
+    "clean" over real rot and _execute never ran, while the dashboard's
+    partition-value-corruption metric (distinct-index-set based) kept
+    flagging the same files. The predicate must mirror _count_broken /
+    _execute's post-condition."""
+
+    def _sql(self):
+        conn = MagicMock()
+        result = MagicMock()
+        result.fetchone.return_value = (True,)
+        conn.execute.return_value = result
+        assert ducklake_maintenance._repair_partition_values_pre_flight_any_rot(conn) is True
+        return conn.execute.call_args[0][0]
+
+    def test_gates_on_index_set_not_row_count(self):
+        sql = self._sql()
+        assert "IS DISTINCT FROM ARRAY[0,1,2]::bigint[]" in sql, "events must compare the index SET"
+        assert "IS DISTINCT FROM ARRAY[0,1]::bigint[]" in sql, "persons must compare the index SET"
+        assert "COUNT(fpv.partition_key_index) <> " not in sql, "row-count check passes the collapsed shape"
+
+    def test_aggregate_matches_count_broken(self):
+        # Non-DISTINCT array_agg (catches duplicated rows per index) with the
+        # NULL-filtered COALESCE-to-empty shape used by _count_broken.
+        sql = self._sql()
+        assert "array_agg(fpv.partition_key_index ORDER BY fpv.partition_key_index)" in sql
+        assert "FILTER (WHERE fpv.partition_key_index IS NOT NULL)" in sql
+
+    def test_expected_arrays_derive_from_spec(self):
+        # Single source of truth: the arrays come from
+        # _REPAIR_PARTITION_VALUE_SPEC, so a spec change can't desync the
+        # pre-flight from the repair.
+        sql = self._sql()
+        for kind, spec in ducklake_maintenance._REPAIR_PARTITION_VALUE_SPEC.items():
+            expected = "ARRAY[" + ",".join(str(idx) for idx, _ in spec) + "]::bigint[]"
+            assert expected in sql, f"{kind} expected-index array missing"
+
+
 class TestPurgeOrphanStats:
     """Verify purge_orphan_stats predicate shape, dry-run gating, and ordering."""
 
@@ -782,29 +825,62 @@ class TestHeartbeat:
         assert net is None or (isinstance(net, tuple) and len(net) == 2 and all(v >= 0 for v in net))
 
 
+def _compact_conn(tables, merge_rows=None, fail_tables=(), candidates=(100, 1000)):
+    """A duckdb-conn-shaped MagicMock driving the per-table compact() flow.
+
+    tables: (schema, table) pairs the information_schema read returns.
+    merge_rows: {table_name: result rows} for its merge CALL (default []).
+    fail_tables: table names whose merge CALL raises.
+    """
+    conn = MagicMock()
+    # The CALL's table name is its second positional arg — parse it instead of
+    # substring-matching, so a mock defect can't masquerade as a table failure.
+    call_re = re.compile(r"ducklake_merge_adjacent_files\('[^']*', '([^']*)'")
+
+    def _execute(sql, *a, **k):
+        res = MagicMock()
+        if "information_schema.tables" in sql:
+            res.fetchall.return_value = list(tables)
+        elif "ducklake_merge_adjacent_files" in sql:
+            m = call_re.search(sql)
+            assert m, f"unparseable merge CALL: {sql}"
+            name = m.group(1)
+            if name in fail_tables:
+                raise RuntimeError("DuckLakeCompactor: Files have different hive partition path")
+            res.fetchall.return_value = (merge_rows or {}).get(name, [])
+        elif "ducklake_options" in sql:
+            res.fetchone.return_value = ("134217728",)  # 128MiB, restore path
+        elif "ducklake_data_file" in sql:
+            res.fetchone.return_value = candidates
+        return res
+
+    conn.execute.side_effect = _execute
+    return conn
+
+
+def _merge_calls(conn):
+    return [c.args[0] for c in conn.execute.call_args_list if "ducklake_merge_adjacent_files" in c.args[0]]
+
+
 class TestCompactSql:
-    """compact() must pass the per-run file cap through to the merge CALL."""
+    """compact() must pass the per-run file cap through to the merge CALL(s)."""
 
     def test_merge_runs_under_heartbeat(self, monkeypatch):
-        """The heartbeat must wrap the merge call and be stopped afterwards."""
+        """The heartbeat must wrap each per-table merge and be stopped afterwards."""
         hb = MagicMock()
         start = MagicMock(return_value=hb)
         monkeypatch.setattr(ducklake_maintenance, "_start_heartbeat", start)
 
-        conn = MagicMock()
-        result = MagicMock()
-        result.fetchone.side_effect = [(100, 1000), ("128MiB",)]
-        result.fetchall.return_value = []
-        conn.execute.return_value = result
-
+        conn = _compact_conn([("posthog", "events")])
         ducklake_maintenance.compact(
             conn, tier=1, table=None, dry_run=False, threads=1, memory_limit="16GB", max_compacted_files=25000
         )
 
-        start.assert_called_once_with(conn, "compact tier-1 merge")
+        start.assert_called_once_with(conn, "compact tier-1 posthog.events")
         hb.set.assert_called_once()
 
-    def test_merge_call_includes_max_compacted_files(self):
+    def test_single_table_call_includes_max_compacted_files(self):
+        """--table invocation keeps the direct one-CALL form (no schema arg)."""
         conn = MagicMock()
         result = MagicMock()
         # candidate-count read, then ducklake_options read for target_file_size restore
@@ -813,11 +889,13 @@ class TestCompactSql:
         conn.execute.return_value = result
 
         ducklake_maintenance.compact(
-            conn, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=100000
+            conn, tier=1, table="events", dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=100000
         )
 
-        merge_calls = [c.args[0] for c in conn.execute.call_args_list if "ducklake_merge_adjacent_files" in c.args[0]]
+        merge_calls = _merge_calls(conn)
         assert len(merge_calls) == 1
+        assert "'events'" in merge_calls[0]
+        assert "schema =>" not in merge_calls[0]
         assert "max_compacted_files => 100000" in merge_calls[0]
         assert "max_file_size =>" in merge_calls[0]
 
@@ -831,8 +909,154 @@ class TestCompactSql:
             conn, tier=1, table=None, dry_run=True, threads=2, memory_limit="16GB", max_compacted_files=100000
         )
 
-        merge_calls = [c.args[0] for c in conn.execute.call_args_list if "ducklake_merge_adjacent_files" in c.args[0]]
-        assert not merge_calls
+        assert not _merge_calls(conn)
+
+
+class TestCompactPerTable:
+    """Catalog-wide compaction is one CALL per live table: a poisoned table
+    (e.g. mixed hive-path conventions from an add_data_files backfill — the
+    production `events` incident) must not abort the other tables' compaction."""
+
+    def test_catalog_wide_iterates_tables_with_schema(self):
+        conn = _compact_conn([("posthog", "events"), ("posthog", "persons")])
+        ducklake_maintenance.compact(
+            conn, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+        )
+        calls = _merge_calls(conn)
+        assert len(calls) == 2
+        assert "schema => 'posthog'" in calls[0] and "'events'" in calls[0]
+        assert "schema => 'posthog'" in calls[1] and "'persons'" in calls[1]
+        assert all("max_compacted_files => 10" in c for c in calls)
+
+    def test_poisoned_table_does_not_abort_run(self, caplog, monkeypatch):
+        hb = MagicMock()
+        start = MagicMock(return_value=hb)
+        monkeypatch.setattr(ducklake_maintenance, "_start_heartbeat", start)
+        conn = _compact_conn(
+            [("posthog", "events"), ("posthog", "persons")],
+            merge_rows={"persons": [("posthog", "persons", 4, 1)]},
+            fail_tables=("events",),
+        )
+        with caplog.at_level(logging.WARNING, logger="maintenance"):
+            n_failed = ducklake_maintenance.compact(
+                conn, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+            )
+        calls = _merge_calls(conn)
+        assert len(calls) == 2, "persons must still be compacted after events fails"
+        assert n_failed == 1
+        assert "1/2 table(s) failed" in caplog.text
+        assert "posthog.events" in caplog.text
+        # Heartbeat stopped on BOTH paths, including the failed table.
+        assert start.call_count == 2
+        assert hb.set.call_count == 2
+        # target_file_size restored despite the partial failure.
+        assert any("ducklake_set_option" in c.args[0] and "128MiB" in c.args[0] for c in conn.execute.call_args_list)
+
+    def test_all_tables_failed_raises(self):
+        conn = _compact_conn(
+            [("posthog", "events"), ("posthog", "persons")],
+            fail_tables=("events", "persons"),
+        )
+        with pytest.raises(RuntimeError, match="all 2 table"):
+            ducklake_maintenance.compact(
+                conn, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+            )
+
+    def test_single_table_catalog_poisoned_does_not_raise(self):
+        """1/1 failed must NOT raise: raising would re-wedge the recipe chain
+        (later tiers + cleanup-all) forever — the exact incident mode this
+        change fixes. The failure surfaces via the returned count/gauge."""
+        conn = _compact_conn([("posthog", "events")], fail_tables=("events",))
+        n_failed = ducklake_maintenance.compact(
+            conn, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+        )
+        assert n_failed == 1
+
+    def test_failure_budget_and_skip_interplay_does_not_raise(self):
+        """fail + budget-exhaust + never-reached must not trip the all-failed
+        policy: failed(1) < total(3)."""
+        conn = _compact_conn(
+            [("posthog", "aaa"), ("posthog", "bbb"), ("posthog", "ccc")],
+            merge_rows={"bbb": [("posthog", "bbb", 10, 1)]},
+            fail_tables=("aaa",),
+        )
+        n_failed = ducklake_maintenance.compact(
+            conn, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+        )
+        calls = _merge_calls(conn)
+        assert len(calls) == 2, "ccc must be deferred once bbb exhausts the budget"
+        assert n_failed == 1
+
+    def test_malformed_result_rows_fail_the_table_not_the_run(self, caplog):
+        """A fork/version drift in the CALL's result schema must fail that
+        table's accounting loudly, not poison the run-wide aggregation."""
+        conn = _compact_conn(
+            [("posthog", "events"), ("posthog", "persons")],
+            merge_rows={"events": [("posthog", "events", 3)], "persons": [("posthog", "persons", 4, 1)]},
+        )
+        with caplog.at_level(logging.WARNING, logger="maintenance"):
+            n_failed = ducklake_maintenance.compact(
+                conn, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+            )
+        assert n_failed == 1
+        assert "unexpected merge result shape" in caplog.text
+        assert len(_merge_calls(conn)) == 2, "persons still compacts after events' malformed rows"
+
+    def test_budget_is_global_across_tables(self):
+        """A table that consumes the whole file budget stops the loop; later
+        tables wait for the next run (preserves the old catalog-scope bound)."""
+        conn = _compact_conn(
+            [("posthog", "events"), ("posthog", "persons")],
+            merge_rows={"events": [("posthog", "events", 10, 1)]},
+        )
+        ducklake_maintenance.compact(
+            conn, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+        )
+        calls = _merge_calls(conn)
+        assert len(calls) == 1 and "'events'" in calls[0]
+
+    def test_remaining_budget_passed_to_next_table(self):
+        conn = _compact_conn(
+            [("posthog", "events"), ("posthog", "persons")],
+            merge_rows={"events": [("posthog", "events", 3, 1)]},
+        )
+        ducklake_maintenance.compact(
+            conn, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+        )
+        calls = _merge_calls(conn)
+        assert len(calls) == 2
+        assert "max_compacted_files => 10" in calls[0]
+        assert "max_compacted_files => 7" in calls[1]
+
+    def test_skips_non_identifier_table_names(self, caplog):
+        conn = _compact_conn([("posthog", "events"), ("posthog", "bad'name")])
+        with caplog.at_level(logging.WARNING, logger="maintenance"):
+            ducklake_maintenance.compact(
+                conn, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+            )
+        calls = _merge_calls(conn)
+        assert len(calls) == 1 and "'events'" in calls[0]
+        assert "non-identifier" in caplog.text
+
+    def test_empty_catalog_is_a_noop(self):
+        conn = _compact_conn([])
+        n_failed = ducklake_maintenance.compact(
+            conn, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+        )
+        assert not _merge_calls(conn)
+        assert n_failed == 0
+
+    def test_dry_run_does_not_enumerate_tables(self):
+        """Dry-run must stay cheap against a wedged catalog: no enumeration,
+        no merge CALLs, just the candidate count."""
+        conn = MagicMock()
+        result = MagicMock()
+        result.fetchone.return_value = (100, 1000)
+        conn.execute.return_value = result
+        ducklake_maintenance.compact(
+            conn, tier=1, table=None, dry_run=True, threads=2, memory_limit="16GB", max_compacted_files=10
+        )
+        assert not any("information_schema" in c.args[0] for c in conn.execute.call_args_list)
 
 
 class TestScopedTargetFileSize:

--- a/tools/ducklake_maintenance.py
+++ b/tools/ducklake_maintenance.py
@@ -957,20 +957,26 @@ def _repair_partition_values_discover_tables(conn: duckdb.DuckDBPyConnection) ->
 def _repair_partition_values_pre_flight_any_rot(conn: duckdb.DuckDBPyConnection) -> bool:
     """Cheap one-shot EXISTS across all in-scope posthog events/persons tables.
 
-    Returns True iff at least one file's fpv state doesn't match expected for
-    its kind: events files must have exactly 3 fpv rows (year/month/day),
-    persons exactly 2 (year/month). Also True if ANY fpv row in scope has a
-    NULL partition_value. EXISTS short-circuits at the first matching row
-    inside the LIMIT 1 subquery — keeps this snappy on clean catalogs.
+    Returns True iff at least one file's fpv INDEX SET is not exactly
+    {0..N-1} for its kind (events {0,1,2}, persons {0,1}), or ANY fpv row in
+    scope has a NULL partition_value. The array-set check mirrors
+    _count_broken / _execute's post-condition and catches BOTH missing rows
+    AND the collapsed-index shape (N rows all stacked on the top index —
+    ducklake_add_data_files rot with the RIGHT row count at the WRONG
+    indexes). A bare row-count check passed that shape, so the pre-flight
+    short-circuited "clean" over real rot and _execute never ran — exactly
+    the corruption the partition-value-corruption dashboard metric flags.
+    EXISTS short-circuits at the first matching row inside the LIMIT 1
+    subquery — keeps this snappy on clean catalogs.
 
-    Important because this subcommand will run as the first step of the
+    Important because this subcommand runs as the first step of the
     15-minute compaction cronjob: most invocations will be against clean
     catalogs and should exit before doing N per-table count queries.
     """
     # Restrict to files a real _execute run would actually touch:
     #   - Table must be PARTITIONED (has a live ducklake_partition_info row) —
     #     otherwise events_nrt / other unpartitioned events*/persons* variants
-    #     produce COUNT(fpv)=0 and trip the HAVING <> 3 branch forever.
+    #     produce an empty fpv index set and trip the HAVING branch forever.
     #   - Path must be S3-absolute — lake-relative files (ducklake-{uuid}.parquet
     #     at the lake root) don't fit the hive layout the repair targets.
     #   - Path must match the kind-specific hive layout _execute expects
@@ -983,11 +989,23 @@ def _repair_partition_values_pre_flight_any_rot(conn: duckdb.DuckDBPyConnection)
     # defeating the cron short-circuit.
     events_path_shape = _repair_partition_values_path_shape_predicate("events", column="df.path")
     persons_path_shape = _repair_partition_values_path_shape_predicate("persons", column="df.path")
+    # Same index-set aggregate + expected arrays as _count_broken and
+    # _execute's post-condition — all three MUST agree, or the pre-flight
+    # short-circuits over rot the repair would fix (or the reverse: fires
+    # forever over files the repair won't touch).
+    index_set_agg = (
+        "COALESCE(array_agg(fpv.partition_key_index ORDER BY fpv.partition_key_index) "
+        "FILTER (WHERE fpv.partition_key_index IS NOT NULL), '{}'::bigint[])"
+    )
+    expected = {
+        kind: "ARRAY[" + ",".join(str(idx) for idx, _ in spec) + "]::bigint[]"
+        for kind, spec in _REPAIR_PARTITION_VALUE_SPEC.items()
+    }
     pre_flight_sql = (
         "SELECT EXISTS ( "
         "  SELECT 1 FROM ( "
         "    SELECT df.data_file_id, df.table_id, t.table_name, "
-        "           COUNT(fpv.partition_key_index) AS n_fpv, "
+        f"           {index_set_agg} AS index_set, "
         "           BOOL_OR(fpv.partition_value IS NULL) AS has_null "
         f"    FROM {PG_CATALOG_SCHEMA}.ducklake_data_file df "
         f"    JOIN {PG_CATALOG_SCHEMA}.ducklake_table t USING (table_id) "
@@ -1014,8 +1032,11 @@ def _repair_partition_values_pre_flight_any_rot(conn: duckdb.DuckDBPyConnection)
         f"          AND {persons_path_shape}) "
         "      ) "
         "    GROUP BY df.data_file_id, df.table_id, t.table_name "
-        "    HAVING (t.table_name LIKE 'events%' AND COUNT(fpv.partition_key_index) <> 3) "
-        "        OR (t.table_name LIKE 'persons%' AND COUNT(fpv.partition_key_index) <> 2) "
+        # Index-SET comparison, not row count: the collapsed shape (3 rows all
+        # at index 2) has the right count at the wrong indexes, and the
+        # non-DISTINCT array_agg also catches duplicated rows per index.
+        f"    HAVING (t.table_name LIKE 'events%' AND {index_set_agg} IS DISTINCT FROM {expected['events']}) "
+        f"        OR (t.table_name LIKE 'persons%' AND {index_set_agg} IS DISTINCT FROM {expected['persons']}) "
         "        OR BOOL_OR(fpv.partition_value IS NULL) "
         "    LIMIT 1 "
         "  ) s "
@@ -1867,6 +1888,47 @@ def _start_heartbeat(conn: duckdb.DuckDBPyConnection, label: str, interval_s: fl
     return stop
 
 
+def _enumerate_compaction_tables(conn: duckdb.DuckDBPyConnection) -> list[tuple[str, str]]:
+    """Live BASE TABLEs in the attached lake as (schema, table_name) pairs.
+
+    Catalog-derived names are ordinary-DDL-controlled and get interpolated
+    into the per-table CALL statements below, so anything outside the
+    conservative identifier shape is skipped LOUDLY rather than quoted
+    heroically (same defense as repair-partition-values discovery).
+    """
+    rows = conn.execute(
+        "SELECT table_schema, table_name FROM information_schema.tables "
+        f"WHERE table_catalog = '{ATTACH_NAME}' AND table_type = 'BASE TABLE' "
+        "ORDER BY table_schema, table_name"
+    ).fetchall()
+    tables: list[tuple[str, str]] = []
+    for schema_name, table_name in rows:
+        # _CATALOG_TABLE_NAME_RE (strict [A-Za-z0-9_]+, fullmatch): these names
+        # are interpolated into single-quoted CALL args, and a millpond-written
+        # table is always a plain identifier — anything else is skipped, never
+        # quoted heroically.
+        if not _CATALOG_TABLE_NAME_RE.fullmatch(schema_name) or not _CATALOG_TABLE_NAME_RE.fullmatch(table_name):
+            log.warning(
+                "compact: skipping table with non-identifier name %r.%r (not millpond-written)",
+                schema_name,
+                table_name,
+            )
+            continue
+        tables.append((schema_name, table_name))
+    return tables
+
+
+def _merge_adjacent_call(schema_name: str | None, table_name: str, args: list[str], file_budget: int) -> str:
+    """Build the per-table ducklake_merge_adjacent_files CALL."""
+    call_args = [*args, f"max_compacted_files => {file_budget}"]
+    if schema_name is None:
+        return f"CALL ducklake_merge_adjacent_files('{ATTACH_NAME}', '{table_name}', {', '.join(call_args)})"
+    return (
+        f"CALL ducklake_merge_adjacent_files('{ATTACH_NAME}', '{table_name}', "
+        f"schema => '{schema_name}', {', '.join(call_args)})"
+    )
+
+
 def compact(
     conn: duckdb.DuckDBPyConnection,
     tier: int,
@@ -1875,8 +1937,15 @@ def compact(
     threads: int,
     memory_limit: str,
     max_compacted_files: int,
-) -> None:
-    """Compact files in tier N (1, 2, or 3) for the catalog or one table."""
+) -> int:
+    """Compact files in tier N (1, 2, or 3) for the catalog or one table.
+
+    Returns the number of tables whose per-table merge FAILED (0 when
+    everything succeeded, and always 0 for the single-table form, which
+    propagates its error raw instead). main() exports this as the
+    maintenance_compact_tables_failed gauge so a permanently-poisoned
+    table is alertable even though partial failure deliberately exits 0.
+    """
     spec = TIERS[tier]
     min_b, max_b, target = spec["min"], spec["max"], spec["target"]
     scope = f"table '{table}'" if table else "catalog-wide"
@@ -1912,32 +1981,112 @@ def compact(
     )
 
     if dry_run:
-        return
+        return 0
     if candidate_count == 0:
         log.info("compact tier-%d: nothing to do, skipping merge", tier)
-        return
+        return 0
 
     # Bound each run: the prod backlog (600k+ tier-1 candidates) is far too
     # large for one merge transaction — it would blow the cron pod's
     # activeDeadlineSeconds and produce one giant catalog commit. A capped
     # run finishes in bounded time and the cron schedule grinds the backlog
     # down incrementally.
-    args = [f"max_file_size => {max_b}", f"max_compacted_files => {max_compacted_files}"]
+    args = [f"max_file_size => {max_b}"]
     if min_b is not None:
         args.append(f"min_file_size => {min_b}")
-    if table:
-        sql = f"CALL ducklake_merge_adjacent_files('{ATTACH_NAME}', '{table}', {', '.join(args)})"
-    else:
-        sql = f"CALL ducklake_merge_adjacent_files('{ATTACH_NAME}', {', '.join(args)})"
 
     _set_compaction_tuning(conn, threads, memory_limit)
-    heartbeat = _start_heartbeat(conn, f"compact tier-{tier} merge")
     t0 = time.monotonic()
-    try:
+    result: list[tuple] = []
+    failed: list[str] = []
+    table_total = 1
+
+    if table:
+        # Single-table invocation: unchanged one-CALL semantics; an error
+        # propagates raw, exactly as before.
+        sql = _merge_adjacent_call(None, table, args, max_compacted_files)
+        heartbeat = _start_heartbeat(conn, f"compact tier-{tier} merge")
+        try:
+            with _scoped_target_file_size(conn, target):
+                result = conn.execute(sql).fetchall()
+        finally:
+            heartbeat.set()
+    else:
+        # Catalog-wide compaction, one CALL PER TABLE. The catalog-scope form
+        # of ducklake_merge_adjacent_files aborts the ENTIRE run when any one
+        # table can't compact — e.g. a merge group mixing hive-path
+        # conventions after an add_data_files backfill registered foreign
+        # paths into a live table (seen in production on `events`: the
+        # compactor groups by logical partition_values, then asserts all
+        # files share one hive directory string), or the orphaned
+        # inlined-data/schema-version classes. Per-table calls isolate the
+        # failure: every healthy table still compacts and the broken one is
+        # reported. Mirrors the battle-tested standalone posthog maintenance
+        # script, which loops tables for exactly this reason.
+        tables = _enumerate_compaction_tables(conn)
+        table_total = len(tables)
+        log.info("compact tier-%d: %d live table(s), per-table merge", tier, table_total)
+        if not tables and candidate_count > 0:
+            # Candidates exist but no table passed the identifier gate — the
+            # per-table WARNs above explain which; escalate so this can't be
+            # a silent perpetual no-op.
+            log.warning(
+                "compact tier-%d: %d candidate file(s) but no compactable tables — check skipped-name warnings",
+                tier,
+                candidate_count,
+            )
         with _scoped_target_file_size(conn, target):
-            result = conn.execute(sql).fetchall()
-    finally:
-        heartbeat.set()
+            # max_compacted_files stays a GLOBAL budget across the run — the
+            # same bound as the old catalog-scope call — so run duration
+            # stays predictable. Each table gets what's left; leftovers wait
+            # for the next cron tick.
+            remaining = max_compacted_files
+            for schema_name, table_name in tables:
+                if remaining <= 0:
+                    log.info(
+                        "compact tier-%d: file budget exhausted; remaining tables wait for the next run",
+                        tier,
+                    )
+                    break
+                sql = _merge_adjacent_call(schema_name, table_name, args, remaining)
+                heartbeat = _start_heartbeat(conn, f"compact tier-{tier} {schema_name}.{table_name}")
+                try:
+                    rows = conn.execute(sql).fetchall()
+                    # Validate shape BEFORE mutating shared state: if a fork/
+                    # version drift changes the CALL's result schema, this
+                    # table's accounting fails loudly but the run-wide
+                    # aggregation below never sees malformed rows.
+                    if any(len(r) < 4 for r in rows):
+                        raise ValueError(f"unexpected merge result shape: {rows[:2]!r}")
+                    consumed = sum(r[2] for r in rows)
+                    result.extend(rows)
+                    remaining -= consumed
+                except duckdb.CatalogException:
+                    # Table vanished between enumeration and the CALL (dropped
+                    # mid-run) — benign, don't count it as a failure.
+                    log.warning(
+                        "compact tier-%d: %s.%s disappeared before merge (dropped?); skipping",
+                        tier,
+                        schema_name,
+                        table_name,
+                    )
+                except Exception:
+                    # Continue-on-error relies on the connection SURVIVING the
+                    # failed CALL (verified on duckdb 1.5.2 even for
+                    # InternalException, and pinned end-to-end by
+                    # test_compaction_isolation_integration). If a future
+                    # duckdb bump invalidates the instance on INTERNAL errors,
+                    # every subsequent CALL fails and the run hard-fails via
+                    # the all-failed policy below — noisy, not silent.
+                    failed.append(f"{schema_name}.{table_name}")
+                    log.exception(
+                        "compact tier-%d: %s.%s failed; continuing with remaining tables",
+                        tier,
+                        schema_name,
+                        table_name,
+                    )
+                finally:
+                    heartbeat.set()
     elapsed = time.monotonic() - t0
 
     # Aggregate result rows (one per output group: schema, table, input_files, output_files)
@@ -1968,6 +2117,29 @@ def compact(
         total_outputs,
         elapsed,
     )
+    if failed:
+        log.warning(
+            "compact tier-%d: %d/%d table(s) failed: %s",
+            tier,
+            len(failed),
+            table_total,
+            ", ".join(failed),
+        )
+        if table_total >= 2 and len(failed) == table_total:
+            # Every table failed — that's systemic (catalog down, bad creds,
+            # broken extension), not one poisoned table. Surface as a run
+            # failure so the Job/backoff machinery reacts. A PARTIAL failure
+            # exits 0 on purpose: the just-recipe chain must proceed to the
+            # later tiers and cleanup-all (deletion-queue drain) for the
+            # healthy tables instead of wedging the whole schedule on one
+            # broken table. A SINGLE-table catalog is exempt for the same
+            # reason — 1/1 failed would re-wedge cleanup forever; the
+            # maintenance_compact_tables_failed gauge carries the alert
+            # instead. (Best-effort heuristic: a systemic failure where one
+            # trivially-empty table "succeeds" also lands on the gauge, not
+            # the raise.)
+            raise RuntimeError(f"compact tier-{tier}: all {table_total} table(s) failed")
+    return len(failed)
 
 
 def compact_probe(conn: duckdb.DuckDBPyConnection, table: str, max_compacted_files: int) -> None:
@@ -2183,6 +2355,15 @@ def main(argv: list[str] | None = None) -> None:
         ["operation", "status"],
         registry=registry,
     )
+    # Partial compaction failures deliberately exit 0 (the recipe chain must
+    # still run later tiers + cleanup-all), so a permanently-poisoned table
+    # would otherwise be invisible to metrics. Alert on sustained nonzero.
+    compact_tables_failed = Gauge(
+        "maintenance_compact_tables_failed",
+        "Tables whose per-table merge failed in the last compact run",
+        ["tier"],
+        registry=registry,
+    )
     operation = args.command
     if hasattr(args, "days") and args.days < 1:
         parser.error("--days must be >= 1")
@@ -2231,7 +2412,7 @@ def main(argv: list[str] | None = None) -> None:
             case "checkpoint":
                 checkpoint(conn)
             case "compact":
-                compact(
+                n_failed = compact(
                     conn,
                     args.tier,
                     args.table or None,
@@ -2240,6 +2421,7 @@ def main(argv: list[str] | None = None) -> None:
                     args.memory_limit,
                     args.max_compacted_files,
                 )
+                compact_tables_failed.labels(tier=str(args.tier)).set(n_failed)
             case "compact-probe":
                 compact_probe(conn, args.table, args.max_compacted_files)
     except Exception:


### PR DESCRIPTION
## Problem

Two independently root-caused failures in the 15-minute maintenance cron:

**1. One poisoned table aborts ALL compaction.** `compact --tier N` (catalog-wide) issues a single catalog-scope `ducklake_merge_adjacent_files` CALL. The extension groups candidates by logical `partition_values`, then asserts every file in a group shares one hive directory string. A table carrying `ducklake_add_data_files`-registered files with a foreign path convention (different prefix + zero-padding within the same logical partition) throws `INTERNAL Error: DuckLakeCompactor: Files have different hive partition path` at bind time — and the whole catalog's run dies. Observed in production: a tenant catalog where every tick failed after ~23 min, so *no* table compacted, ever.

**2. The repair's pre-flight is blind to the collapsed-index rot it exists to fix.** `repair-partition-values` short-circuits via a row-count check (`COUNT(fpv) <> 3/2`). The actual corruption (N fpv rows all stacked on the top `partition_key_index`) has the *right count at the wrong indexes*, so the pre-flight reported "clean" and `_execute` — which handles exactly this shape ("Era 3") and rewrites fpv from the intact hive path — never ran. Meanwhile the corruption dashboard metric (index-set based) kept flagging the same files: 78 on one production catalog, verified against the RDS.

## Changes

`tools/ducklake_maintenance.py`:
- Catalog-wide `compact()` is now **one CALL per live table** (enumerated from information_schema, strict identifier gate), `schema =>`-qualified, continue-on-error. `max_compacted_files` remains a **global** budget across the run. Failures: WARN summary; **raise only when ALL tables (≥2) failed** (systemic). Partial failure exits 0 deliberately — the recipe chain must still run later tiers + `cleanup-all`. Single-table catalogs never raise (raising would re-wedge the chain forever — the incident mode). Dropped-mid-run tables (`CatalogException`) are a benign skip.
- New **`maintenance_compact_tables_failed{tier}` gauge** so a permanently-poisoned table is alertable despite exit 0.
- Result-row shape validated before touching shared state — a fork/version drift in the CALL's result schema fails that table loudly instead of poisoning the run aggregation.
- **Pre-flight predicate**: row count → index-set comparison (`IS DISTINCT FROM ARRAY[0..N-1]`), using the same aggregate as `_count_broken`/`_execute`'s post-condition, with expected arrays derived from `_REPAIR_PARTITION_VALUE_SPEC` — the three predicates cannot desync.

## Validation

Authored with an AI assistant; checks actually run:
- `ruff check` + `ruff format --check` clean; **558 unit tests + 1 xfail pass** (12 new/updated for the loop contract: per-table SQL shape, budget threading incl. remaining-budget passthrough, poisoned-table-continues, all-fail raise, single-table exemption, malformed-rows guard, heartbeat stop on failure, target_file_size restore on partial failure, dry-run stays cheap, non-identifier skip, empty catalog; 3 new for the pre-flight predicate).
- **2 integration tests against a real local DuckLake** (stock extension): reproduce the exact production error end to end — poisoned table contained (healthy table merges, poisoned untouched, exact error string asserted), all-poisoned raises. Marker-gated (`pytest.mark.integration`) out of the CI unit lane.
- Empirically verified during review: the DuckDB connection **survives** the extension's `InternalException` (the loop's load-bearing property; pinned by the integration test), the CALL's result schema matches the budget arithmetic, and no-op merge CALLs commit no snapshot.
- Reviewed by two independent adversarial passes (QE + SWE lens); all BLOCKER/HIGH/MEDIUM findings addressed or explicitly dispositioned (one heuristic rejected as re-wedging the chain in steady state — documented in-code).

## Deferred (fast-follow)

- Candidate-driven table enumeration (skip zero-candidate tables; also fixes alphabetical budget starvation) — same small refactor.
- The true fix for mixed-path tables is fork-side: include the derived hive directory in the compaction group key so foreign-path files form their own groups. Until then they are contained, not compacted.

## Rollout

No config change; ships with the next image. On the affected catalogs: healthy tables start compacting on the first tick; the collapsed-index files get repaired by the recipe's first post-deploy run (pre-flight now fires), draining the corruption metric.