### PR TITLE
fix(maintenance): candidate-driven compaction enumeration, biggest backlog first

### DIFF
--- a/tests/integration/test_compaction_isolation_integration.py
+++ b/tests/integration/test_compaction_isolation_integration.py
@@ -133,13 +133,46 @@ def test_poisoned_table_does_not_abort_catalog_compaction(lake, caplog):
     assert "Files have different hive partition path" in caplog.text
 
 
-def test_all_tables_poisoned_raises(lake):
-    """Every table failing is systemic and must surface as a run failure —
-    pinned against the real extension error, not a mock."""
+def test_all_tables_poisoned_does_not_wedge(lake, caplog):
+    """Even ALL tables failing must not raise — the poison-set attractor:
+    candidate-driven enumeration converges on the failed set (healthy tables
+    drain out once compacted; poisoned ones never do), so all-failed is the
+    steady state under persistent poison. Raising would wedge the recipe
+    chain (later tiers + cleanup-all) every tick — the incident mode this
+    loop exists to prevent. Pinned against the real extension error."""
     conn, attach = lake
     for t in ("bad1", "bad2"):
         _seed_partitioned_table(conn, t)
     _poison_tables(conn, attach, ("bad1", "bad2"))
 
-    with pytest.raises(RuntimeError, match="all 2 table"):
-        _compact_tier1(conn)
+    with caplog.at_level(logging.WARNING, logger="maintenance"):
+        n_failed = _compact_tier1(conn)
+
+    assert n_failed == 2
+    assert _live_file_count(conn, "bad1") == 4
+    assert _live_file_count(conn, "bad2") == 4
+    assert "2/2 table(s) failed" in caplog.text
+
+
+def test_biggest_backlog_served_first_within_budget(lake):
+    """Behavioral pin of the whole fix: with an alphabetically-first small
+    table and an alphabetically-last big one, the big one must be served
+    first (ORDER BY candidate count DESC flowing through the loop), and the
+    budget must stop the run before the small one — no alphabetical
+    starvation of the backlog."""
+    conn, _attach = lake
+    _seed_partitioned_table(conn, "aaa_small", n_files=2)
+    _seed_partitioned_table(conn, "zzz_big", n_files=6)
+
+    ducklake_maintenance.compact(
+        conn,
+        tier=1,
+        table=None,
+        dry_run=False,
+        threads=2,
+        memory_limit="1GB",
+        max_compacted_files=6,
+    )
+
+    assert _live_file_count(conn, "zzz_big") < 6, "biggest backlog must be served first"
+    assert _live_file_count(conn, "aaa_small") == 2, "budget must exhaust before the small table"

--- a/tests/unit/test_ducklake_maintenance.py
+++ b/tests/unit/test_ducklake_maintenance.py
@@ -928,7 +928,9 @@ class TestCompactPerTable:
         assert len(calls) == 2
         assert "schema => 'posthog'" in calls[0] and "'events'" in calls[0]
         assert "schema => 'posthog'" in calls[1] and "'persons'" in calls[1]
-        assert all("max_compacted_files => 10" in c for c in calls)
+        # Multi-table runs cap each table's grant at half the budget so the
+        # first (biggest-backlog) table can't monopolize every run.
+        assert all("max_compacted_files => 5" in c for c in calls)
 
     def test_poisoned_table_does_not_abort_run(self, caplog, monkeypatch):
         hb = MagicMock()
@@ -954,15 +956,24 @@ class TestCompactPerTable:
         # target_file_size restored despite the partial failure.
         assert any("ducklake_set_option" in c.args[0] and "128MiB" in c.args[0] for c in conn.execute.call_args_list)
 
-    def test_all_tables_failed_raises(self):
+    def test_all_tables_failed_does_not_raise(self, caplog):
+        """Per-table failures NEVER raise — the poison-set attractor: with
+        candidate-driven enumeration, healthy tables drain OUT of the table
+        list once compacted while poisoned ones never do, so
+        failed == table_total is the steady state under any persistent
+        poison. An all-failed raise would wedge the recipe chain (later
+        tiers + cleanup-all) every tick, forever — the incident mode this
+        loop exists to prevent. The WARN + gauge carry the alert."""
         conn = _compact_conn(
             [("posthog", "events"), ("posthog", "persons")],
             fail_tables=("events", "persons"),
         )
-        with pytest.raises(RuntimeError, match="all 2 table"):
-            ducklake_maintenance.compact(
+        with caplog.at_level(logging.WARNING, logger="maintenance"):
+            n_failed = ducklake_maintenance.compact(
                 conn, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
             )
+        assert n_failed == 2
+        assert "2/2 table(s) failed" in caplog.text
 
     def test_single_table_catalog_poisoned_does_not_raise(self):
         """1/1 failed must NOT raise: raising would re-wedge the recipe chain
@@ -1017,7 +1028,10 @@ class TestCompactPerTable:
         calls = _merge_calls(conn)
         assert len(calls) == 1 and "'events'" in calls[0]
 
-    def test_remaining_budget_passed_to_next_table(self):
+    def test_grant_cap_prevents_whale_monopoly(self):
+        """Multi-table runs grant each table at most half the budget per CALL
+        (biggest backlog gets the biggest cut, never the whole pie); the
+        single-table form keeps the full budget."""
         conn = _compact_conn(
             [("posthog", "events"), ("posthog", "persons")],
             merge_rows={"events": [("posthog", "events", 3, 1)]},
@@ -1027,8 +1041,15 @@ class TestCompactPerTable:
         )
         calls = _merge_calls(conn)
         assert len(calls) == 2
-        assert "max_compacted_files => 10" in calls[0]
-        assert "max_compacted_files => 7" in calls[1]
+        assert "max_compacted_files => 5" in calls[0], "first table capped at budget//2"
+        assert "max_compacted_files => 5" in calls[1], "second grant = min(remaining=7, cap=5)"
+
+        # Single-table catalog: no cap — the whole budget goes to the one table.
+        conn1 = _compact_conn([("posthog", "events")])
+        ducklake_maintenance.compact(
+            conn1, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+        )
+        assert "max_compacted_files => 10" in _merge_calls(conn1)[0]
 
     def test_skips_non_identifier_table_names(self, caplog):
         conn = _compact_conn([("posthog", "events"), ("posthog", "bad'name")])
@@ -1077,6 +1098,13 @@ class TestCompactPerTable:
         assert "ducklake_data_file" in sql and "ducklake_table" in sql and "ducklake_schema" in sql
         assert "ORDER BY COUNT(*) DESC" in sql, "most backlogged table must be served first"
         assert "file_size_bytes < 1048576" in sql, "enumeration must be scoped to the tier's size band"
+        # Liveness on ALL FOUR relations: file, table, schema, and the
+        # delete-file anti-join. Dropping the table one silently enumerates
+        # renamed tables under stale names (perpetual CatalogException noise);
+        # dropping the delete-file one lets unmergeable delete-laden whales
+        # rank first and no-op forever.
+        assert sql.count("end_snapshot IS NULL") == 4
+        assert "NOT EXISTS" in sql and "ducklake_delete_file" in sql
         assert not any("information_schema" in c.args[0] for c in conn.execute.call_args_list)
 
     def test_enumeration_band_includes_min_for_upper_tiers(self):
@@ -1086,6 +1114,20 @@ class TestCompactPerTable:
         )
         sql = next(c.args[0] for c in conn.execute.call_args_list if "HAVING COUNT(*) >= 2" in c.args[0])
         assert "file_size_bytes >= 1048576" in sql and "file_size_bytes < 10485760" in sql
+
+    def test_all_singleton_candidates_logs_info_not_warning(self, caplog):
+        """Candidates exist but no table qualifies (all per-table singletons,
+        or delete-laden files excluded): benign INFO, zero merge CALLs, no
+        raise — NOT a warning-level anomaly."""
+        conn = _compact_conn([], candidates=(5, 1000))
+        with caplog.at_level(logging.INFO, logger="maintenance"):
+            n_failed = ducklake_maintenance.compact(
+                conn, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+            )
+        assert n_failed == 0
+        assert not _merge_calls(conn)
+        rec = next(r for r in caplog.records if "nothing mergeable" in r.message)
+        assert rec.levelno == logging.INFO
 
 
 class TestScopedTargetFileSize:

--- a/tests/unit/test_ducklake_maintenance.py
+++ b/tests/unit/test_ducklake_maintenance.py
@@ -828,7 +828,8 @@ class TestHeartbeat:
 def _compact_conn(tables, merge_rows=None, fail_tables=(), candidates=(100, 1000)):
     """A duckdb-conn-shaped MagicMock driving the per-table compact() flow.
 
-    tables: (schema, table) pairs the information_schema read returns.
+    tables: (schema, table) pairs the candidate-driven enumeration returns
+    (the mock returns them verbatim — production orders by backlog DESC).
     merge_rows: {table_name: result rows} for its merge CALL (default []).
     fail_tables: table names whose merge CALL raises.
     """
@@ -839,7 +840,8 @@ def _compact_conn(tables, merge_rows=None, fail_tables=(), candidates=(100, 1000
 
     def _execute(sql, *a, **k):
         res = MagicMock()
-        if "information_schema.tables" in sql:
+        if "HAVING COUNT(*) >= 2" in sql:
+            # candidate-driven table enumeration
             res.fetchall.return_value = list(tables)
         elif "ducklake_merge_adjacent_files" in sql:
             m = call_re.search(sql)
@@ -1056,7 +1058,34 @@ class TestCompactPerTable:
         ducklake_maintenance.compact(
             conn, tier=1, table=None, dry_run=True, threads=2, memory_limit="16GB", max_compacted_files=10
         )
+        assert not any("HAVING COUNT(*) >= 2" in c.args[0] for c in conn.execute.call_args_list)
+
+    def test_enumeration_is_candidate_driven_backlog_first(self):
+        """The table list must come from the tier's candidate files — sized to
+        the tier band, >= 2 files per table (singletons can't merge), most
+        backlogged first — NOT information_schema. Alphabetical enumeration
+        over all live tables let 2-file cosmetic merges starve the real
+        backlog out of the budget (observed: 3,074 tables, budget gone on
+        five billing tables, the 15k-candidate events table never reached)."""
+        conn = _compact_conn([("posthog", "events")])
+        ducklake_maintenance.compact(
+            conn, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+        )
+        enum_calls = [c.args[0] for c in conn.execute.call_args_list if "HAVING COUNT(*) >= 2" in c.args[0]]
+        assert len(enum_calls) == 1
+        sql = enum_calls[0]
+        assert "ducklake_data_file" in sql and "ducklake_table" in sql and "ducklake_schema" in sql
+        assert "ORDER BY COUNT(*) DESC" in sql, "most backlogged table must be served first"
+        assert "file_size_bytes < 1048576" in sql, "enumeration must be scoped to the tier's size band"
         assert not any("information_schema" in c.args[0] for c in conn.execute.call_args_list)
+
+    def test_enumeration_band_includes_min_for_upper_tiers(self):
+        conn = _compact_conn([("posthog", "events")])
+        ducklake_maintenance.compact(
+            conn, tier=2, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+        )
+        sql = next(c.args[0] for c in conn.execute.call_args_list if "HAVING COUNT(*) >= 2" in c.args[0])
+        assert "file_size_bytes >= 1048576" in sql and "file_size_bytes < 10485760" in sql
 
 
 class TestScopedTargetFileSize:

--- a/tools/ducklake_maintenance.py
+++ b/tools/ducklake_maintenance.py
@@ -1915,9 +1915,22 @@ def _enumerate_compaction_tables(
         "t.end_snapshot IS NULL",
         "sch.end_snapshot IS NULL",
         f"df.file_size_bytes < {max_b}",
+        # Mirror the compactor's own selection: merge_adjacent skips any file
+        # carrying live delete files, so counting them here would let an
+        # unmergeable-but-huge table rank first and no-op at the top of every
+        # run (rank inflated by files the extension refuses to touch).
+        (
+            f"NOT EXISTS (SELECT 1 FROM {METADATA_SCHEMA}.ducklake_delete_file dl "
+            "WHERE dl.data_file_id = df.data_file_id AND dl.end_snapshot IS NULL)"
+        ),
     ]
     if min_b is not None:
         where.append(f"df.file_size_bytes >= {min_b}")
+    # NOTE: COUNT(*) >= 2 is per-TABLE; the extension merges per
+    # (partition_id, partition_values) group, so 2 candidates in different
+    # partitions still yield a zero-group no-op CALL. That's a wasted bind
+    # scan, not a correctness issue — do not read >= 2 as a mergeability
+    # guarantee. Zero-group CALLs are counted and logged by the caller.
     rows = conn.execute(
         "SELECT sch.schema_name, t.table_name "
         f"FROM {METADATA_SCHEMA}.ducklake_data_file df "
@@ -2027,6 +2040,7 @@ def compact(
     result: list[tuple] = []
     failed: list[str] = []
     table_total = 1
+    noop_tables = 0
 
     if table:
         # Single-table invocation: unchanged one-CALL semantics; an error
@@ -2070,8 +2084,15 @@ def compact(
         with _scoped_target_file_size(conn, target):
             # max_compacted_files stays a GLOBAL budget across the run — the
             # same bound as the old catalog-scope call — so run duration
-            # stays predictable. Each table gets what's left; leftovers wait
-            # for the next cron tick.
+            # stays predictable. Leftover tables wait for the next cron tick.
+            #
+            # Per-table GRANT cap: on multi-table runs no single table may
+            # claim more than half the budget in one CALL. Backlog-DESC
+            # ordering without the cap re-created starvation in mirror image —
+            # a whale whose ingest outpaces the drain rate would consume the
+            # entire budget every tick and tables #2..N would never be
+            # served. Biggest backlog still gets the biggest cut; it just
+            # can't take the whole pie.
             remaining = max_compacted_files
             for schema_name, table_name in tables:
                 if remaining <= 0:
@@ -2080,7 +2101,8 @@ def compact(
                         tier,
                     )
                     break
-                sql = _merge_adjacent_call(schema_name, table_name, args, remaining)
+                grant = remaining if table_total == 1 else min(remaining, max(1, max_compacted_files // 2))
+                sql = _merge_adjacent_call(schema_name, table_name, args, grant)
                 heartbeat = _start_heartbeat(conn, f"compact tier-{tier} {schema_name}.{table_name}")
                 try:
                     rows = conn.execute(sql).fetchall()
@@ -2090,6 +2112,12 @@ def compact(
                     # aggregation below never sees malformed rows.
                     if any(len(r) < 4 for r in rows):
                         raise ValueError(f"unexpected merge result shape: {rows[:2]!r}")
+                    if not rows:
+                        # >= 2 in-band files but zero merge groups: candidates
+                        # are per-partition singletons, row-id-non-contiguous,
+                        # or otherwise unmergeable. Counted so a catalog full
+                        # of these is visible, not a silent perpetual no-op.
+                        noop_tables += 1
                     consumed = sum(r[2] for r in rows)
                     result.extend(rows)
                     remaining -= consumed
@@ -2108,8 +2136,9 @@ def compact(
                     # InternalException, and pinned end-to-end by
                     # test_compaction_isolation_integration). If a future
                     # duckdb bump invalidates the instance on INTERNAL errors,
-                    # every subsequent CALL fails and the run hard-fails via
-                    # the all-failed policy below — noisy, not silent.
+                    # every table fails, the failure summary + gauge spike,
+                    # and the target_file_size restore raises — noisy, not
+                    # silent.
                     failed.append(f"{schema_name}.{table_name}")
                     log.exception(
                         "compact tier-%d: %s.%s failed; continuing with remaining tables",
@@ -2149,7 +2178,27 @@ def compact(
         total_outputs,
         elapsed,
     )
+    if noop_tables:
+        log.info(
+            "compact tier-%d: %d/%d table(s) had >= 2 in-band files but zero merge groups "
+            "(per-partition singletons / non-contiguous row-ids)",
+            tier,
+            noop_tables,
+            table_total,
+        )
     if failed:
+        # Per-table failures NEVER raise, no matter how many. An
+        # all-failed raise sounds like a systemic-failure detector, but
+        # candidate-driven enumeration converges on exactly the failed set:
+        # healthy tables drain out of the enumeration once compacted while
+        # poisoned tables never do, so failed == table_total is this
+        # system's steady state under any persistent poison — and raising
+        # would wedge the recipe chain (later tiers + cleanup-all) forever,
+        # the exact incident this loop exists to prevent. The WARN + the
+        # maintenance_compact_tables_failed gauge carry the alert; genuinely
+        # systemic failures still fail the run elsewhere (a dead catalog
+        # fails the candidate query above; dead object storage fails
+        # cleanup-all right after).
         log.warning(
             "compact tier-%d: %d/%d table(s) failed: %s",
             tier,
@@ -2157,20 +2206,6 @@ def compact(
             table_total,
             ", ".join(failed),
         )
-        if table_total >= 2 and len(failed) == table_total:
-            # Every table failed — that's systemic (catalog down, bad creds,
-            # broken extension), not one poisoned table. Surface as a run
-            # failure so the Job/backoff machinery reacts. A PARTIAL failure
-            # exits 0 on purpose: the just-recipe chain must proceed to the
-            # later tiers and cleanup-all (deletion-queue drain) for the
-            # healthy tables instead of wedging the whole schedule on one
-            # broken table. A SINGLE-table catalog is exempt for the same
-            # reason — 1/1 failed would re-wedge cleanup forever; the
-            # maintenance_compact_tables_failed gauge carries the alert
-            # instead. (Best-effort heuristic: a systemic failure where one
-            # trivially-empty table "succeeds" also lands on the gauge, not
-            # the raise.)
-            raise RuntimeError(f"compact tier-{tier}: all {table_total} table(s) failed")
     return len(failed)
 
 

--- a/tools/ducklake_maintenance.py
+++ b/tools/ducklake_maintenance.py
@@ -1888,18 +1888,45 @@ def _start_heartbeat(conn: duckdb.DuckDBPyConnection, label: str, interval_s: fl
     return stop
 
 
-def _enumerate_compaction_tables(conn: duckdb.DuckDBPyConnection) -> list[tuple[str, str]]:
-    """Live BASE TABLEs in the attached lake as (schema, table_name) pairs.
+def _enumerate_compaction_tables(
+    conn: duckdb.DuckDBPyConnection, min_b: int | None, max_b: int
+) -> list[tuple[str, str]]:
+    """Tables with >= 2 live files in the tier's size band, biggest backlog first.
+
+    Candidate-driven (from ducklake_data_file), NOT information_schema: a
+    catalog can carry thousands of live tables (dlt/Fivetran staging) with
+    zero tier candidates — enumerating all of them costs a bind-time
+    candidate scan per table per tier against a PG catalog with a history
+    of read-tax problems, and alphabetical order let trivially-small
+    early-alphabet tables (2-file cosmetic merges) eat the global file
+    budget every run while the real backlog starved. Observed in prod:
+    3,074 live tables, the budget exhausted on five 2-file billing tables,
+    and the 15k-candidate events table never reached. Candidate-count DESC
+    serves the most backlogged table first; ties break by name for
+    determinism. Single-candidate tables can't merge and are excluded.
 
     Catalog-derived names are ordinary-DDL-controlled and get interpolated
     into the per-table CALL statements below, so anything outside the
     conservative identifier shape is skipped LOUDLY rather than quoted
     heroically (same defense as repair-partition-values discovery).
     """
+    where = [
+        "df.end_snapshot IS NULL",
+        "t.end_snapshot IS NULL",
+        "sch.end_snapshot IS NULL",
+        f"df.file_size_bytes < {max_b}",
+    ]
+    if min_b is not None:
+        where.append(f"df.file_size_bytes >= {min_b}")
     rows = conn.execute(
-        "SELECT table_schema, table_name FROM information_schema.tables "
-        f"WHERE table_catalog = '{ATTACH_NAME}' AND table_type = 'BASE TABLE' "
-        "ORDER BY table_schema, table_name"
+        "SELECT sch.schema_name, t.table_name "
+        f"FROM {METADATA_SCHEMA}.ducklake_data_file df "
+        f"JOIN {METADATA_SCHEMA}.ducklake_table t USING (table_id) "
+        f"JOIN {METADATA_SCHEMA}.ducklake_schema sch ON sch.schema_id = t.schema_id "
+        f"WHERE {' AND '.join(where)} "
+        "GROUP BY sch.schema_name, t.table_name "
+        "HAVING COUNT(*) >= 2 "
+        "ORDER BY COUNT(*) DESC, sch.schema_name, t.table_name"
     ).fetchall()
     tables: list[tuple[str, str]] = []
     for schema_name, table_name in rows:
@@ -2023,15 +2050,20 @@ def compact(
         # failure: every healthy table still compacts and the broken one is
         # reported. Mirrors the battle-tested standalone posthog maintenance
         # script, which loops tables for exactly this reason.
-        tables = _enumerate_compaction_tables(conn)
+        tables = _enumerate_compaction_tables(conn, min_b, max_b)
         table_total = len(tables)
-        log.info("compact tier-%d: %d live table(s), per-table merge", tier, table_total)
+        log.info(
+            "compact tier-%d: %d table(s) with >= 2 tier candidates, biggest backlog first",
+            tier,
+            table_total,
+        )
         if not tables and candidate_count > 0:
-            # Candidates exist but no table passed the identifier gate — the
-            # per-table WARNs above explain which; escalate so this can't be
-            # a silent perpetual no-op.
-            log.warning(
-                "compact tier-%d: %d candidate file(s) but no compactable tables — check skipped-name warnings",
+            # Candidates exist but no table qualified: every candidate is a
+            # per-table singleton (nothing to merge with — benign), or the
+            # holders were skipped by the identifier gate (per-table WARNs
+            # above say which). INFO, not a failure.
+            log.info(
+                "compact tier-%d: %d candidate file(s) but no table has >= 2 — nothing mergeable this run",
                 tier,
                 candidate_count,
             )


### PR DESCRIPTION
## Problem

The per-table compaction loop (#105) enumerates **all live BASE TABLEs from information_schema, alphabetically**. First production run on a warehouse catalog exposed both follow-ups the #105 reviews flagged, at once:

```
compact tier-1: 15896 candidates … 3074 live table(s), per-table merge
compact tier-1: file budget exhausted; remaining tables wait for the next run
compact tier-1: 5 groups total, 10 files → 5 output files   ← five billing_* tables, 2 files each
```

- **Deterministic starvation**: `billing_*` sorts before `posthog.*`, so five 2-file cosmetic merges ate the whole global budget every tick and the 15k-candidate `events` table would never be reached.
- **Wasted work**: ~3,000 zero-candidate tables each cost a bind-time candidate scan per tier per run against a PG catalog with a known read-tax history.

## Changes (commit 1: candidate-driven enumeration)

Enumerate from the tier's **actual candidates**: `ducklake_data_file` filtered to the tier's size band, grouped per table, `HAVING COUNT(*) >= 2` (a singleton has nothing to merge with), `ORDER BY COUNT(*) DESC` — most backlogged table first, ties by name for determinism.

## Changes (commit 2: adversarial-review findings applied)

Two independent reviews (QE + SWE lens) on commit 1 surfaced three substantive issues, fixed here:

1. **Poison-set attractor (QE-HIGH):** with candidate-driven enumeration, healthy tables drain *out* of the table list once compacted while poisoned tables never do — `failed == table_total` is the steady state under any persistent poison, so #105's all-failed `RuntimeError` would wedge the recipe chain (later tiers + `cleanup-all`) every tick, forever. **Per-table failures now never raise.** The WARN + `maintenance_compact_tables_failed{tier}` gauge carry the alert; genuinely systemic failures still fail the run elsewhere (dead catalog fails the candidate query; dead object storage fails `cleanup-all` immediately after). Alert on sustained nonzero gauge.
2. **Whale monopoly (QE-HIGH/SWE-MED):** backlog-DESC + whole-remaining-budget grants re-created starvation in mirror image (an ingest-outpaces-drain table would consume every run forever). Multi-table runs now cap each table's grant at **half the budget**; single-table runs keep the full budget. Biggest backlog gets the biggest cut, never the whole pie.
3. **Rank inflation by unmergeable files (QE-MED/SWE-MED):** `merge_adjacent` skips files with live delete files, so counting them let an unmergeable whale rank first and no-op at the top of every run. Enumeration now **anti-joins live `ducklake_delete_file`**, mirroring the compactor's own selection. Zero-group CALLs (per-partition singletons / non-contiguous row-ids) are counted and logged per run.

Plus: fixed an `UnboundLocalError` on the single-table path (`noop_tables` init), and the all-singletons "candidates but nothing mergeable" case logs INFO (benign), with per-table identifier-gate WARNs unchanged.

## Validation

Authored with an AI assistant; checks actually run:
- `ruff check` + `format` clean; **561 unit tests pass**. New/updated pins: enumeration SQL (band, ≥2 threshold, `ORDER BY COUNT(*) DESC`, `end_snapshot IS NULL` on all four relations — dropping the table one silently enumerates renamed tables under stale names; delete-file anti-join; no information_schema), grant cap both ways (5/5 on a 10-budget pair; full 10 single-table), all-failed never raises (2/2 → return 2 + WARN), all-singletons INFO path, dry-run still skips enumeration.
- **3 real-extension integration tests pass**, including two new behavioral pins: all-poisoned does **not** wedge (real hive-path error on both tables, no raise, files untouched), and **biggest-backlog-first proven through the loop** — alphabetically-first 2-file table vs alphabetically-last 6-file table with budget 6: big one merges, small one untouched.

## Notes

- Budget semantics: global across the run, decremented by input files consumed (conservative vs the extension's group-based cap — unchanged from #105).
- Deferred: fusing the candidate-count and enumeration scans into one (they can disagree on dropped-table files; cosmetic), budget-unit alignment.