### PR TITLE
docker: ship postgresql-client for the bootstrap-index recipes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,10 @@ RUN test -n "$TARGETARCH" \
 
 FROM python:3.12-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends just=1.40.0* && rm -rf /var/lib/apt/lists/*
+# postgresql-client: the justfile's bootstrap-index-* recipes shell out to
+# psql for CREATE INDEX CONCURRENTLY (cannot run inside a transaction, so
+# the python/duckdb connection path is not a substitute).
+RUN apt-get update && apt-get install -y --no-install-recommends just=1.40.0* postgresql-client && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/.venv /app/.venv
 COPY --from=builder /app/millpond /app/millpond

--- a/tools/justfile
+++ b/tools/justfile
@@ -302,6 +302,23 @@ compact-to-tier-3-dry-run table="":
 [group('compaction')]
 compact-all-tiers table="": (compact-to-tier-1 table) (compact-to-tier-2 table) (compact-to-tier-3 table)
 
+# Chain-safe no-arg wrappers for the tenant maintenance CronJob. In a
+# multi-recipe invocation (`just a b c`) a recipe with a positional param
+# EATS the next recipe name as its argument — `just compact-all-tiers
+# expire ...` runs compaction against table="expire". These wrappers pin
+# the defaults so the composition-stamped cron can run one flat chain:
+#   just -f /justfile bootstrap-indexes compact-all-tiers-default \
+#     expire-7d purge-orphan-stats cleanup-all
+# The SEQUENCE deliberately lives in the cron definition (crossplane
+# composition), not an umbrella recipe here — changing the steps must not
+# require a millpond release.
+
+# compact-all-tiers with the default (all tables), chain-safe
+compact-all-tiers-default: (compact-all-tiers)
+
+# snapshot expiry at the 7-day fleet default, chain-safe
+expire-7d: (expire "7")
+
 # Run all tiered compactions sequentially (tier 1 -> 2 -> 3) then delete scheduled S3 files
 [group('compaction')]
 compact-all-tiers-and-clean table="": (compact-to-tier-1 table) (compact-to-tier-2 table) (compact-to-tier-3 table) cleanup-all


### PR DESCRIPTION
The justfile's `bootstrap-index-*` recipes shell out to `psql` for `CREATE INDEX CONCURRENTLY` (can't run inside a transaction, so the python/duckdb connection path is not a substitute). The runtime image never carried psql — the central viaduck crons never ran these recipes, so it went unnoticed until the composition-stamped tenant maintenance cron (charts #13458) put `bootstrap-indexes` first in its chain: every run dies at `psql: not found` (exit 127) before any compaction happens. Observed live on team-2's first `*/15` run.

After merge this needs a release + the charts `compactionImage.tag` bump to unblock the tenant crons.