### PR TITLE
docker: pre-install the duckdb aws extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,10 @@ USER millpond
 # returns 404). The DuckDB Python pin (1.5.2 in pyproject.toml) locks the
 # DuckLake major line, and tests/unit/test_ducklake_pin.py asserts the loaded
 # extension's build SHA at runtime so a drift trips in CI rather than in prod.
-RUN python -c "import duckdb; c = duckdb.connect(); c.execute('INSTALL httpfs'); c.execute('INSTALL ducklake'); c.execute('INSTALL postgres')"
+# aws: required by CREATE SECRET (TYPE s3, PROVIDER credential_chain) — the
+# Pod-Identity path the tenant maintenance crons use. Without it DuckDB
+# auto-installs at runtime, which dies on a read-only root filesystem.
+RUN python -c "import duckdb; c = duckdb.connect(); c.execute('INSTALL httpfs'); c.execute('INSTALL ducklake'); c.execute('INSTALL postgres'); c.execute('INSTALL aws')"
 
 # Build-time smoke test for the duckdb CLI as the runtime user. Catches any
 # regression where the CLI is installed somewhere the `millpond` user can't


### PR DESCRIPTION
`CREATE SECRET (TYPE s3, PROVIDER credential_chain)` — the Pod-Identity path the composition-stamped tenant maintenance crons use — requires DuckDB's `aws` extension. It was never in the build-time pre-install set (httpfs/ducklake/postgres), so DuckDB attempts a runtime auto-install, which dies on the crons' read-only root filesystem:

```
Cannot open file ".../.duckdb/extensions/v1.5.2/linux_arm64/aws...": Read-only file system
```

The central viaduck crons never exercised this path — they authenticate with static env credentials, which need no aws extension. Same first-time-exercised class as the psql gap (#110): observed live on the first tenant cron run to get past `bootstrap-indexes` (psql now works fleet-wide, so #110 is confirmed in prod).

With the image now floating on `:prod` (charts #13475), a release after merge reaches every tenant cron on its next tick — no chart change.