### PR TITLE
metrics: one-shot push mode for the per-tenant metrics CronJob

### DIFF
--- a/tests/unit/test_ducklake_metrics.py
+++ b/tests/unit/test_ducklake_metrics.py
@@ -854,3 +854,110 @@ class TestSchedulerStartsLiveness:
 # Drives the handler against an actual ThreadingHTTPServer with a tiny timeout,
 # so the wiring of _liveness_status → status code → counter → log is exercised
 # end-to-end. The unit tests above stay focused on the pure decision function.
+
+
+# ---------------------------------------------------------------------------
+# --once mode: _run_once / _push_metrics against a real local HTTP sink
+# ---------------------------------------------------------------------------
+
+
+class _CaptureSink:
+    """Local HTTP server standing in for the VictoriaMetrics import
+    endpoint: captures POST bodies, answers a configurable status."""
+
+    def __init__(self, status: int = 204):
+        from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+        sink = self
+
+        class H(BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802 - stdlib signature
+                length = int(self.headers.get("Content-Length", "0"))
+                sink.bodies.append(self.rfile.read(length))
+                sink.content_types.append(self.headers.get("Content-Type", ""))
+                self.send_response(sink.status)
+                self.end_headers()
+
+            def log_message(self, *args):  # noqa: A002
+                pass
+
+        self.status = status
+        self.bodies: list[bytes] = []
+        self.content_types: list[str] = []
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.srv.server_address[1]}/api/v1/import/prometheus"
+
+    def close(self):
+        self.srv.shutdown()
+        self.srv.server_close()
+
+
+def _once_query(name="t_once", sql="SELECT 7 AS n"):
+    return dm.Query(name=name, help="t", sql=sql, interval_seconds=60, labels=[], values=["n"])
+
+
+class TestRunOnce:
+    def test_success_pushes_only_tenant_scoped_metrics(self, conn, monkeypatch):
+        monkeypatch.setattr(dm, "_connect_once", lambda _ml: conn)
+        sink = _CaptureSink()
+        try:
+            rc = dm._run_once([_once_query()], TENANT, sink.url, None)
+        finally:
+            sink.close()
+        assert rc == 0
+        assert len(sink.bodies) == 1
+        body = sink.bodies[0].decode()
+        assert 't_once_n{tenant="test"} 7.0' in body
+        assert 'ducklake_metrics_up{tenant="test"} 1.0' in body
+        # Dedicated registry: the untenanted default-registry collectors
+        # must never reach the shared import endpoint.
+        assert "python_info" not in body
+        assert "process_" not in body
+        assert sink.content_types[0].startswith("text/plain")
+
+    def test_all_queries_failing_exits_nonzero_without_push(self, conn, monkeypatch):
+        monkeypatch.setattr(dm, "_connect_once", lambda _ml: conn)
+        sink = _CaptureSink()
+        try:
+            rc = dm._run_once([_once_query(sql="SELECT n FROM missing_table")], TENANT, sink.url, None)
+        finally:
+            sink.close()
+        assert rc == 1
+        assert sink.bodies == []
+
+    def test_partial_failure_still_pushes_with_error_counter(self, conn, monkeypatch):
+        monkeypatch.setattr(dm, "_connect_once", lambda _ml: conn)
+        sink = _CaptureSink()
+        try:
+            rc = dm._run_once(
+                [_once_query(), _once_query(name="t_bad", sql="SELECT n FROM missing_table")],
+                TENANT,
+                sink.url,
+                None,
+            )
+        finally:
+            sink.close()
+        assert rc == 0
+        body = sink.bodies[0].decode()
+        assert 't_once_n{tenant="test"} 7.0' in body
+        assert 'ducklake_metrics_query_errors_total{query="t_bad",tenant="test"} 1.0' in body
+
+    def test_push_failure_exits_nonzero(self, conn, monkeypatch):
+        monkeypatch.setattr(dm, "_connect_once", lambda _ml: conn)
+        sink = _CaptureSink(status=500)
+        try:
+            rc = dm._run_once([_once_query()], TENANT, sink.url, None)
+        finally:
+            sink.close()
+        assert rc == 1
+
+    def test_connect_failure_exits_nonzero(self, monkeypatch):
+        def boom(_ml):
+            raise RuntimeError("no catalog")
+
+        monkeypatch.setattr(dm, "_connect_once", boom)
+        assert dm._run_once([_once_query()], TENANT, "http://127.0.0.1:1/nope", None) == 1

--- a/tests/unit/test_ducklake_metrics.py
+++ b/tests/unit/test_ducklake_metrics.py
@@ -961,3 +961,9 @@ class TestRunOnce:
 
         monkeypatch.setattr(dm, "_connect_once", boom)
         assert dm._run_once([_once_query()], TENANT, "http://127.0.0.1:1/nope", None) == 1
+
+    def test_non_http_push_url_rejected(self, conn, monkeypatch):
+        # file:// (or any non-http scheme) must fail loudly, never touch
+        # the filesystem — the semgrep dynamic-urllib hardening.
+        monkeypatch.setattr(dm, "_connect_once", lambda _ml: conn)
+        assert dm._run_once([_once_query()], TENANT, "file:///etc/passwd", None) == 1

--- a/tools/ducklake_metrics.py
+++ b/tools/ducklake_metrics.py
@@ -53,6 +53,7 @@ import sys
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -829,7 +830,16 @@ def _push_metrics(url: str, registry: CollectorRegistry) -> None:
     Plain exposition text over HTTP — the payload is byte-identical to what
     a scrape of the daemon would have produced, which is what keeps every
     existing dashboard selector working. urllib raises on >=400; VM answers
-    204 on success."""
+    204 on success.
+
+    Scheme is validated to http(s) before opening: urllib also accepts
+    file:// (the semgrep dynamic-urllib finding), and a misconfigured
+    push URL must fail loudly rather than "succeed" against the local
+    filesystem. The URL itself is operator-supplied deploy config (helm
+    value → env), never request data."""
+    scheme = urllib.parse.urlsplit(url).scheme
+    if scheme not in ("http", "https"):
+        raise ValueError(f"push-url must be http(s), got scheme {scheme!r}")
     body = generate_latest(registry)
     req = urllib.request.Request(
         url,
@@ -837,7 +847,8 @@ def _push_metrics(url: str, registry: CollectorRegistry) -> None:
         method="POST",
         headers={"Content-Type": CONTENT_TYPE_LATEST},
     )
-    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 - operator-supplied cluster URL
+    # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 - scheme-validated operator config
         log.info("Pushed %d bytes to %s (HTTP %d)", len(body), url, resp.status)
 
 

--- a/tools/ducklake_metrics.py
+++ b/tools/ducklake_metrics.py
@@ -1,7 +1,18 @@
 #!/usr/bin/env python3
-"""DuckLake state-metrics daemon.
+"""DuckLake state-metrics daemon / one-shot exporter.
 
-Long-running process that periodically runs a fixed set of catalog-side
+Two modes over the same query set:
+
+- Daemon (default): long-running scheduler + /metrics HTTP server, one
+  process per tenant (the legacy deployment model).
+- ``--once``: run every query once and POST the exposition payload to a
+  Prometheus-import endpoint (``--push-url``, e.g. VictoriaMetrics
+  vmagent ``/api/v1/import/prometheus``) — the per-tenant metrics
+  CronJob's mode, mirroring the maintenance cron's scoped-lifecycle
+  model. Metric names and the ``tenant`` label are identical across
+  modes, so dashboards don't care which produced the samples.
+
+Periodically (or once) runs a fixed set of catalog-side
 queries against a DuckLake and exposes the results as Prometheus gauges.
 Built-in queries cover lake-shape signals (size-band distribution,
 compaction-tier candidate counts, pending-deletion queue depth, snapshot
@@ -41,6 +52,8 @@ import signal
 import sys
 import threading
 import time
+import urllib.error
+import urllib.request
 from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
@@ -792,6 +805,93 @@ def _connect_with_backoff(
     return None
 
 
+def _connect_once(memory_limit: str | None) -> duckdb.DuckDBPyConnection:
+    """Single connect attempt for --once mode: no backoff — the CronJob's
+    next tick IS the retry, and a loud fast failure is the signal we want
+    (kube_job_status_failed is the alert surface, same as the maintenance
+    cron)."""
+    if memory_limit is not None:
+        ducklake_maintenance._sanitize_setting_value(memory_limit)
+    conn = ducklake_maintenance.connect()
+    if memory_limit is not None:
+        conn.execute(f"SET memory_limit = '{memory_limit}'")
+    log.info(
+        "Connected to DuckLake catalog (memory_limit=%s)",
+        memory_limit if memory_limit is not None else "DuckDB default",
+    )
+    return conn
+
+
+def _push_metrics(url: str, registry: CollectorRegistry) -> None:
+    """POST the registry in exposition format to a Prometheus-import
+    endpoint (VictoriaMetrics vmagent/vminsert `/api/v1/import/prometheus`).
+
+    Plain exposition text over HTTP — the payload is byte-identical to what
+    a scrape of the daemon would have produced, which is what keeps every
+    existing dashboard selector working. urllib raises on >=400; VM answers
+    204 on success."""
+    body = generate_latest(registry)
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={"Content-Type": CONTENT_TYPE_LATEST},
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 - operator-supplied cluster URL
+        log.info("Pushed %d bytes to %s (HTTP %d)", len(body), url, resp.status)
+
+
+def _run_once(
+    queries: list[Query],
+    tenant: str,
+    push_url: str,
+    memory_limit: str | None,
+) -> int:
+    """One-shot mode: connect, run every query once, push, exit.
+
+    Per-query failures do NOT fail the run — they are themselves pushed
+    (ducklake_metrics_query_errors_total) and therefore visible where the
+    dashboards already look. The run exits nonzero only when nothing useful
+    could be produced or delivered: connect failure, zero successful
+    queries, or push failure.
+
+    A DEDICATED registry, never the global default: the default registry
+    carries the untenanted python_*/process_* collectors, and pushing
+    those through an import endpoint (no scrape instance label) would make
+    every tenant's job fight over the same series. The push must contain
+    exactly the tenant-labeled metrics and nothing else.
+    """
+    registry = CollectorRegistry()
+    self_metrics = _build_self_metrics(registry)
+    gauges = _build_query_gauges(queries, registry)
+
+    try:
+        conn = _connect_once(memory_limit)
+    except Exception:
+        log.exception("connect to DuckLake failed")
+        return 1
+    try:
+        self_metrics.up.labels(tenant).set(1)
+        succeeded = 0
+        for q in queries:
+            if _run_query(conn, q, gauges[q.name], self_metrics, tenant):
+                succeeded += 1
+        log.info("Ran %d/%d queries successfully", succeeded, len(queries))
+    finally:
+        with contextlib.suppress(Exception):
+            conn.close()
+
+    if succeeded == 0:
+        log.error("no query succeeded; not pushing a metrics payload of pure errors")
+        return 1
+    try:
+        _push_metrics(push_url, registry)
+    except Exception:
+        log.exception("metrics push failed")
+        return 1
+    return 0
+
+
 def _setup_logging() -> None:
     logging.basicConfig(
         level=os.environ.get("LOG_LEVEL", "INFO").upper(),
@@ -860,6 +960,26 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print resolved query list and exit (validates config without connecting)",
     )
+    p.add_argument(
+        "--once",
+        action="store_true",
+        help=(
+            "One-shot mode for the per-tenant metrics CronJob: connect, run "
+            "every query once, POST the exposition-format payload to "
+            "--push-url, exit. No HTTP server, no scheduler, no backoff — "
+            "the cron's next tick is the retry and a failed Job is the "
+            "alert surface. Requires --push-url."
+        ),
+    )
+    p.add_argument(
+        "--push-url",
+        default=os.environ.get("DUCKLAKE_METRICS_PUSH_URL"),
+        help=(
+            "Prometheus-import endpoint for --once mode, e.g. a "
+            "VictoriaMetrics vmagent's /api/v1/import/prometheus. Falls "
+            "back to DUCKLAKE_METRICS_PUSH_URL env."
+        ),
+    )
     return p
 
 
@@ -883,6 +1003,11 @@ def main(argv: list[str] | None = None) -> None:
         )
     tenant: str = args.tenant
     log.info("Tenant: %s", tenant)
+
+    if args.once:
+        if not args.push_url:
+            sys.exit("--once requires --push-url (or DUCKLAKE_METRICS_PUSH_URL env)")
+        sys.exit(_run_once(queries, tenant, args.push_url, args.duckdb_memory_limit))
 
     self_metrics = _build_self_metrics()
     gauges = _build_query_gauges(queries)

--- a/tools/justfile
+++ b/tools/justfile
@@ -448,3 +448,12 @@ ducklake-metrics-with-config config port="9100":
 [group('metrics')]
 ducklake-metrics-list config="":
     env {{ _target_env }} python {{ ducklake_metrics }} --list-queries {{ if config != "" { "--config " + quote(config) } else { "" } }}
+
+# One-shot: run every query once and push exposition to
+# $DUCKLAKE_METRICS_PUSH_URL (VictoriaMetrics import endpoint).
+# Chain-safe (no positional params) — the per-tenant metrics CronJob's
+# recipe; tenant identity via $DUCKLAKE_TENANT, catalog target via the
+# same _target_env contract the maintenance recipes use.
+[group('metrics')]
+metrics-once:
+    env {{ _target_env }} python {{ ducklake_metrics }} --once


### PR DESCRIPTION
## Why

Per-tenant metrics move to the same scoped-lifecycle model as the maintenance crons: a composition-stamped CronJob per Duckling (charts PR follows), replacing the central ducklake-metrics-daemon. A batch job can't be scraped — nothing is running when the scraper comes — so it pushes its samples to the pipeline on the way out.

## What

- `--once` / `--push-url` on `ducklake_metrics.py`: connect once (no backoff — the cron's next tick is the retry), run the existing query set once, POST the exposition payload to a Prometheus-import endpoint (vmagent `/api/v1/import/prometheus`), exit. Metric names and the `tenant` label are byte-identical to the daemon's — existing dashboard selectors keep working.
- **Dedicated registry** for the push: the default registry's untenanted `python_*`/`process_*` collectors would collide across every tenant's job at the import endpoint (no scrape instance label). Pinned by test.
- Failure semantics: per-query failures are pushed (`query_errors_total`) and don't fail the run; exit is nonzero only for connect failure, zero successful queries, or push failure — `kube_job_status_failed` is the alert surface, same as the maintenance crons.
- `metrics-once` chain-safe justfile recipe; same `_target_env` contract as the maintenance recipes; tenant identity via `$DUCKLAKE_TENANT`.
- Bonus: the 30-second job lifetime structurally sidesteps the daemon's documented Pod-Identity STS-expiry wart.

## How did you test this code?

Authored by an agent; checks actually run: 5 new tests drive the real flow against a live local HTTP sink (success payload + tenant label + no default-registry pollution, all-fail no-push nonzero, partial-failure push with error counter, HTTP 500, connect failure); full unit suite 623 passed; ruff check + format clean; `just --list` resolves the new recipe.