### PR TITLE
metrics: per-value filter match counter

### DIFF
--- a/millpond/main.py
+++ b/millpond/main.py
@@ -160,6 +160,12 @@ def _apply_filter(table: pa.Table, cfg: config.Config, values: tuple[int, ...] |
         metrics.records_skipped_total.labels(reason="filter_field_missing").inc(null_count)
     if n_excluded > 0:
         metrics.records_skipped_total.labels(reason="filter_excluded").inc(n_excluded)
+    if len(filtered) > 0:
+        # Per-value match counts on the KEPT rows only (bounded by the
+        # include set). value_counts on the filtered column is one pass
+        # over the minority the filter retained.
+        for chunk in pc.value_counts(filtered[field]).to_pylist():
+            metrics.filter_matched_total.labels(value=str(chunk["values"])).inc(chunk["counts"])
     return filtered
 
 

--- a/millpond/metrics.py
+++ b/millpond/metrics.py
@@ -35,6 +35,12 @@ _records_skipped_total = Counter(
     "Records skipped",
     ["pipeline", "broker_source", "reason"],
 )
+_filter_matched_total = Counter(
+    "millpond_filter_matched_total",
+    "Records kept by the include filter, by matched filter value (team id). "
+    "Cardinality is bounded by the include set (static pins + CP discovery).",
+    ["pipeline", "broker_source", "value"],
+)
 _errors_total = Counter(
     "millpond_errors_total",
     "Errors by type",
@@ -213,6 +219,7 @@ records_consumed_total = _records_consumed_total
 records_written_total = _records_written_total
 batches_flushed_total = _batches_flushed_total
 records_skipped_total = _records_skipped_total
+filter_matched_total = _filter_matched_total
 errors_total = _errors_total
 flush_duration_seconds = _flush_duration_seconds
 arrow_conversion_seconds = _arrow_conversion_seconds
@@ -257,6 +264,7 @@ def init(pipeline: str, broker_source: str = ""):
     global include_values_size, include_values_last_success_timestamp_seconds
     global include_values_pending_removals, include_values_poll_failures_total
     global include_values_refused_total, include_values_changes_total, include_values_mode
+    global filter_matched_total
     global include_values_shadow_only_static, include_values_shadow_only_remote
     global include_values_pinned, include_values_pinned_only
     global rdkafka_replyq, rdkafka_msg_cnt, rdkafka_msg_size
@@ -268,6 +276,7 @@ def init(pipeline: str, broker_source: str = ""):
     records_consumed_total = _AutoCommonLabels(_records_consumed_total, pipeline, bs)
     batches_flushed_total = _AutoCommonLabels(_batches_flushed_total, pipeline, bs)
     records_skipped_total = _AutoCommonLabels(_records_skipped_total, pipeline, bs)
+    filter_matched_total = _AutoCommonLabels(_filter_matched_total, pipeline, bs)
     sort_skipped_total = _AutoCommonLabels(_sort_skipped_total, pipeline, bs)
     columns_coerced_total = _AutoCommonLabels(_columns_coerced_total, pipeline, bs)
     include_values_changes_total = _AutoCommonLabels(_include_values_changes_total, pipeline, bs)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -369,6 +369,37 @@ class TestApplyFilter:
         assert skip_calls == [("filter_excluded", 1)]
 
     @patch("millpond.main.metrics")
+    def test_matched_counts_per_value(self, mock_metrics):
+        # filter_matched_total gets one increment per DISTINCT kept value
+        # with the per-value row count — the stacked-proportion panel's
+        # data. Excluded values must not appear.
+        from millpond.main import _apply_filter
+
+        match_calls: list[tuple[str, int]] = []
+
+        def _counter_for(value):
+            counter = MagicMock()
+            counter.inc.side_effect = lambda n, v=value: match_calls.append((v, n))
+            return counter
+
+        mock_metrics.filter_matched_total.labels.side_effect = _counter_for
+        table = pa.table({"team_id": [2, 2, 2, 47074, 47074, 999]})
+        result = _apply_filter(table, self._cfg(keep="team_id"), (2, 47074))
+
+        assert result.num_rows == 5
+        assert sorted(match_calls) == [("2", 3), ("47074", 2)]
+
+    @patch("millpond.main.metrics")
+    def test_matched_counts_skipped_on_empty_result(self, mock_metrics):
+        # Nothing kept -> no filter_matched_total activity at all.
+        from millpond.main import _apply_filter
+
+        table = pa.table({"team_id": [7, 8, 9]})
+        result = _apply_filter(table, self._cfg(keep="team_id"), (2,))
+        assert result.num_rows == 0
+        mock_metrics.filter_matched_total.labels.assert_not_called()
+
+    @patch("millpond.main.metrics")
     def test_int_values_coerce_to_string_column(self, mock_metrics):
         # When the column is string-typed and values parsed as int, the
         # values get cast to their canonical string form ("2") and matched


### PR DESCRIPTION
Adds `millpond_filter_matched_total{pipeline, broker_source, value}`: records kept by the include filter, per matched filter value (team id). This is the data source for the new share-of-NRT-ingest dashboard panel — relevant now that the include set spans tenants of very different sizes (the Lovable load-test pin, charts#13604, being the immediate case).

- One `value_counts` pass over only the **kept** rows (the filtered minority), per batch.
- Cardinality bounded by the include set (static pins + CP discovery list).
- Wired through the `_AutoCommonLabels` binding like the other reason-labeled counters.

Tests pin the per-value (value, count) pairing and that an empty filter result produces no metric activity; full unit suite 626 passed, ruff clean.