### PR TITLE
feat: implement drop-direction record filter (denylist)

### DIFF
--- a/millpond/config.py
+++ b/millpond/config.py
@@ -62,20 +62,25 @@ class Config:
     # Broker source label for metrics (e.g. "msk", "warpstream")
     broker_source: str
 
-    # Optional record filter. Exactly one of `filter_keep_field` /
-    # `filter_drop_field` may be set; whichever is set names the column to
-    # check against `filter_values`. Keep = allowlist (keep records whose
-    # value is in filter_values, drop the rest). Drop = denylist (drop
-    # records whose value is in filter_values, keep the rest). Only the
-    # keep direction is implemented today; the drop slot reserves the
-    # namespace and the mutual-exclusion contract for a future add.
-    # `filter_values` is parsed at load time and is homogeneous — either a
-    # tuple of ints (if all comma-separated tokens parsed as int) or a tuple
-    # of strings (otherwise). main.py applies this after JSON→Arrow but
-    # before the pending buffer.
+    # Optional record filters. Keep = allowlist (keep records whose value
+    # in `filter_keep_field` is in `filter_values`, drop the rest). Drop =
+    # denylist (drop records whose value in `filter_drop_field` is in
+    # `filter_drop_values`, keep the rest). The directions COMPOSE: keep
+    # runs first, drop refines the survivors — that's the point (the keep
+    # side may be the CP-driven dynamic include set, while drop is a
+    # static operator blacklist, e.g. muting one tenant's firehose share
+    # during an incident). Each direction has its own values var so they
+    # never share a list. Values are parsed at load time and homogeneous —
+    # tuple of ints (if every comma-separated token parses as int) or of
+    # strings (otherwise). main.py applies both after JSON→Arrow but
+    # before the pending buffer. Failure semantics differ by direction
+    # (see main.py): an unevaluable ALLOWLIST drops the batch (fail
+    # closed); an unevaluable DENYLIST keeps it (fail open — a blacklist
+    # that can't evaluate must not turn schema drift into data loss).
     filter_keep_field: str | None
     filter_drop_field: str | None
     filter_values: tuple[int, ...] | tuple[str, ...] | None
+    filter_drop_values: tuple[int, ...] | tuple[str, ...] | None
 
     # Optional dynamic source for the keep-filter's include set (see
     # include_values.py). URL unset = today's static behavior. Mode
@@ -181,52 +186,56 @@ def _parse_filter_values(raw: str) -> tuple[int, ...] | tuple[str, ...]:
     """
     tokens = tuple(t.strip() for t in raw.split(",") if t.strip())
     if not tokens:
-        raise RuntimeError("MILLPOND_FILTER_VALUES must contain at least one value")
+        # Both directions parse through here; name both vars so a 3am
+        # operator debugging the drop side isn't misdirected to the keep var.
+        raise RuntimeError("MILLPOND_FILTER_VALUES / MILLPOND_FILTER_DROP_VALUES must contain at least one value")
     try:
         return tuple(int(t) for t in tokens)
     except ValueError:
         return tokens
 
 
-def _load_filter_fields() -> tuple[str | None, str | None, tuple[int, ...] | tuple[str, ...] | None]:
-    """Read MILLPOND_FILTER_{KEEP,DROP}_FIELD_NAME + MILLPOND_FILTER_VALUES.
+def _load_filter_fields() -> tuple[
+    str | None,
+    str | None,
+    tuple[int, ...] | tuple[str, ...] | None,
+    tuple[int, ...] | tuple[str, ...] | None,
+]:
+    """Read MILLPOND_FILTER_{KEEP,DROP}_FIELD_NAME + their values vars.
 
-    At most one of keep/drop may be set. If either is set, FILTER_VALUES is
-    required. Field names must be safe identifiers so misconfigurations
-    surface at startup rather than under load. Drop is reserved for a
-    future change — config rejects it explicitly with a clear message
-    rather than silently accepting and doing nothing.
+    Keep pairs with MILLPOND_FILTER_VALUES (unchanged contract); drop
+    pairs with MILLPOND_FILTER_DROP_VALUES. The directions may be set
+    together (keep ∩ ¬drop) or alone; each field-with-values pairing is
+    enforced so a half-configured filter surfaces at startup rather than
+    silently passing everything. Field names must be safe identifiers.
+
+    Note: the original drop reservation shared MILLPOND_FILTER_VALUES.
+    Implemented drop uses its OWN values var instead — sharing one list
+    between an allowlist and a denylist would make the composed case
+    (CP-driven keep + operator blacklist) unexpressible.
     """
     keep = os.environ.get("MILLPOND_FILTER_KEEP_FIELD_NAME", "").strip() or None
     drop = os.environ.get("MILLPOND_FILTER_DROP_FIELD_NAME", "").strip() or None
     values_raw = os.environ.get("MILLPOND_FILTER_VALUES", "").strip()
+    drop_values_raw = os.environ.get("MILLPOND_FILTER_DROP_VALUES", "").strip()
 
-    if keep and drop:
-        raise RuntimeError("MILLPOND_FILTER_KEEP_FIELD_NAME and MILLPOND_FILTER_DROP_FIELD_NAME are mutually exclusive")
+    if bool(keep) != bool(values_raw):
+        raise RuntimeError("MILLPOND_FILTER_VALUES must be set together with MILLPOND_FILTER_KEEP_FIELD_NAME")
+    if bool(drop) != bool(drop_values_raw):
+        raise RuntimeError("MILLPOND_FILTER_DROP_VALUES must be set together with MILLPOND_FILTER_DROP_FIELD_NAME")
 
-    active = keep or drop
-    if bool(active) != bool(values_raw):
-        raise RuntimeError(
-            "MILLPOND_FILTER_VALUES must be set together with "
-            "MILLPOND_FILTER_KEEP_FIELD_NAME (or MILLPOND_FILTER_DROP_FIELD_NAME)"
-        )
+    for field in (keep, drop):
+        if field is not None and not _SAFE_COLUMN_NAME.match(field):
+            raise RuntimeError(
+                f"Filter field name {field!r} contains unsafe characters (must match [a-zA-Z_][a-zA-Z0-9_]*)"
+            )
 
-    if active is None:
-        return None, None, None
-
-    if not _SAFE_COLUMN_NAME.match(active):
-        raise RuntimeError(
-            f"Filter field name {active!r} contains unsafe characters (must match [a-zA-Z_][a-zA-Z0-9_]*)"
-        )
-
-    if drop:
-        # Reserved for a future change; rejecting explicitly today keeps the
-        # env-var namespace and the keep/drop mutual-exclusion contract
-        # stable so a later commit can flip the implementation on without
-        # any operator-facing config rename.
-        raise RuntimeError("MILLPOND_FILTER_DROP_FIELD_NAME is reserved for a future release; not implemented yet")
-
-    return keep, None, _parse_filter_values(values_raw)
+    return (
+        keep,
+        drop,
+        _parse_filter_values(values_raw) if keep else None,
+        _parse_filter_values(drop_values_raw) if drop else None,
+    )
 
 
 def _load_include_values_config(
@@ -496,7 +505,7 @@ def load() -> Config:
             "(allowed: earliest, latest) so the value gets validated."
         )
 
-    filter_keep_field, filter_drop_field, filter_values = _load_filter_fields()
+    filter_keep_field, filter_drop_field, filter_values, filter_drop_values = _load_filter_fields()
     sort_by = _load_sort_by()
     typed_columns = _load_typed_columns()
 
@@ -518,6 +527,7 @@ def load() -> Config:
         filter_keep_field=filter_keep_field,
         filter_drop_field=filter_drop_field,
         filter_values=filter_values,
+        filter_drop_values=filter_drop_values,
         **_load_include_values_config(filter_keep_field, filter_values),
         sort_by=sort_by,
         typed_columns=typed_columns,
@@ -547,6 +557,8 @@ def load() -> Config:
     )
     if cfg.filter_keep_field is not None:
         log.info("Filter (keep): %s in %s", cfg.filter_keep_field, cfg.filter_values)
+    if cfg.filter_drop_field is not None:
+        log.info("Filter (drop): %s in %s", cfg.filter_drop_field, cfg.filter_drop_values)
     if cfg.sort_by is not None:
         log.info("Sort by: %s (ascending)", ", ".join(cfg.sort_by))
     if cfg.typed_columns is not None:

--- a/millpond/main.py
+++ b/millpond/main.py
@@ -97,8 +97,8 @@ def _apply_filter(table: pa.Table, cfg: config.Config, values: tuple[int, ...] |
          the consume loop.
 
     No-op when filter not configured. The drop-direction filter is
-    reserved at the config layer but not implemented here yet — config
-    rejects it explicitly at startup.
+    implemented separately in _apply_drop_filter, applied AFTER this one
+    (keep ∩ ¬drop).
     """
     if cfg.filter_keep_field is None or values is None:
         return table
@@ -166,6 +166,65 @@ def _apply_filter(table: pa.Table, cfg: config.Config, values: tuple[int, ...] |
         # over the minority the filter retained.
         for chunk in pc.value_counts(filtered[field]).to_pylist():
             metrics.filter_matched_total.labels(value=str(chunk["values"])).inc(chunk["counts"])
+    return filtered
+
+
+def _apply_drop_filter(table: pa.Table, cfg: config.Config) -> pa.Table:
+    """Apply the drop-direction filter (denylist): drop records whose value
+    in `filter_drop_field` is in `filter_drop_values`; keep everything else.
+    Runs AFTER the keep-filter — the composed semantics are keep ∩ ¬drop
+    (e.g. the CP-driven include set minus an operator blacklist).
+
+    Failure semantics are the OPPOSITE of the keep-filter, deliberately:
+    an allowlist that can't evaluate fails closed (dropping the batch is
+    the conservative reading of "only deliver what's on the list"), but a
+    denylist that can't evaluate fails OPEN — keeping the batch leaks the
+    blacklisted minority temporarily, while dropping it would turn a
+    schema hiccup into data loss for every tenant. Unevaluable batches
+    WARN and pass through unchanged. Null field values are kept for the
+    same reason (a null can't match the blacklist).
+
+    Dropped rows count under `records_skipped_total{reason="filter_dropped"}`.
+    """
+    if cfg.filter_drop_field is None or cfg.filter_drop_values is None:
+        return table
+
+    field = cfg.filter_drop_field
+    if field not in table.column_names:
+        log.warning("Drop-filter field %r missing from batch; keeping batch unchanged (fail-open)", field)
+        return table
+
+    column = table[field]
+    if not (
+        pa.types.is_integer(column.type) or pa.types.is_string(column.type) or pa.types.is_large_string(column.type)
+    ):
+        log.warning(
+            "Drop-filter field %r has unsupported type %s; keeping batch unchanged (fail-open)",
+            field,
+            column.type,
+        )
+        return table
+
+    try:
+        value_array = pa.array(cfg.filter_drop_values).cast(column.type)
+    except (pa.ArrowInvalid, pa.ArrowNotImplementedError, pa.ArrowTypeError) as e:
+        log.warning(
+            "Drop-filter values %r incompatible with column %r type %s (%s); keeping batch unchanged (fail-open)",
+            cfg.filter_drop_values,
+            field,
+            column.type,
+            e,
+        )
+        return table
+
+    # is_in returns false-or-null for null inputs depending on pyarrow
+    # version; fill_null(False) normalizes either way, keeping null rows
+    # (a null can't match the blacklist — fail-open, see docstring).
+    drop_mask = pc.fill_null(pc.is_in(column, value_array), False)
+    filtered = table.filter(pc.invert(drop_mask))
+    n_dropped = len(table) - len(filtered)
+    if n_dropped > 0:
+        metrics.records_skipped_total.labels(reason="filter_dropped").inc(n_dropped)
     return filtered
 
 
@@ -451,6 +510,7 @@ def main():
                         skipped = len(values) - len(table)
                         table = _coerce_columns(table, cfg)
                         table = _apply_filter(table, cfg, include_source.current())
+                        table = _apply_drop_filter(table, cfg)
                         if len(table) > 0:
                             pending.append(table)
                             pending_bytes += table.nbytes

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -358,20 +358,52 @@ class TestFilterConfig:
         with pytest.raises(RuntimeError, match="MILLPOND_FILTER_VALUES"):
             load()
 
-    def test_keep_and_drop_mutually_exclusive(self, monkeypatch):
-        monkeypatch.setenv("MILLPOND_FILTER_KEEP_FIELD_NAME", "team_id")
+    def test_drop_alone_parsed(self, monkeypatch):
         monkeypatch.setenv("MILLPOND_FILTER_DROP_FIELD_NAME", "team_id")
-        monkeypatch.setenv("MILLPOND_FILTER_VALUES", "1,2")
-        with pytest.raises(RuntimeError, match="mutually exclusive"):
+        monkeypatch.setenv("MILLPOND_FILTER_DROP_VALUES", "47074")
+        cfg = load()
+        assert cfg.filter_drop_field == "team_id"
+        assert cfg.filter_drop_values == (47074,)
+        assert cfg.filter_keep_field is None
+        assert cfg.filter_values is None
+
+    def test_keep_and_drop_compose(self, monkeypatch):
+        # The load-shedding case this exists for: CP-driven keep-filter
+        # stays authoritative while an operator blacklist subtracts one
+        # tenant. Each direction pairs with its OWN values var.
+        monkeypatch.setenv("MILLPOND_FILTER_KEEP_FIELD_NAME", "team_id")
+        monkeypatch.setenv("MILLPOND_FILTER_VALUES", "1,2,47074")
+        monkeypatch.setenv("MILLPOND_FILTER_DROP_FIELD_NAME", "team_id")
+        monkeypatch.setenv("MILLPOND_FILTER_DROP_VALUES", "47074")
+        cfg = load()
+        assert cfg.filter_keep_field == "team_id"
+        assert cfg.filter_values == (1, 2, 47074)
+        assert cfg.filter_drop_field == "team_id"
+        assert cfg.filter_drop_values == (47074,)
+
+    def test_drop_field_without_drop_values_rejected(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_FILTER_DROP_FIELD_NAME", "team_id")
+        with pytest.raises(RuntimeError, match="MILLPOND_FILTER_DROP_VALUES"):
             load()
 
-    def test_drop_direction_rejected_until_implemented(self, monkeypatch):
-        # Reserved namespace: drop is parsed and validated but explicitly
-        # refused so an operator setting it today gets a clear startup
-        # error rather than silently no-filtering.
+    def test_drop_values_without_drop_field_rejected(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_FILTER_DROP_VALUES", "1,2")
+        with pytest.raises(RuntimeError, match="MILLPOND_FILTER_DROP_VALUES"):
+            load()
+
+    def test_drop_does_not_pair_with_keep_values(self, monkeypatch):
+        # The original reservation shared MILLPOND_FILTER_VALUES; the
+        # implementation deliberately does not — a drop field with only
+        # the keep-values var set is half-configured and must refuse.
         monkeypatch.setenv("MILLPOND_FILTER_DROP_FIELD_NAME", "team_id")
         monkeypatch.setenv("MILLPOND_FILTER_VALUES", "1,2")
-        with pytest.raises(RuntimeError, match="reserved for a future release"):
+        with pytest.raises(RuntimeError, match="MILLPOND_FILTER"):
+            load()
+
+    def test_unsafe_drop_field_name_rejected(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_FILTER_DROP_FIELD_NAME", "team_id; DROP TABLE x")
+        monkeypatch.setenv("MILLPOND_FILTER_DROP_VALUES", "1")
+        with pytest.raises(RuntimeError, match="unsafe characters"):
             load()
 
     def test_unsafe_field_name_rejected(self, monkeypatch):

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -159,6 +159,7 @@ def _make_cfg(**overrides) -> Config:
         filter_keep_field=None,
         filter_drop_field=None,
         filter_values=None,
+        filter_drop_values=None,
         include_values_url=None,
         include_values_mode="shadow",
         include_values_poll_interval_s=60.0,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -646,6 +646,103 @@ def _capture_sort_skip_calls(mock_metrics):
     return sort_calls
 
 
+class TestApplyDropFilter:
+    """Drop-direction (denylist) filter. Composes AFTER the keep-filter;
+    fail-open on anything unevaluable (the opposite of keep — see the
+    docstring on _apply_drop_filter for why)."""
+
+    def _cfg(self, *, drop=None, drop_values=None):
+        cfg = MagicMock()
+        cfg.filter_drop_field = drop
+        cfg.filter_drop_values = drop_values
+        return cfg
+
+    def test_no_op_when_unconfigured(self):
+        from millpond.main import _apply_drop_filter
+
+        table = pa.table({"team_id": [1, 2, 3]})
+        result = _apply_drop_filter(table, self._cfg())
+        assert result is table
+
+    @patch("millpond.main.metrics")
+    def test_int_denylist_drops_matching_rows(self, mock_metrics):
+        from millpond.main import _apply_drop_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        table = pa.table({"team_id": [1, 47074, 3, 47074, 5], "event": ["a", "b", "c", "d", "e"]})
+        result = _apply_drop_filter(table, self._cfg(drop="team_id", drop_values=(47074,)))
+
+        assert result.column("team_id").to_pylist() == [1, 3, 5]
+        assert result.column("event").to_pylist() == ["a", "c", "e"]
+        assert skip_calls == [("filter_dropped", 2)]
+
+    @patch("millpond.main.metrics")
+    def test_string_values_cast_to_int_column(self, mock_metrics):
+        # Operator wrote MILLPOND_FILTER_DROP_VALUES with a stray
+        # non-numeric token → whole tuple parses as strings; safe cast to
+        # the int64 column must still match.
+        from millpond.main import _apply_drop_filter
+
+        _capture_skip_calls(mock_metrics)
+        table = pa.table({"team_id": [1, 47074, 3]})
+        result = _apply_drop_filter(table, self._cfg(drop="team_id", drop_values=("47074",)))
+        assert result.column("team_id").to_pylist() == [1, 3]
+
+    @patch("millpond.main.metrics")
+    def test_missing_field_fails_open(self, mock_metrics):
+        from millpond.main import _apply_drop_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        table = pa.table({"other": [1, 2, 3]})
+        result = _apply_drop_filter(table, self._cfg(drop="team_id", drop_values=(47074,)))
+        # Batch unchanged — a blacklist that can't evaluate must not drop.
+        assert result is table
+        assert skip_calls == []
+
+    @patch("millpond.main.metrics")
+    def test_unsupported_column_type_fails_open(self, mock_metrics):
+        from millpond.main import _apply_drop_filter
+
+        _capture_skip_calls(mock_metrics)
+        table = pa.table({"team_id": pa.array([1.5, 2.5], pa.float64())})
+        result = _apply_drop_filter(table, self._cfg(drop="team_id", drop_values=(47074,)))
+        assert result is table
+
+    @patch("millpond.main.metrics")
+    def test_uncastable_values_fail_open(self, mock_metrics):
+        from millpond.main import _apply_drop_filter
+
+        _capture_skip_calls(mock_metrics)
+        table = pa.table({"team_id": [1, 2]})
+        result = _apply_drop_filter(table, self._cfg(drop="team_id", drop_values=("not-a-number",)))
+        assert result is table
+
+    @patch("millpond.main.metrics")
+    def test_null_field_values_are_kept(self, mock_metrics):
+        from millpond.main import _apply_drop_filter
+
+        skip_calls = _capture_skip_calls(mock_metrics)
+        table = pa.table({"team_id": pa.array([1, None, 47074], pa.int64())})
+        result = _apply_drop_filter(table, self._cfg(drop="team_id", drop_values=(47074,)))
+        # Null can't match a blacklist → kept; only the real match drops.
+        assert result.column("team_id").to_pylist() == [1, None]
+        assert skip_calls == [("filter_dropped", 1)]
+
+    @patch("millpond.main.metrics")
+    def test_composes_with_keep_filter(self, mock_metrics):
+        # The production shape: CP include set says {2, 47074, 50689},
+        # blacklist says drop 47074 → survivors are keep ∩ ¬drop.
+        from millpond.main import _apply_drop_filter, _apply_filter
+
+        _capture_skip_calls(mock_metrics)
+        table = pa.table({"team_id": [2, 47074, 50689, 99999]})
+        keep_cfg = MagicMock()
+        keep_cfg.filter_keep_field = "team_id"
+        kept = _apply_filter(table, keep_cfg, (2, 47074, 50689))
+        result = _apply_drop_filter(kept, self._cfg(drop="team_id", drop_values=(47074,)))
+        assert result.column("team_id").to_pylist() == [2, 50689]
+
+
 class TestApplySort:
     """Hot-path pre-write sort behaviour.
 

--- a/tests/unit/test_millpond_logging_config.py
+++ b/tests/unit/test_millpond_logging_config.py
@@ -63,6 +63,7 @@ def _minimal_config() -> Config:
         filter_keep_field=None,
         filter_drop_field=None,
         filter_values=None,
+        filter_drop_values=None,
         include_values_url=None,
         include_values_mode="shadow",
         include_values_poll_interval_s=60.0,


### PR DESCRIPTION
## What

Implements the drop-direction record filter (denylist) that was reserved at the config layer: drop records whose value in `MILLPOND_FILTER_DROP_FIELD_NAME` is in `MILLPOND_FILTER_DROP_VALUES`, keep everything else. Composes AFTER the keep filter (keep ∩ ¬drop).

## Why now

Emergency drain lever: team 47074 is ~75% of the `events_nrt` firehose, and every viaduck cursor-group read pays full-firehose scan cost — the two lagging tenants (~200K snapshots behind) can't outrun the source while it dominates the stream. Muting one tenant at millpond shrinks every group's scan ~4× without touching the CP-driven include set. The pairing charts PR (template + schema + prod-us-ws values) activates it.

## Design decisions (deviations from the reservation, both deliberate)

- **Own values var + composition**: drop pairs with `MILLPOND_FILTER_DROP_VALUES` (not the shared `MILLPOND_FILTER_VALUES`), and the keep/drop mutual exclusion is removed — the motivating case is CP-driven keep + operator blacklist simultaneously, unexpressible with one shared list.
- **Fail-open**: an unevaluable denylist (missing field / unsupported type / uncastable values) keeps the batch and WARNs — the opposite of keep's fail-closed. Dropped rows are irrecoverable (Kafka offsets advance), so a blacklist misfire turning schema drift into all-tenant data loss is strictly worse than temporarily leaking the blacklisted minority. Nulls kept for the same reason.
- **Observability**: dropped rows count under `records_skipped_total{reason="filter_dropped"}` — that counter climbing is the positive confirmation a mute is live. (`filter_matched_total` still counts include-set matches pre-drop; known and acceptable for the drain window.)

## Validation

- 661 tests green (638 unit + 23 integration, Docker suite genuinely ran): denylist hit, string↔int cast both directions, all three fail-open paths, null handling, keep∘drop composition, full config pairing matrix.
- Adversarial review pair (QE + principal): ship, zero functional defects; review nits (stale docstring, pyarrow null-semantics comment, error-message env naming) applied.

## Deploy order (matters)

v0.0.92 **refuses** `MILLPOND_FILTER_DROP_FIELD_NAME` at startup ("reserved for a future release") — rendering the new env onto the old image crash-loops. Chain: merge → release → **manual promote-to-prod** → verify `:prod` retag → only then merge the charts PR.

## Follow-ups (non-blocking)

- `drop_filter_unevaluable_total` counter (fail-open is WARN-only today) + WARN dedup.
- Consider running drop BEFORE keep (set-equivalent, makes `filter_matched_total` truthful, cheaper on high-drop workloads).
