### PR TITLE
maintenance: max-outputs-per-call — many small merge txns per compaction run

### DIFF
--- a/tests/unit/test_ducklake_maintenance.py
+++ b/tests/unit/test_ducklake_maintenance.py
@@ -177,13 +177,31 @@ class TestArgparse:
         # argparse defaults read COMPACTION_* env at parser-build time, so a
         # lingering shell override (the justfile exports COMPACTION_MAX_FILES)
         # would make this test flaky — isolate and rebuild the parser.
-        for var in ("COMPACTION_THREADS", "COMPACTION_MEMORY_LIMIT", "COMPACTION_MAX_FILES"):
+        for var in (
+            "COMPACTION_THREADS",
+            "COMPACTION_MEMORY_LIMIT",
+            "COMPACTION_MAX_FILES",
+            "COMPACTION_MAX_OUTPUTS_PER_CALL",
+        ):
             monkeypatch.delenv(var, raising=False)
         parser = ducklake_maintenance.build_parser()
         args = parser.parse_args(["compact", "--tier", "1"])
         assert args.threads == 2
         assert args.memory_limit == "4GB"
         assert args.max_compacted_files == 80  # fallback aligned with justfile export
+        assert args.max_outputs_per_call is None  # unset = legacy single-call mode
+
+    def test_max_outputs_per_call_env(self, monkeypatch):
+        monkeypatch.setenv("COMPACTION_MAX_OUTPUTS_PER_CALL", "10")
+        parser = ducklake_maintenance.build_parser()
+        args = parser.parse_args(["compact", "--tier", "3"])
+        assert args.max_outputs_per_call == 10
+
+    def test_max_outputs_per_call_empty_env_is_unset(self, monkeypatch):
+        monkeypatch.setenv("COMPACTION_MAX_OUTPUTS_PER_CALL", "")
+        parser = ducklake_maintenance.build_parser()
+        args = parser.parse_args(["compact", "--tier", "3"])
+        assert args.max_outputs_per_call is None
 
     def test_compact_threads_memory_override(self):
         args = self.parser.parse_args(
@@ -825,18 +843,24 @@ class TestHeartbeat:
         assert net is None or (isinstance(net, tuple) and len(net) == 2 and all(v >= 0 for v in net))
 
 
-def _compact_conn(tables, merge_rows=None, fail_tables=(), candidates=(100, 1000)):
+def _compact_conn(tables, merge_rows=None, fail_tables=(), candidates=(100, 1000), merge_rows_seq=None):
     """A duckdb-conn-shaped MagicMock driving the per-table compact() flow.
 
     tables: (schema, table) pairs the candidate-driven enumeration returns
     (the mock returns them verbatim — production orders by backlog DESC).
-    merge_rows: {table_name: result rows} for its merge CALL (default []).
+    merge_rows: {table_name: result rows} for its merge CALL (default []) —
+    the SAME rows for every call to that table.
+    merge_rows_seq: {table_name: [rows_call1, rows_call2, ...]} — per-call
+    sequence for multi-call (max_outputs_per_call) tests; exhausted → [].
+    An Exception instance in the sequence is RAISED on that call (mid-loop
+    failure injection). Takes precedence over merge_rows for tables it names.
     fail_tables: table names whose merge CALL raises.
     """
     conn = MagicMock()
     # The CALL's table name is its second positional arg — parse it instead of
     # substring-matching, so a mock defect can't masquerade as a table failure.
     call_re = re.compile(r"ducklake_merge_adjacent_files\('[^']*', '([^']*)'")
+    seq_state = {k: list(v) for k, v in (merge_rows_seq or {}).items()}
 
     def _execute(sql, *a, **k):
         res = MagicMock()
@@ -849,7 +873,13 @@ def _compact_conn(tables, merge_rows=None, fail_tables=(), candidates=(100, 1000
             name = m.group(1)
             if name in fail_tables:
                 raise RuntimeError("DuckLakeCompactor: Files have different hive partition path")
-            res.fetchall.return_value = (merge_rows or {}).get(name, [])
+            if name in seq_state:
+                step = seq_state[name].pop(0) if seq_state[name] else []
+                if isinstance(step, Exception):
+                    raise step
+                res.fetchall.return_value = step
+            else:
+                res.fetchall.return_value = (merge_rows or {}).get(name, [])
         elif "ducklake_options" in sql:
             res.fetchone.return_value = ("134217728",)  # 128MiB, restore path
         elif "ducklake_data_file" in sql:
@@ -912,6 +942,219 @@ class TestCompactSql:
         )
 
         assert not _merge_calls(conn)
+
+
+class TestOutputsPerCall:
+    """max_outputs_per_call: many small always-committable txns per run.
+
+    The fork CALL's `max_compacted_files =>` bounds OUTPUT files (txn size),
+    while compact()'s run budget accounts INPUT files consumed. Unset must
+    be byte-identical legacy (single call per table, whole grant); set must
+    re-call each table with the small cap until the grant/budget drains or
+    a call produces nothing."""
+
+    _R = staticmethod(lambda n_inputs: [("posthog", "events_nrt", n_inputs, 10)])
+
+    def test_unset_is_legacy_single_call(self):
+        conn = _compact_conn(
+            [("main", "events_nrt")],
+            merge_rows={"events_nrt": [("main", "events_nrt", 929, 5)]},
+        )
+        ducklake_maintenance.compact(
+            conn, tier=3, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+        )
+        calls = _merge_calls(conn)
+        assert len(calls) == 1
+        # Single-table: whole budget in one call, exactly as before.
+        assert "max_compacted_files => 10" in calls[0]
+
+    def test_capped_recalls_until_budget_consumed(self):
+        # Budget 3000 inputs, cap 10 outputs/call; each call consumes 1000
+        # inputs -> exactly 3 calls, all with the small cap.
+        conn = _compact_conn(
+            [("main", "events_nrt")],
+            merge_rows_seq={"events_nrt": [self._R(1000), self._R(1000), self._R(1000), self._R(1000)]},
+        )
+        ducklake_maintenance.compact(
+            conn,
+            tier=3,
+            table=None,
+            dry_run=False,
+            threads=2,
+            memory_limit="16GB",
+            max_compacted_files=3000,
+            max_outputs_per_call=10,
+        )
+        calls = _merge_calls(conn)
+        assert len(calls) == 3
+        assert all("max_compacted_files => 10" in c for c in calls)
+
+    def test_capped_stops_when_table_drains(self):
+        # Second call returns nothing -> table drained; no third call, and
+        # the table is NOT counted as a no-op (it did work on call 1).
+        conn = _compact_conn(
+            [("main", "events_nrt")],
+            merge_rows_seq={"events_nrt": [self._R(500)]},
+        )
+        ducklake_maintenance.compact(
+            conn,
+            tier=3,
+            table=None,
+            dry_run=False,
+            threads=2,
+            memory_limit="16GB",
+            max_compacted_files=10000,
+            max_outputs_per_call=10,
+        )
+        assert len(_merge_calls(conn)) == 2  # work, then empty -> stop
+
+    def test_capped_first_call_empty_counts_noop(self, caplog):
+        conn = _compact_conn([("main", "events_nrt")], merge_rows_seq={"events_nrt": []})
+        with caplog.at_level(logging.INFO, logger="maintenance"):
+            ducklake_maintenance.compact(
+                conn,
+                tier=3,
+                table=None,
+                dry_run=False,
+                threads=2,
+                memory_limit="16GB",
+                max_compacted_files=10000,
+                max_outputs_per_call=10,
+            )
+        assert len(_merge_calls(conn)) == 1
+        assert "zero merge groups" in caplog.text
+
+    def test_capped_multi_table_drain_then_next_table(self):
+        # Table A drains (two productive calls then empty); table B still
+        # gets served. Nothing fails.
+        conn = _compact_conn(
+            [("main", "aaa"), ("main", "bbb")],
+            merge_rows_seq={
+                "aaa": [
+                    [("main", "aaa", 100, 10)],
+                    [("main", "aaa", 100, 10)],
+                ],
+                "bbb": [[("main", "bbb", 50, 5)]],
+            },
+        )
+        n_failed = ducklake_maintenance.compact(
+            conn,
+            tier=3,
+            table=None,
+            dry_run=False,
+            threads=2,
+            memory_limit="16GB",
+            max_compacted_files=1000,
+            max_outputs_per_call=10,
+        )
+        calls = _merge_calls(conn)
+        # aaa: 2 productive + 1 empty (drained) = 3; bbb: 1 productive + 1 empty = 2
+        assert len([c for c in calls if "'aaa'" in c]) == 3
+        assert len([c for c in calls if "'bbb'" in c]) == 2
+        assert n_failed == 0
+
+    def test_capped_mid_loop_failure_keeps_progress_and_serves_next_table(self, caplog):
+        # Table A: two productive calls, then the THIRD call raises — A is
+        # counted failed, its committed progress stands (rows from calls 1-2
+        # stay in the summary), and table B still gets served.
+        conn = _compact_conn(
+            [("main", "aaa"), ("main", "bbb")],
+            merge_rows_seq={
+                "aaa": [
+                    [("main", "aaa", 100, 10)],
+                    [("main", "aaa", 100, 10)],
+                    RuntimeError("DuckLakeCompactor: Files have different hive partition path"),
+                ],
+                "bbb": [[("main", "bbb", 50, 5)]],
+            },
+        )
+        with caplog.at_level(logging.WARNING, logger="maintenance"):
+            n_failed = ducklake_maintenance.compact(
+                conn,
+                tier=3,
+                table=None,
+                dry_run=False,
+                threads=2,
+                memory_limit="16GB",
+                max_compacted_files=1000,
+                max_outputs_per_call=10,
+            )
+        calls = _merge_calls(conn)
+        assert len([c for c in calls if "'aaa'" in c]) == 3  # 2 productive + 1 failing
+        assert len([c for c in calls if "'bbb'" in c]) == 2  # productive + drain probe
+        assert n_failed == 1
+        assert "1/2 table(s) failed" in caplog.text
+
+    def test_capped_zero_input_rows_fail_loudly_not_forever(self):
+        # Progress guard: rows with zero inputs consumed must classify the
+        # table as failed (loud) instead of re-issuing identical merge txns
+        # until the activeDeadline kills the pod.
+        conn = _compact_conn(
+            [("main", "aaa")],
+            merge_rows_seq={"aaa": [[("main", "aaa", 0, 10)]] * 5},
+        )
+        n_failed = ducklake_maintenance.compact(
+            conn,
+            tier=3,
+            table=None,
+            dry_run=False,
+            threads=2,
+            memory_limit="16GB",
+            max_compacted_files=1000,
+            max_outputs_per_call=10,
+        )
+        assert len(_merge_calls(conn)) == 1  # no retry storm
+        assert n_failed == 1
+
+    def test_single_table_form_honors_cap(self):
+        # A manual `compact --table X` in a pod with the env set must NOT
+        # silently issue one giant txn — the loop applies there too.
+        conn = _compact_conn(
+            [],
+            merge_rows_seq={"events_nrt": [self._R(1000), self._R(1000)]},
+        )
+        ducklake_maintenance.compact(
+            conn,
+            tier=3,
+            table="events_nrt",
+            dry_run=False,
+            threads=2,
+            memory_limit="16GB",
+            max_compacted_files=5000,
+            max_outputs_per_call=10,
+        )
+        calls = _merge_calls(conn)
+        assert len(calls) == 3  # 2 productive + drain probe
+        assert all("max_compacted_files => 10" in c for c in calls)
+
+    def test_capped_respects_run_budget_mid_table(self):
+        # Budget 150 inputs; first call eats 100, second eats 100 -> budget
+        # crossed; no third call for this table and none for the next.
+        conn = _compact_conn(
+            [("main", "aaa"), ("main", "bbb")],
+            merge_rows_seq={
+                "aaa": [[("main", "aaa", 100, 10)], [("main", "aaa", 100, 10)], [("main", "aaa", 100, 10)]],
+                "bbb": [[("main", "bbb", 50, 5)]],
+            },
+        )
+        ducklake_maintenance.compact(
+            conn,
+            tier=3,
+            table=None,
+            dry_run=False,
+            threads=2,
+            memory_limit="16GB",
+            max_compacted_files=150,
+            max_outputs_per_call=10,
+        )
+        calls = _merge_calls(conn)
+        # multi-table grant = max(1, 150//2) = 75 -> aaa's first call (100
+        # inputs) already exceeds its grant -> ONE aaa call; bbb then gets
+        # grant min(remaining=50, 75) = 50, and its one call consumes all
+        # 50 -> budget exactly exhausted -> loop stops WITHOUT a wasted
+        # drain-probe call.
+        assert len([c for c in calls if "'aaa'" in c]) == 1
+        assert len([c for c in calls if "'bbb'" in c]) == 1
 
 
 class TestCompactPerTable:

--- a/tools/ducklake_maintenance.py
+++ b/tools/ducklake_maintenance.py
@@ -1977,6 +1977,7 @@ def compact(
     threads: int,
     memory_limit: str,
     max_compacted_files: int,
+    max_outputs_per_call: int | None = None,
 ) -> int:
     """Compact files in tier N (1, 2, or 3) for the catalog or one table.
 
@@ -1985,6 +1986,19 @@ def compact(
     propagates its error raw instead). main() exports this as the
     maintenance_compact_tables_failed gauge so a permanently-poisoned
     table is alertable even though partial failure deliberately exits 0.
+
+    max_outputs_per_call decouples per-TRANSACTION size from the per-RUN
+    budget. The fork CALL's `max_compacted_files =>` bounds OUTPUT files
+    (txn size ~ outputs x target_file_size), while this function's run
+    budget accounts INPUT files consumed. Unset (default): one CALL per
+    table with the legacy grant — byte-identical behavior to before the
+    knob existed. Set: each CALL is capped at this many outputs and a
+    table is called REPEATEDLY (until its grant or the run budget is
+    consumed, or a call produces nothing) — many small always-committable
+    transactions per run instead of one. Built for the megaduck source
+    catalog, where a single large merge txn cannot commit inside the
+    activeDeadline (documented DeadlineExceeded history) but dozens of
+    ~10-output txns per run converge its tier-3 backlog.
     """
     spec = TIERS[tier]
     min_b, max_b, target = spec["min"], spec["max"], spec["target"]
@@ -2043,13 +2057,29 @@ def compact(
     noop_tables = 0
 
     if table:
-        # Single-table invocation: unchanged one-CALL semantics; an error
-        # propagates raw, exactly as before.
-        sql = _merge_adjacent_call(None, table, args, max_compacted_files)
+        # Single-table invocation. Errors propagate raw, exactly as before.
+        # max_outputs_per_call applies here too (review finding: silently
+        # ignoring the pod-wide env on a manual `compact --table` run would
+        # issue exactly the giant single txn the knob exists to prevent).
         heartbeat = _start_heartbeat(conn, f"compact tier-{tier} merge")
         try:
             with _scoped_target_file_size(conn, target):
-                result = conn.execute(sql).fetchall()
+                remaining = max_compacted_files
+                while remaining > 0:
+                    call_cap = remaining if max_outputs_per_call is None else min(max_outputs_per_call, remaining)
+                    sql = _merge_adjacent_call(None, table, args, call_cap)
+                    rows = conn.execute(sql).fetchall()
+                    if any(len(r) < 4 for r in rows):
+                        raise ValueError(f"unexpected merge result shape: {rows[:2]!r}")
+                    if not rows:
+                        break
+                    consumed = sum(r[2] for r in rows)
+                    if consumed <= 0:
+                        raise ValueError(f"merge returned rows but zero inputs consumed: {rows[:2]!r}")
+                    result.extend(rows)
+                    remaining -= consumed
+                    if max_outputs_per_call is None:
+                        break
         finally:
             heartbeat.set()
     else:
@@ -2102,52 +2132,89 @@ def compact(
                     )
                     break
                 grant = remaining if table_total == 1 else min(remaining, max(1, max_compacted_files // 2))
-                sql = _merge_adjacent_call(schema_name, table_name, args, grant)
-                heartbeat = _start_heartbeat(conn, f"compact tier-{tier} {schema_name}.{table_name}")
-                try:
-                    rows = conn.execute(sql).fetchall()
-                    # Validate shape BEFORE mutating shared state: if a fork/
-                    # version drift changes the CALL's result schema, this
-                    # table's accounting fails loudly but the run-wide
-                    # aggregation below never sees malformed rows.
-                    if any(len(r) < 4 for r in rows):
-                        raise ValueError(f"unexpected merge result shape: {rows[:2]!r}")
-                    if not rows:
-                        # >= 2 in-band files but zero merge groups: candidates
-                        # are per-partition singletons, row-id-non-contiguous,
-                        # or otherwise unmergeable. Counted so a catalog full
-                        # of these is visible, not a silent perpetual no-op.
-                        noop_tables += 1
-                    consumed = sum(r[2] for r in rows)
-                    result.extend(rows)
-                    remaining -= consumed
-                except duckdb.CatalogException:
-                    # Table vanished between enumeration and the CALL (dropped
-                    # mid-run) — benign, don't count it as a failure.
-                    log.warning(
-                        "compact tier-%d: %s.%s disappeared before merge (dropped?); skipping",
-                        tier,
-                        schema_name,
-                        table_name,
+                # Inner loop: legacy mode (max_outputs_per_call unset) makes
+                # exactly ONE call with the whole grant — unchanged behavior.
+                # Capped mode re-calls the same table with small per-txn
+                # output caps until the grant/budget is consumed or a call
+                # produces nothing (table drained for this tier).
+                call_idx = 0
+                while grant > 0 and remaining > 0:
+                    # min() with the grant: when the remaining grant is
+                    # smaller than the cap, degrade to exactly legacy
+                    # semantics — never issue a larger per-txn cap than the
+                    # legacy single call would have.
+                    call_cap = grant if max_outputs_per_call is None else min(max_outputs_per_call, grant)
+                    sql = _merge_adjacent_call(schema_name, table_name, args, call_cap)
+                    heartbeat = _start_heartbeat(
+                        conn,
+                        f"compact tier-{tier} {schema_name}.{table_name}"
+                        + (f" call {call_idx + 1}" if call_idx else ""),
                     )
-                except Exception:
-                    # Continue-on-error relies on the connection SURVIVING the
-                    # failed CALL (verified on duckdb 1.5.2 even for
-                    # InternalException, and pinned end-to-end by
-                    # test_compaction_isolation_integration). If a future
-                    # duckdb bump invalidates the instance on INTERNAL errors,
-                    # every table fails, the failure summary + gauge spike,
-                    # and the target_file_size restore raises — noisy, not
-                    # silent.
-                    failed.append(f"{schema_name}.{table_name}")
-                    log.exception(
-                        "compact tier-%d: %s.%s failed; continuing with remaining tables",
-                        tier,
-                        schema_name,
-                        table_name,
-                    )
-                finally:
-                    heartbeat.set()
+                    try:
+                        rows = conn.execute(sql).fetchall()
+                        # Validate shape BEFORE mutating shared state: if a fork/
+                        # version drift changes the CALL's result schema, this
+                        # table's accounting fails loudly but the run-wide
+                        # aggregation below never sees malformed rows.
+                        if any(len(r) < 4 for r in rows):
+                            raise ValueError(f"unexpected merge result shape: {rows[:2]!r}")
+                        if not rows:
+                            if call_idx == 0:
+                                # >= 2 in-band files but zero merge groups:
+                                # candidates are per-partition singletons,
+                                # row-id-non-contiguous, or otherwise
+                                # unmergeable. Counted so a catalog full of
+                                # these is visible, not a silent perpetual
+                                # no-op. (An empty LATER call just means the
+                                # table drained — not a no-op table.)
+                                noop_tables += 1
+                            break
+                        consumed = sum(r[2] for r in rows)
+                        if consumed <= 0:
+                            # Progress guard: termination of this loop rests
+                            # on every productive call consuming >= 2 inputs
+                            # (a merge group by definition). A fork bump that
+                            # reorders result columns or emits zero-input
+                            # rows must fail THIS table loudly, not re-issue
+                            # identical merge txns until the activeDeadline
+                            # kills the pod.
+                            raise ValueError(f"merge returned rows but zero inputs consumed: {rows[:2]!r}")
+                        result.extend(rows)
+                        remaining -= consumed
+                        grant -= consumed
+                    except duckdb.CatalogException:
+                        # Table vanished between enumeration and the CALL
+                        # (dropped mid-run) — benign, not a failure.
+                        log.warning(
+                            "compact tier-%d: %s.%s disappeared before merge (dropped?); skipping",
+                            tier,
+                            schema_name,
+                            table_name,
+                        )
+                        break
+                    except Exception:
+                        # Continue-on-error relies on the connection SURVIVING
+                        # the failed CALL (verified on duckdb 1.5.2 even for
+                        # InternalException, and pinned end-to-end by
+                        # test_compaction_isolation_integration). If a future
+                        # duckdb bump invalidates the instance on INTERNAL
+                        # errors, every table fails, the failure summary +
+                        # gauge spike, and the target_file_size restore raises
+                        # — noisy, not silent. A mid-loop failure keeps the
+                        # progress already committed by earlier calls.
+                        failed.append(f"{schema_name}.{table_name}")
+                        log.exception(
+                            "compact tier-%d: %s.%s failed; continuing with remaining tables",
+                            tier,
+                            schema_name,
+                            table_name,
+                        )
+                        break
+                    finally:
+                        heartbeat.set()
+                    call_idx += 1
+                    if max_outputs_per_call is None:
+                        break
     elapsed = time.monotonic() - t0
 
     # Aggregate result rows (one per output group: schema, table, input_files, output_files)
@@ -2383,7 +2450,22 @@ def build_parser() -> argparse.ArgumentParser:
         # Fallback matches the justfile's exported default: a direct python
         # invocation must not be 1250x more aggressive than `just compact-*`.
         default=_positive_int(os.environ.get("COMPACTION_MAX_FILES", "80")),
-        help="Cap on files merged per run (default $COMPACTION_MAX_FILES or 80)",
+        help="Cap on INPUT files merged per run (default $COMPACTION_MAX_FILES or 80)",
+    )
+    p.add_argument(
+        "--max-outputs-per-call",
+        type=_positive_int,
+        default=(
+            _positive_int(os.environ["COMPACTION_MAX_OUTPUTS_PER_CALL"])
+            if os.environ.get("COMPACTION_MAX_OUTPUTS_PER_CALL")
+            else None
+        ),
+        help=(
+            "Cap OUTPUT files per merge CALL/transaction (txn size ~ this x "
+            "target_file_size) and re-call each table until its grant is "
+            "consumed. Unset = legacy single-call-per-table behavior. "
+            "(default $COMPACTION_MAX_OUTPUTS_PER_CALL or unset)"
+        ),
     )
 
     # compact-probe
@@ -2487,6 +2569,7 @@ def main(argv: list[str] | None = None) -> None:
                     args.threads,
                     args.memory_limit,
                     args.max_compacted_files,
+                    max_outputs_per_call=args.max_outputs_per_call,
                 )
                 compact_tables_failed.labels(tier=str(args.tier)).set(n_failed)
             case "compact-probe":


### PR DESCRIPTION
## Problem

The fork CALL's `max_compacted_files =>` bounds **output files per call** (txn size ≈ outputs × target_file_size), while the tool's run budget accounts **input files consumed**. The megaduck source catalog can't commit one large merge txn inside its activeDeadline (documented DeadlineExceeded at 80 outputs ≈ 10 GB), so it runs `COMPACTION_MAX_FILES=10` — and its tier-3 backlog (**636K files / 19.8 TB**) converges at ~5 outputs per run, i.e. never.

## Change

New `--max-outputs-per-call` / `$COMPACTION_MAX_OUTPUTS_PER_CALL`:

- **Unset (default): byte-identical legacy** — one CALL per table with the whole grant (reviewer-verified path equivalence; pinned by tests).
- **Set**: each CALL capped at N outputs (min'd with the remaining grant — no txn ever exceeds what legacy would have issued) and the table is **re-called** until its grant/run-budget is consumed or a call produces nothing. Many small always-committable transactions per run. Applies to the single-table form too (review finding: a manual `compact --table X` in a pod with the env set must not silently issue the giant txn the knob exists to prevent).

## Hardening (from the adversarial review pair)

- **Progress guard**: result rows with zero inputs consumed fail the table loudly instead of re-issuing identical merge txns until the deadline kills the pod (termination otherwise rests on the fork invariant that merge groups have ≥2 inputs — verified in the current fork's `ducklake_compaction_functions.cpp`, guarded against drift).
- noop accounting: only a first-call empty counts as a no-op table; later empty = drained.
- Fixture supports per-call sequences + exception injection; tests cover mid-loop failure (progress kept, next table served), zero-input guard, single-table cap, budget interplay, env parsing (empty string = unset), env isolation for parser tests.

130 maintenance tests green (11 new); 672 suite-wide; ruff clean.

## Deployment (separate charts PR after release+promote)

Megaduck keeps its proven txn size via `COMPACTION_MAX_OUTPUTS_PER_CALL=10` and gets a raised input budget → ~15–20 small deadline-safe txns per run → tier-3 converges in days. Companion fleet change: PostHog/charts#13731.