### PR TITLE
feat: dual-write JSON property columns as DuckLake VARIANT

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Malformed JSON nulls only the VARIANT companion (the string column still lands).
 
 Degrades without crash-looping when dual-write cannot run cleanly:
 
-- Payload fields named `{name}_variant` are stripped non-fatally (`records_skipped_total{reason="variant_companion_collision"}`) so a poison key cannot evolve a VARCHAR companion or bind-conflict the INSERT.
+- Payload fields named `{name}_variant` (any casing — DuckDB identifiers are case-insensitive) are stripped non-fatally (`variant_companion_columns_dropped_total`; records still land minus the field) so a poison key cannot evolve a VARCHAR companion or bind-conflict the INSERT. Writers also strip any payload field whose *live* table column is VARIANT, so a pod whose `MILLPOND_VARIANT_COLUMNS` is unset or stale (mixed fleet) cannot corrupt a companion via the implicit VARCHAR→VARIANT cast. A batch left with zero columns by the strip is skipped whole (`records_skipped_total{reason="variant_companion_collision"}` — those records *are* lost and excluded from `records_written_total`) instead of crash-looping the partition.
 - If `{name}_variant` already exists as a non-VARIANT type, or ADD COLUMN fails, that source is omitted from the VARIANT projection (string column still writes); `errors_total{type="schema"}` is bumped. DuckLake cannot `ALTER VARCHAR → VARIANT`.
 
 This is an opt-in migration step: readers can move from `json_extract(properties, …)` to `properties_variant."$browser"` (etc.) once the companion is populated, then a later cutover can drop the string column if desired. Dual-write (new column) is the supported path for that reason.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,12 @@ For each listed source present in a batch, millpond:
 2. `ADD COLUMN IF NOT EXISTS {name}_variant VARIANT` on the DuckLake table
 3. Projects `try_cast(try_cast(col AS JSON) AS VARIANT) AS {name}_variant` on INSERT
 
-Malformed JSON nulls only the VARIANT companion (the string column still lands). DuckDB shreds VARIANT on Parquet write automatically — no millpond-side shredding config. Existing tables get the companion column via schema evolution on the first dual-write flush; historical rows keep a NULL companion until rewritten. If `{name}_variant` already exists as a non-VARIANT type, startup writes fail loud (DuckLake cannot `ALTER VARCHAR → VARIANT`).
+Malformed JSON nulls only the VARIANT companion (the string column still lands). DuckDB shreds VARIANT on Parquet write automatically — no millpond-side shredding config. Existing tables get the companion column via schema evolution on the first dual-write flush; historical rows keep a NULL companion until rewritten.
+
+Degrades without crash-looping when dual-write cannot run cleanly:
+
+- Payload fields named `{name}_variant` are stripped non-fatally (`records_skipped_total{reason="variant_companion_collision"}`) so a poison key cannot evolve a VARCHAR companion or bind-conflict the INSERT.
+- If `{name}_variant` already exists as a non-VARIANT type, or ADD COLUMN fails, that source is omitted from the VARIANT projection (string column still writes); `errors_total{type="schema"}` is bumped. DuckLake cannot `ALTER VARCHAR → VARIANT`.
 
 This is an opt-in migration step: readers can move from `json_extract(properties, …)` to `properties_variant."$browser"` (etc.) once the companion is populated, then a later cutover can drop the string column if desired. Dual-write (new column) is the supported path for that reason.
 

--- a/README.md
+++ b/README.md
@@ -147,9 +147,15 @@ For each listed source present in a batch, millpond:
 2. `ADD COLUMN IF NOT EXISTS {name}_variant VARIANT` on the DuckLake table
 3. Projects `try_cast(try_cast(col AS JSON) AS VARIANT) AS {name}_variant` on INSERT
 
-Malformed JSON nulls only the VARIANT companion (the string column still lands). DuckDB shreds VARIANT on Parquet write automatically — no millpond-side shredding config. Existing tables get the companion column via schema evolution on the first dual-write flush; historical rows keep a NULL companion until rewritten.
+Malformed JSON nulls only the VARIANT companion (the string column still lands). DuckDB shreds VARIANT on Parquet write automatically — no millpond-side shredding config. Existing tables get the companion column via schema evolution on the first dual-write flush; historical rows keep a NULL companion until rewritten. If `{name}_variant` already exists as a non-VARIANT type, startup writes fail loud (DuckLake cannot `ALTER VARCHAR → VARIANT`).
 
-This is an opt-in migration step: readers can move from `json_extract(properties, …)` to `properties_variant."$browser"` (etc.) once the companion is populated, then a later cutover can drop the string column if desired. DuckLake cannot `ALTER VARCHAR → VARIANT` in place, which is why dual-write (new column) is the supported path.
+This is an opt-in migration step: readers can move from `json_extract(properties, …)` to `properties_variant."$browser"` (etc.) once the companion is populated, then a later cutover can drop the string column if desired. Dual-write (new column) is the supported path for that reason.
+
+**Production caveats (canary first):**
+
+- **Key cardinality / shredding.** DuckDB auto-shreds VARIANT from the structure it sees at Parquet write time. PostHog-scale `properties` have a long tail of custom keys; a flush can produce very wide Parquet schemas (hundreds–thousands of shredded leaf fields). Prefer canarying on a filtered consumer or lower-cardinality table before enabling fleet-wide on `events`.
+- **Memory.** Dual-write keeps the VARCHAR column and materializes VARIANT at INSERT — peak flush memory is higher than string-only. Leave headroom vs `FLUSH_SIZE` and the pod limit when turning this on for large property blobs.
+- **Test coverage.** Unit/integration dual-write tests exercise the SQL cast and companion DDL against plain DuckDB; they do not exercise DuckLake catalog DDL, Parquet shredding, or data-inlining edge cases. Validate shredding and file shape on a real DuckLake canary before relying on query performance.
 
 ## Adaptive Backpressure
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,24 @@ Why those columns: date-times arrive as strings, so inference types them `VARCHA
 
 The timestamp wire format is space-separated, UTC implied, with 0, 3, or 6 fractional digits depending on column/producer (e.g. `2024-01-01 12:00:00.123`); all parse. Each cleanly-coerced column increments `millpond_columns_coerced_total{target_type=...}`. Coercion is **non-fatal and type-consistent**: a present, configured column is always emitted as the target type — values that can't be cast (a producer format/type drift) are **nulled** (only the unconvertible ones; good values in the batch are kept), never left as the source type. That keeps buffered batches concat-compatible at flush and bumps `millpond_errors_total{type="column_coercion"}` so the drift is loud via metrics, without crashing the pod or risking offset commits past unwritten records. Columns absent from a batch or already the target type are left untouched, so the same map is safe across heterogeneous batches.
 
+### VARIANT dual-write (JSON properties → shredded VARIANT)
+
+JSON property blobs (e.g. PostHog `properties`) land as VARCHAR today. `MILLPOND_VARIANT_COLUMNS` dual-writes listed source columns into companion VARIANT columns so DuckDB can auto-shred common sub-fields into typed Parquet columns, without dropping the original string:
+
+```
+MILLPOND_VARIANT_COLUMNS=properties,person_properties
+```
+
+For each listed source present in a batch, millpond:
+
+1. Keeps the original column as-is (VARCHAR JSON text)
+2. `ADD COLUMN IF NOT EXISTS {name}_variant VARIANT` on the DuckLake table
+3. Projects `try_cast(try_cast(col AS JSON) AS VARIANT) AS {name}_variant` on INSERT
+
+Malformed JSON nulls only the VARIANT companion (the string column still lands). DuckDB shreds VARIANT on Parquet write automatically — no millpond-side shredding config. Existing tables get the companion column via schema evolution on the first dual-write flush; historical rows keep a NULL companion until rewritten.
+
+This is an opt-in migration step: readers can move from `json_extract(properties, …)` to `properties_variant."$browser"` (etc.) once the companion is populated, then a later cutover can drop the string column if desired. DuckLake cannot `ALTER VARCHAR → VARIANT` in place, which is why dual-write (new column) is the supported path.
+
 ## Adaptive Backpressure
 
 The consume batch size automatically scales based on how full the pending buffer is relative to the flush threshold. When the buffer is empty, millpond consumes at full speed. As the buffer approaches the flush size, the batch size drops proportionally, smoothing throughput during catchup and traffic spikes. OOM prevention comes from bounding librdkafka's internal fetch buffer via `queued.max.messages.kbytes` (16MB per partition).
@@ -258,6 +276,7 @@ See [Record Handling](#record-handling) for context. All four variables below ar
 | `MILLPOND_INCLUDE_VALUES_AUTH_TOKEN` | no | | Header value. Must be set together with the header name. |
 | `MILLPOND_SORT_BY` | no | | Comma-separated column names; the batch is sorted ascending by these in tuple order before each write. Missing fields cause the sort to be skipped (records still flow). |
 | `MILLPOND_TYPED_COLUMNS` | no | | Comma-separated `column:type` pairs pinning columns to a target type before write (types: `timestamptz`, `bigint`, `double`, `boolean`, `varchar`). Needed when writing into a table whose columns are already typed and JSON inference would diverge (date-times → `VARCHAR` vs `TIMESTAMPTZ`; all-null `project_id` → `VARCHAR` vs `BIGINT`). Column names validated as safe identifiers; types validated against the allowlist. |
+| `MILLPOND_VARIANT_COLUMNS` | no | | Comma-separated source column names to dual-write as DuckLake `VARIANT` companions (`properties` → `properties_variant`). Original string columns are kept. Malformed JSON nulls only the VARIANT side. Column names validated as safe identifiers; names ending in `_variant` are rejected (list the source, not the derived column). |
 
 ## Releases
 

--- a/millpond/config.py
+++ b/millpond/config.py
@@ -4,7 +4,7 @@ import re
 from dataclasses import dataclass
 
 from millpond import arrow_converter
-from millpond.schema import VARIANT_COLUMN_SUFFIX
+from millpond.schema import SAFE_IDENTIFIER, VARIANT_COLUMN_SUFFIX
 
 _SAFE_TABLE_NAME = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
@@ -182,9 +182,6 @@ def _require(name: str) -> str:
     return val
 
 
-_SAFE_COLUMN_NAME = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
-
-
 def _parse_filter_values(raw: str) -> tuple[int, ...] | tuple[str, ...]:
     """Parse MILLPOND_FILTER_VALUES into a homogeneous tuple.
 
@@ -234,7 +231,7 @@ def _load_filter_fields() -> tuple[
         raise RuntimeError("MILLPOND_FILTER_DROP_VALUES must be set together with MILLPOND_FILTER_DROP_FIELD_NAME")
 
     for field in (keep, drop):
-        if field is not None and not _SAFE_COLUMN_NAME.match(field):
+        if field is not None and not SAFE_IDENTIFIER.match(field):
             raise RuntimeError(
                 f"Filter field name {field!r} contains unsafe characters (must match [a-zA-Z_][a-zA-Z0-9_]*)"
             )
@@ -332,26 +329,46 @@ def _load_include_values_config(
     )
 
 
-def _load_sort_by() -> tuple[str, ...] | None:
-    """Parse MILLPOND_SORT_BY into a tuple of column names.
+def _require_safe_column(env_name: str, name: str) -> None:
+    """Raise at startup when a configured column name is unsafe for generated SQL.
 
-    Comma-separated; whitespace trimmed; empty tokens dropped. Each name
-    must match the safe-identifier pattern (`[a-zA-Z_][a-zA-Z0-9_]*`) so
-    a misconfiguration surfaces at startup, not at the first flush.
-    Returns None when the env var is absent or whitespace-only.
+    Uses schema.SAFE_IDENTIFIER — the same gate the write path applies per
+    field — so a name accepted here can never be silently skipped at flush time.
     """
-    raw = os.environ.get("MILLPOND_SORT_BY", "").strip()
+    if not SAFE_IDENTIFIER.match(name):
+        raise RuntimeError(f"{env_name} column {name!r} contains unsafe characters (must match [a-zA-Z_][a-zA-Z0-9_]*)")
+
+
+def _parse_column_list(env_name: str) -> tuple[str, ...] | None:
+    """Parse a comma-separated env var into an ordered tuple of column names.
+
+    Whitespace trimmed; empty tokens dropped; duplicates de-duplicated (first
+    wins). Each name must match the safe-identifier pattern so a
+    misconfiguration surfaces at startup, not at the first flush. Returns None
+    when the env var is absent or whitespace-only.
+    """
+    raw = os.environ.get(env_name, "").strip()
     if not raw:
         return None
-    fields = tuple(t.strip() for t in raw.split(",") if t.strip())
-    if not fields:
+    seen: set[str] = set()
+    cols: list[str] = []
+    for token in raw.split(","):
+        name = token.strip()
+        if not name:
+            continue
+        _require_safe_column(env_name, name)
+        if name in seen:
+            continue
+        seen.add(name)
+        cols.append(name)
+    if not cols:
         return None
-    for field in fields:
-        if not _SAFE_COLUMN_NAME.match(field):
-            raise RuntimeError(
-                f"MILLPOND_SORT_BY field {field!r} contains unsafe characters (must match [a-zA-Z_][a-zA-Z0-9_]*)"
-            )
-    return fields
+    return tuple(cols)
+
+
+def _load_sort_by() -> tuple[str, ...] | None:
+    """Parse MILLPOND_SORT_BY into a tuple of column names."""
+    return _parse_column_list("MILLPOND_SORT_BY")
 
 
 def _load_typed_columns() -> tuple[tuple[str, str], ...] | None:
@@ -384,10 +401,7 @@ def _load_typed_columns() -> tuple[tuple[str, str], ...] | None:
             raise RuntimeError(f"MILLPOND_TYPED_COLUMNS entry {token!r} must be 'column:type'")
         name, _, type_name = token.partition(":")
         name, type_name = name.strip(), type_name.strip().lower()
-        if not _SAFE_COLUMN_NAME.match(name):
-            raise RuntimeError(
-                f"MILLPOND_TYPED_COLUMNS column {name!r} contains unsafe characters (must match [a-zA-Z_][a-zA-Z0-9_]*)"
-            )
+        _require_safe_column("MILLPOND_TYPED_COLUMNS", name)
         if type_name not in arrow_converter.COERCIBLE_TYPES:
             raise RuntimeError(
                 f"MILLPOND_TYPED_COLUMNS type {type_name!r} for column {name!r} must be one of "
@@ -415,38 +429,22 @@ def _load_variant_columns() -> tuple[str, ...] | None:
     injection-safe identifiers are mandatory. Returns None when the env var is
     absent/whitespace.
     """
-    raw = os.environ.get("MILLPOND_VARIANT_COLUMNS", "").strip()
-    if not raw:
+    cols = _parse_column_list("MILLPOND_VARIANT_COLUMNS")
+    if cols is None:
         return None
-
-    seen: set[str] = set()
-    cols: list[str] = []
-    for token in raw.split(","):
-        name = token.strip()
-        if not name:
-            continue
-        if not _SAFE_COLUMN_NAME.match(name):
-            raise RuntimeError(
-                f"MILLPOND_VARIANT_COLUMNS column {name!r} contains unsafe characters "
-                f"(must match [a-zA-Z_][a-zA-Z0-9_]*)"
-            )
+    for name in cols:
         # Reject names that already end in the dual-write suffix — the derived
         # column would be ``foo_variant_variant``, which is almost always a
         # misconfiguration (operator listed the sink column, not the source).
-        if name.endswith(VARIANT_COLUMN_SUFFIX):
+        # Case-insensitive: DuckDB resolves identifiers case-insensitively, so
+        # ``properties_VARIANT`` names the same sink column.
+        if name.lower().endswith(VARIANT_COLUMN_SUFFIX):
             raise RuntimeError(
                 f"MILLPOND_VARIANT_COLUMNS column {name!r} already ends with "
                 f"{VARIANT_COLUMN_SUFFIX!r}; list the source JSON/VARCHAR column "
                 f"(e.g. 'properties'), not the derived VARIANT column name"
             )
-        if name in seen:
-            continue
-        seen.add(name)
-        cols.append(name)
-
-    if not cols:
-        return None
-    return tuple(cols)
+    return cols
 
 
 _VALID_AUTO_OFFSET_RESET = ("earliest", "latest")

--- a/millpond/config.py
+++ b/millpond/config.py
@@ -4,6 +4,7 @@ import re
 from dataclasses import dataclass
 
 from millpond import arrow_converter
+from millpond.schema import VARIANT_COLUMN_SUFFIX
 
 _SAFE_TABLE_NAME = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
@@ -115,9 +116,10 @@ class Config:
 
     # Optional source column names to dual-write as DuckLake VARIANT columns.
     # Each listed column is kept as-is (typically VARCHAR JSON text) and also
-    # written to `{name}_variant` via try_cast(try_cast(col AS JSON) AS VARIANT).
-    # DuckDB auto-shreds VARIANT on Parquet write. None disables dual-write
-    # (default — existing consumers are unaffected). See ducklake.write.
+    # written to `{name}{VARIANT_COLUMN_SUFFIX}` via
+    # try_cast(try_cast(col AS JSON) AS VARIANT). DuckDB auto-shreds VARIANT
+    # on Parquet write. None disables dual-write (default — existing consumers
+    # are unaffected). See ducklake.write.
     variant_columns: tuple[str, ...] | None
 
     # Extra librdkafka config (from KAFKA_CONSUMER_* env vars)
@@ -409,8 +411,9 @@ def _load_variant_columns() -> tuple[str, ...] | None:
     Format: comma-separated column names, e.g. ``properties,person_properties``.
     Whitespace trimmed; empty tokens dropped; duplicates de-duplicated (first
     wins). Column names must match the safe-identifier pattern — each source is
-    dual-written to ``{name}_variant`` via generated SQL, so injection-safe
-    identifiers are mandatory. Returns None when the env var is absent/whitespace.
+    dual-written to ``{name}{VARIANT_COLUMN_SUFFIX}`` via generated SQL, so
+    injection-safe identifiers are mandatory. Returns None when the env var is
+    absent/whitespace.
     """
     raw = os.environ.get("MILLPOND_VARIANT_COLUMNS", "").strip()
     if not raw:
@@ -430,11 +433,11 @@ def _load_variant_columns() -> tuple[str, ...] | None:
         # Reject names that already end in the dual-write suffix — the derived
         # column would be ``foo_variant_variant``, which is almost always a
         # misconfiguration (operator listed the sink column, not the source).
-        if name.endswith("_variant"):
+        if name.endswith(VARIANT_COLUMN_SUFFIX):
             raise RuntimeError(
-                f"MILLPOND_VARIANT_COLUMNS column {name!r} already ends with '_variant'; "
-                f"list the source JSON/VARCHAR column (e.g. 'properties'), not the "
-                f"derived VARIANT column name"
+                f"MILLPOND_VARIANT_COLUMNS column {name!r} already ends with "
+                f"{VARIANT_COLUMN_SUFFIX!r}; list the source JSON/VARCHAR column "
+                f"(e.g. 'properties'), not the derived VARIANT column name"
             )
         if name in seen:
             continue
@@ -618,6 +621,6 @@ def load() -> Config:
     if cfg.variant_columns is not None:
         log.info(
             "Dual-write VARIANT columns: %s",
-            ", ".join(f"{n} -> {n}_variant" for n in cfg.variant_columns),
+            ", ".join(f"{n} -> {n}{VARIANT_COLUMN_SUFFIX}" for n in cfg.variant_columns),
         )
     return cfg

--- a/millpond/config.py
+++ b/millpond/config.py
@@ -113,6 +113,13 @@ class Config:
     # own freshly-created table is unaffected).
     typed_columns: tuple[tuple[str, str], ...] | None
 
+    # Optional source column names to dual-write as DuckLake VARIANT columns.
+    # Each listed column is kept as-is (typically VARCHAR JSON text) and also
+    # written to `{name}_variant` via try_cast(try_cast(col AS JSON) AS VARIANT).
+    # DuckDB auto-shreds VARIANT on Parquet write. None disables dual-write
+    # (default — existing consumers are unaffected). See ducklake.write.
+    variant_columns: tuple[str, ...] | None
+
     # Extra librdkafka config (from KAFKA_CONSUMER_* env vars)
     kafka_config_overrides: tuple[tuple[str, str], ...]
 
@@ -396,6 +403,49 @@ def _load_typed_columns() -> tuple[tuple[str, str], ...] | None:
     return tuple(pairs)
 
 
+def _load_variant_columns() -> tuple[str, ...] | None:
+    """Parse MILLPOND_VARIANT_COLUMNS into an ordered tuple of source column names.
+
+    Format: comma-separated column names, e.g. ``properties,person_properties``.
+    Whitespace trimmed; empty tokens dropped; duplicates de-duplicated (first
+    wins). Column names must match the safe-identifier pattern — each source is
+    dual-written to ``{name}_variant`` via generated SQL, so injection-safe
+    identifiers are mandatory. Returns None when the env var is absent/whitespace.
+    """
+    raw = os.environ.get("MILLPOND_VARIANT_COLUMNS", "").strip()
+    if not raw:
+        return None
+
+    seen: set[str] = set()
+    cols: list[str] = []
+    for token in raw.split(","):
+        name = token.strip()
+        if not name:
+            continue
+        if not _SAFE_COLUMN_NAME.match(name):
+            raise RuntimeError(
+                f"MILLPOND_VARIANT_COLUMNS column {name!r} contains unsafe characters "
+                f"(must match [a-zA-Z_][a-zA-Z0-9_]*)"
+            )
+        # Reject names that already end in the dual-write suffix — the derived
+        # column would be ``foo_variant_variant``, which is almost always a
+        # misconfiguration (operator listed the sink column, not the source).
+        if name.endswith("_variant"):
+            raise RuntimeError(
+                f"MILLPOND_VARIANT_COLUMNS column {name!r} already ends with '_variant'; "
+                f"list the source JSON/VARCHAR column (e.g. 'properties'), not the "
+                f"derived VARIANT column name"
+            )
+        if name in seen:
+            continue
+        seen.add(name)
+        cols.append(name)
+
+    if not cols:
+        return None
+    return tuple(cols)
+
+
 _VALID_AUTO_OFFSET_RESET = ("earliest", "latest")
 
 
@@ -508,6 +558,7 @@ def load() -> Config:
     filter_keep_field, filter_drop_field, filter_values, filter_drop_values = _load_filter_fields()
     sort_by = _load_sort_by()
     typed_columns = _load_typed_columns()
+    variant_columns = _load_variant_columns()
 
     cfg = Config(
         bootstrap_servers=_require("KAFKA_BOOTSTRAP_SERVERS"),
@@ -531,6 +582,7 @@ def load() -> Config:
         **_load_include_values_config(filter_keep_field, filter_values),
         sort_by=sort_by,
         typed_columns=typed_columns,
+        variant_columns=variant_columns,
         kafka_config_overrides=kafka_overrides,
         # No ``MILLPOND_`` prefix on POSTHOG_PROJECT_TOKEN: it's a
         # PostHog-wide secret typically sourced from a shared K8s Secret
@@ -563,4 +615,9 @@ def load() -> Config:
         log.info("Sort by: %s (ascending)", ", ".join(cfg.sort_by))
     if cfg.typed_columns is not None:
         log.info("Coerce typed columns: %s", ", ".join(f"{n}:{t}" for n, t in cfg.typed_columns))
+    if cfg.variant_columns is not None:
+        log.info(
+            "Dual-write VARIANT columns: %s",
+            ", ".join(f"{n} -> {n}_variant" for n in cfg.variant_columns),
+        )
     return cfg

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -70,15 +70,22 @@ def check_variant_column_collision(
         )
 
 
+def _quote_ident(name: str) -> str:
+    """Double-quote a DuckDB identifier, escaping embedded quotes."""
+    return '"' + name.replace('"', '""') + '"'
+
+
 def build_insert_select_sql(
     column_names: list[str],
     variant_columns: tuple[str, ...] | None,
 ) -> str:
     """Build the SELECT list for ``INSERT ... BY NAME (SELECT ... FROM batch)``.
 
-    Always projects every batch column by name plus ``NOW() AS _inserted_at``.
-    For each name in ``variant_columns`` that is present in ``column_names``,
-    also projects a companion VARIANT column:
+    When no dual-write companions are projected this batch, returns the
+    historical shape ``*, NOW() AS _inserted_at`` so opt-in VARIANT dual-write
+    does not rewrite every writer's INSERT. When at least one configured
+    source is present, expands an explicit column list and, for each active
+    source, also projects a companion VARIANT column:
 
         try_cast(try_cast("properties" AS JSON) AS VARIANT) AS "properties_variant"
 
@@ -90,22 +97,19 @@ def build_insert_select_sql(
     default / absent-from-INSERT BY NAME behavior.
     """
     active = frozenset(variant_columns or ())
-    present = set(column_names)
+    dual_write_sources = [name for name in column_names if name in active and SAFE_IDENTIFIER.match(name) is not None]
+    if not dual_write_sources:
+        return "*, NOW() AS _inserted_at"
+
     parts: list[str] = []
     for name in column_names:
-        # Identifiers are double-quoted. Unsafe names (non-SAFE_IDENTIFIER) can
-        # still appear in the batch — CREATE TABLE AS copies them, and SELECT *
-        # historically included them. Quoting keeps the projection equivalent.
-        parts.append(f'"{name}"')
-        if name in active and name in present:
-            # Only dual-write when the source name is SQL-safe: the derived
-            # companion is added via ADD COLUMN with the same identifier rules
-            # SchemaManager uses, and an unsafe source cannot be a configured
-            # variant column (config rejects non-SAFE names at load).
-            if not SAFE_IDENTIFIER.match(name):
-                continue
+        parts.append(_quote_ident(name))
+        if name in active and SAFE_IDENTIFIER.match(name):
+            # Config rejects non-SAFE names at load; double-check here so a
+            # mis-wired caller cannot inject an unsafe identifier into SQL.
             vname = variant_column_name(name)
-            parts.append(f'try_cast(try_cast("{name}" AS JSON) AS VARIANT) AS "{vname}"')
+            qname = _quote_ident(name)
+            parts.append(f"try_cast(try_cast({qname} AS JSON) AS VARIANT) AS {_quote_ident(vname)}")
     parts.append("NOW() AS _inserted_at")
     return ", ".join(parts)
 
@@ -306,47 +310,22 @@ def write(
     """
     check_reserved_collision(batch.schema, RESERVED_COLUMNS)
     check_variant_column_collision(batch.schema, variant_columns)
+    if variant_columns and schema_mgr is None:
+        # Dual-write requires SchemaManager for ADD COLUMN + fail-loud type
+        # checks. DuckLakeSink always supplies one; module-level callers that
+        # enable dual-write must too (no divergent raw DDL path).
+        raise ValueError("VARIANT dual-write requires a SchemaManager (schema_mgr is None)")
     _ensure_table(conn, table_name, batch, tables_ensured, partition_by, schema_name)
     if schema_mgr is not None:
         schema_mgr.evolve(batch.schema)
         if variant_columns:
             schema_mgr.ensure_variant_columns(variant_columns, set(batch.schema.names))
-    elif variant_columns:
-        # No SchemaManager: still need the VARIANT companion columns to exist
-        # before INSERT BY NAME, otherwise DuckDB rejects unknown targets.
-        # Callers that pass variant_columns without a schema_mgr (tests,
-        # one-shot scripts) get a best-effort ADD COLUMN here; production
-        # always goes through DuckLakeSink which owns a SchemaManager.
-        _ensure_variant_columns_raw(conn, table_name, schema_name, variant_columns, set(batch.schema.names))
     select_list = build_insert_select_sql(list(batch.schema.names), variant_columns)
     conn.register("_arrow_batch", batch)
     try:
         conn.execute(f"INSERT INTO lake.{schema_name}.{table_name} BY NAME (SELECT {select_list} FROM _arrow_batch)")
     finally:
         conn.unregister("_arrow_batch")
-
-
-def _ensure_variant_columns_raw(
-    conn: duckdb.DuckDBPyConnection,
-    table_name: str,
-    schema_name: str,
-    variant_columns: tuple[str, ...],
-    present_source_names: set[str],
-) -> None:
-    """ADD COLUMN IF NOT EXISTS for VARIANT companions without a SchemaManager.
-
-    Production uses SchemaManager.ensure_variant_columns (which also keeps the
-    type cache coherent). This path exists so the module-level write() helper
-    stays usable in tests that skip SchemaManager.
-    """
-    for source in variant_columns:
-        if source not in present_source_names or not SAFE_IDENTIFIER.match(source):
-            continue
-        vname = variant_column_name(source)
-        try:
-            conn.execute(f'ALTER TABLE lake.{schema_name}.{table_name} ADD COLUMN IF NOT EXISTS "{vname}" VARIANT')
-        except duckdb.Error as e:
-            log.warning("Failed to add VARIANT column %s: %s", vname, e)
 
 
 class DuckLakeSink:

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -7,7 +7,7 @@ import re
 import duckdb
 import pyarrow as pa
 
-from millpond import schema
+from millpond import metrics, schema
 from millpond.config import Config
 from millpond.schema import SAFE_IDENTIFIER, variant_column_name
 
@@ -41,33 +41,41 @@ def check_reserved_collision(batch_schema: pa.Schema, reserved: frozenset[str]) 
         )
 
 
-def check_variant_column_collision(
-    batch_schema: pa.Schema,
-    variant_columns: tuple[str, ...] | None,
-) -> None:
-    """Raise if dual-write would collide with a source column name.
-
-    For each configured source column present in the batch, the write path
-    projects ``{source}_variant``. If the batch already carries that name,
-    INSERT BY NAME would either overwrite the source field's identity or
-    produce a duplicate select-list alias — fail loud instead.
-    """
+def variant_companion_names(variant_columns: tuple[str, ...] | None) -> frozenset[str]:
+    """Sink-managed companion names for a dual-write config (e.g. properties_variant)."""
     if not variant_columns:
-        return
-    names = set(batch_schema.names)
-    collisions: list[str] = []
-    for source in variant_columns:
-        if source not in names:
-            continue
-        derived = variant_column_name(source)
-        if derived in names:
-            collisions.append(derived)
-    if collisions:
-        raise ValueError(
-            f"Source schema column(s) {sorted(collisions)!r} collide with "
-            f"VARIANT dual-write target names; rename them upstream or remove "
-            f"the source from MILLPOND_VARIANT_COLUMNS."
+        return frozenset()
+    return frozenset(variant_column_name(s) for s in variant_columns)
+
+
+def drop_variant_companion_columns(
+    batch: pa.Table,
+    variant_columns: tuple[str, ...] | None,
+) -> pa.Table:
+    """Strip sink-managed ``{source}_variant`` columns from the batch non-fatally.
+
+    Kafka payloads can carry a literal ``properties_variant`` key. Leaving it in
+    the batch would let evolve() ADD it as VARCHAR (silent corruption when a
+    later dual-write projects VARIANT into it) or collide with the INSERT
+    projection (crash loop). Drop companions before ensure_table/evolve/insert;
+    keep dual-writing from the real source column when present. Bumps
+    ``records_skipped_total{reason="variant_companion_collision"}`` once per
+    dropped field name (same cadence as ``unsafe_field_name``).
+    """
+    companions = variant_companion_names(variant_columns)
+    if not companions:
+        return batch
+    drop = [n for n in batch.schema.names if n in companions]
+    if not drop:
+        return batch
+    for name in drop:
+        log.warning(
+            "Dropping source column %r that collides with a VARIANT dual-write "
+            "target; dual-write continues from the configured source when present",
+            name,
         )
+        metrics.records_skipped_total.labels(reason="variant_companion_collision").inc()
+    return batch.drop_columns(drop)
 
 
 def _quote_ident(name: str) -> str:
@@ -83,21 +91,18 @@ def build_insert_select_sql(
 
     When no dual-write companions are projected this batch, returns the
     historical shape ``*, NOW() AS _inserted_at`` so opt-in VARIANT dual-write
-    does not rewrite every writer's INSERT. When at least one configured
-    source is present, expands an explicit column list and, for each active
-    source, also projects a companion VARIANT column:
+    does not rewrite every writer's INSERT. When at least one source is in
+    ``variant_columns`` (the *ready* set from ensure_variant_columns), expands
+    an explicit column list and projects companions:
 
         try_cast(try_cast("properties" AS JSON) AS VARIANT) AS "properties_variant"
 
-    ``try_cast`` (not hard cast) so one malformed JSON value nulls only that
-    cell rather than failing the whole flush — the original string column is
-    still written, so no data is lost. Columns listed in ``variant_columns``
-    but absent from this batch are skipped (heterogeneous batches / schema
-    drift); the companion column stays NULL for those rows via the table
-    default / absent-from-INSERT BY NAME behavior.
+    Identifiers are quote-escaped (``"`` → ``""``) so a Kafka key containing a
+    quote cannot break the INSERT or inject SQL. ``try_cast`` nulls malformed
+    JSON on the VARIANT side only; the original string column still lands.
     """
     active = frozenset(variant_columns or ())
-    dual_write_sources = [name for name in column_names if name in active and SAFE_IDENTIFIER.match(name) is not None]
+    dual_write_sources = [name for name in column_names if name in active and SAFE_IDENTIFIER.match(name)]
     if not dual_write_sources:
         return "*, NOW() AS _inserted_at"
 
@@ -105,8 +110,6 @@ def build_insert_select_sql(
     for name in column_names:
         parts.append(_quote_ident(name))
         if name in active and SAFE_IDENTIFIER.match(name):
-            # Config rejects non-SAFE names at load; double-check here so a
-            # mis-wired caller cannot inject an unsafe identifier into SQL.
             vname = variant_column_name(name)
             qname = _quote_ident(name)
             parts.append(f"try_cast(try_cast({qname} AS JSON) AS VARIANT) AS {_quote_ident(vname)}")
@@ -307,20 +310,29 @@ def write(
     batch is dual-written: the original column is kept as-is, and a companion
     ``{name}_variant`` column receives ``try_cast(try_cast(col AS JSON) AS
     VARIANT)``. DuckDB auto-shreds VARIANT sub-fields on Parquet write.
+
+    Dual-write is best-effort per source: companions that cannot be ensured as
+    VARIANT are omitted from the INSERT projection (string column still lands).
+    Payload fields named like dual-write targets are stripped non-fatally so a
+    poison key cannot crash-loop the partition or poison the table as VARCHAR.
     """
     check_reserved_collision(batch.schema, RESERVED_COLUMNS)
-    check_variant_column_collision(batch.schema, variant_columns)
     if variant_columns and schema_mgr is None:
-        # Dual-write requires SchemaManager for ADD COLUMN + fail-loud type
-        # checks. DuckLakeSink always supplies one; module-level callers that
-        # enable dual-write must too (no divergent raw DDL path).
+        # Dual-write requires SchemaManager for ADD COLUMN + type checks.
+        # DuckLakeSink always supplies one; module-level callers that enable
+        # dual-write must too (no divergent raw DDL path).
         raise ValueError("VARIANT dual-write requires a SchemaManager (schema_mgr is None)")
+    # Drop sink-managed companion names before CREATE/evolve so a Kafka key
+    # named properties_variant cannot land as VARCHAR or collide on INSERT.
+    batch = drop_variant_companion_columns(batch, variant_columns)
     _ensure_table(conn, table_name, batch, tables_ensured, partition_by, schema_name)
+    ready_sources: tuple[str, ...] | None = None
     if schema_mgr is not None:
         schema_mgr.evolve(batch.schema)
         if variant_columns:
-            schema_mgr.ensure_variant_columns(variant_columns, set(batch.schema.names))
-    select_list = build_insert_select_sql(list(batch.schema.names), variant_columns)
+            ready = schema_mgr.ensure_variant_columns(variant_columns, set(batch.schema.names))
+            ready_sources = tuple(s for s in variant_columns if s in ready) or None
+    select_list = build_insert_select_sql(list(batch.schema.names), ready_sources)
     conn.register("_arrow_batch", batch)
     try:
         conn.execute(f"INSERT INTO lake.{schema_name}.{table_name} BY NAME (SELECT {select_list} FROM _arrow_batch)")

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -9,7 +9,7 @@ import pyarrow as pa
 
 from millpond import metrics, schema
 from millpond.config import Config
-from millpond.schema import SAFE_IDENTIFIER, variant_column_name
+from millpond.schema import variant_column_name
 
 log = logging.getLogger(__name__)
 
@@ -31,6 +31,11 @@ def check_reserved_collision(batch_schema: pa.Schema, reserved: frozenset[str]) 
     append step explodes deep in the stack (duplicate column on the
     post-write projection). Catch it at the top of `write()` with a
     clear message instead.
+
+    Deliberately fatal, unlike the non-fatal VARIANT companion drops in
+    _drop_protected_columns: silently dropping a payload `_inserted_at` would
+    re-stamp replayed data and change its partition placement, which the
+    reserved-columns contract predating dual-write chose to surface loudly.
     """
     collisions = sorted(name for name in batch_schema.names if name in reserved)
     if collisions:
@@ -41,31 +46,23 @@ def check_reserved_collision(batch_schema: pa.Schema, reserved: frozenset[str]) 
         )
 
 
-def variant_companion_names(variant_columns: tuple[str, ...] | None) -> frozenset[str]:
-    """Sink-managed companion names for a dual-write config (e.g. properties_variant)."""
-    if not variant_columns:
-        return frozenset()
-    return frozenset(variant_column_name(s) for s in variant_columns)
+def _drop_protected_columns(batch: pa.Table, protected_lower: frozenset[str] | set[str]) -> pa.Table:
+    """Drop batch columns whose lowercased name is a sink-managed VARIANT target.
 
+    Matching is case-insensitive because DuckDB resolves identifiers
+    case-insensitively — a ``PROPERTIES_VARIANT`` key would land in the same
+    catalog column as ``properties_variant``. Bumps
+    ``variant_companion_columns_dropped_total`` once per dropped field name
+    (records still land, so this is not a ``records_skipped_total`` reason).
 
-def drop_variant_companion_columns(
-    batch: pa.Table,
-    variant_columns: tuple[str, ...] | None,
-) -> pa.Table:
-    """Strip sink-managed ``{source}_variant`` columns from the batch non-fatally.
-
-    Kafka payloads can carry a literal ``properties_variant`` key. Leaving it in
-    the batch would let evolve() ADD it as VARCHAR (silent corruption when a
-    later dual-write projects VARIANT into it) or collide with the INSERT
-    projection (crash loop). Drop companions before ensure_table/evolve/insert;
-    keep dual-writing from the real source column when present. Bumps
-    ``records_skipped_total{reason="variant_companion_collision"}`` once per
-    dropped field name (same cadence as ``unsafe_field_name``).
+    NB: reserved metadata names (``_inserted_at``, ``year``…) deliberately do
+    NOT go through this drop path — check_reserved_collision keeps its fatal
+    policy because silently re-stamping ``_inserted_at`` on replayed data would
+    change partition placement; that trade-off predates dual-write.
     """
-    companions = variant_companion_names(variant_columns)
-    if not companions:
+    if not protected_lower:
         return batch
-    drop = [n for n in batch.schema.names if n in companions]
+    drop = [n for n in batch.schema.names if n.lower() in protected_lower]
     if not drop:
         return batch
     for name in drop:
@@ -74,8 +71,26 @@ def drop_variant_companion_columns(
             "target; dual-write continues from the configured source when present",
             name,
         )
-        metrics.records_skipped_total.labels(reason="variant_companion_collision").inc()
+        metrics.variant_companion_columns_dropped_total.inc()
     return batch.drop_columns(drop)
+
+
+def drop_variant_companion_columns(
+    batch: pa.Table,
+    variant_columns: tuple[str, ...] | None,
+) -> pa.Table:
+    """Strip config-managed ``{source}_variant`` columns from the batch non-fatally.
+
+    Kafka payloads can carry a literal ``properties_variant`` key. Leaving it in
+    the batch would let evolve() ADD it as VARCHAR (silent corruption when a
+    later dual-write projects VARIANT into it) or collide with the INSERT
+    projection (crash loop). Drop companions before ensure_table/evolve/insert;
+    keep dual-writing from the real source column when present. write() also
+    drops any column whose *live* table type is VARIANT, protecting writers
+    whose local config is absent or stale (mixed fleet).
+    """
+    protected = {variant_column_name(s).lower() for s in variant_columns or ()}
+    return _drop_protected_columns(batch, protected)
 
 
 def _quote_ident(name: str) -> str:
@@ -97,20 +112,29 @@ def build_insert_select_sql(
 
         try_cast(try_cast("properties" AS JSON) AS VARIANT) AS "properties_variant"
 
-    Identifiers are quote-escaped (``"`` → ``""``) so a Kafka key containing a
-    quote cannot break the INSERT or inject SQL. ``try_cast`` nulls malformed
-    JSON on the VARIANT side only; the original string column still lands.
+    Source matching is case-insensitive (DuckDB resolves identifiers
+    case-insensitively, so a ``Properties`` batch column feeds the same catalog
+    column as configured ``properties``); the companion alias always uses the
+    configured source's casing, projected at most once per source. Identifiers
+    are quote-escaped (``"`` → ``""``) so a Kafka key containing a quote cannot
+    break the INSERT or inject SQL — the sole gate on these names, which is why
+    no SAFE_IDENTIFIER filter re-runs here: silently dropping a ready source
+    would leave a permanently-NULL companion with no signal. ``try_cast`` nulls
+    malformed JSON on the VARIANT side only; the original string column still
+    lands.
     """
-    active = frozenset(variant_columns or ())
-    dual_write_sources = [name for name in column_names if name in active and SAFE_IDENTIFIER.match(name)]
-    if not dual_write_sources:
+    active = {s.lower(): s for s in (variant_columns or ())}
+    if not any(name.lower() in active for name in column_names):
         return "*, NOW() AS _inserted_at"
 
     parts: list[str] = []
+    projected: set[str] = set()
     for name in column_names:
         parts.append(_quote_ident(name))
-        if name in active and SAFE_IDENTIFIER.match(name):
-            vname = variant_column_name(name)
+        source = active.get(name.lower())
+        if source is not None and source not in projected:
+            projected.add(source)
+            vname = variant_column_name(source)
             qname = _quote_ident(name)
             parts.append(f"try_cast(try_cast({qname} AS JSON) AS VARIANT) AS {_quote_ident(vname)}")
     parts.append("NOW() AS _inserted_at")
@@ -303,8 +327,11 @@ def write(
     partition_by: str | None = None,
     schema_name: str = "main",
     variant_columns: tuple[str, ...] | None = None,
-) -> None:
+) -> int:
     """Write an Arrow table to DuckLake with _inserted_at timestamp.
+
+    Returns the number of records actually written (0 when the batch is
+    skipped whole) so callers can keep records_written_total honest.
 
     When ``variant_columns`` is set, each listed source column present in the
     batch is dual-written: the original column is kept as-is, and a companion
@@ -324,7 +351,30 @@ def write(
         raise ValueError("VARIANT dual-write requires a SchemaManager (schema_mgr is None)")
     # Drop sink-managed companion names before CREATE/evolve so a Kafka key
     # named properties_variant cannot land as VARCHAR or collide on INSERT.
+    had_columns = batch.num_columns > 0
     batch = drop_variant_companion_columns(batch, variant_columns)
+    if schema_mgr is not None:
+        # Also drop any column whose *live* table type is VARIANT. Only the
+        # sink creates VARIANT columns (evolve maps nested Arrow types to
+        # JSON), so every VARIANT column is sink-managed. This protects
+        # writers whose variant_columns config is absent or stale (mixed
+        # fleet): INSERT BY NAME would otherwise implicitly cast the raw JSON
+        # text into a string-wrapped variant — silent corruption invisible to
+        # `companion.field` queries.
+        batch = _drop_protected_columns(batch, schema_mgr.live_variant_column_names())
+    if had_columns and batch.num_columns == 0:
+        # Every field was a companion collision (poison producer). SELECT *
+        # over a zero-column relation errors, so skip the flush instead of
+        # crash-looping the partition on the same batch. These records ARE
+        # lost, hence records_skipped_total (unlike the per-column drops).
+        # Gated on had_columns: a batch that arrives with zero columns did
+        # not collide with anything and must keep failing loudly below.
+        log.warning(
+            "Skipping batch of %d record(s): all columns collided with VARIANT dual-write targets",
+            batch.num_rows,
+        )
+        metrics.records_skipped_total.labels(reason="variant_companion_collision").inc(batch.num_rows)
+        return 0
     _ensure_table(conn, table_name, batch, tables_ensured, partition_by, schema_name)
     ready_sources: tuple[str, ...] | None = None
     if schema_mgr is not None:
@@ -338,6 +388,7 @@ def write(
         conn.execute(f"INSERT INTO lake.{schema_name}.{table_name} BY NAME (SELECT {select_list} FROM _arrow_batch)")
     finally:
         conn.unregister("_arrow_batch")
+    return batch.num_rows
 
 
 class DuckLakeSink:
@@ -384,8 +435,8 @@ class DuckLakeSink:
         self._schema_mgr = schema.SchemaManager(self._conn, self._table_name, self._schema_name)
         self._variant_columns = cfg.variant_columns
 
-    def write(self, batch: pa.Table) -> None:
-        write(
+    def write(self, batch: pa.Table) -> int:
+        return write(
             self._conn,
             self._table_name,
             batch,

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -9,6 +9,7 @@ import pyarrow as pa
 
 from millpond import schema
 from millpond.config import Config
+from millpond.schema import SAFE_IDENTIFIER, variant_column_name
 
 log = logging.getLogger(__name__)
 
@@ -38,6 +39,75 @@ def check_reserved_collision(batch_schema: pa.Schema, reserved: frozenset[str]) 
             f"DuckLake-reserved metadata column names; rename them "
             f"upstream or filter them out before write()."
         )
+
+
+def check_variant_column_collision(
+    batch_schema: pa.Schema,
+    variant_columns: tuple[str, ...] | None,
+) -> None:
+    """Raise if dual-write would collide with a source column name.
+
+    For each configured source column present in the batch, the write path
+    projects ``{source}_variant``. If the batch already carries that name,
+    INSERT BY NAME would either overwrite the source field's identity or
+    produce a duplicate select-list alias — fail loud instead.
+    """
+    if not variant_columns:
+        return
+    names = set(batch_schema.names)
+    collisions: list[str] = []
+    for source in variant_columns:
+        if source not in names:
+            continue
+        derived = variant_column_name(source)
+        if derived in names:
+            collisions.append(derived)
+    if collisions:
+        raise ValueError(
+            f"Source schema column(s) {sorted(collisions)!r} collide with "
+            f"VARIANT dual-write target names; rename them upstream or remove "
+            f"the source from MILLPOND_VARIANT_COLUMNS."
+        )
+
+
+def build_insert_select_sql(
+    column_names: list[str],
+    variant_columns: tuple[str, ...] | None,
+) -> str:
+    """Build the SELECT list for ``INSERT ... BY NAME (SELECT ... FROM batch)``.
+
+    Always projects every batch column by name plus ``NOW() AS _inserted_at``.
+    For each name in ``variant_columns`` that is present in ``column_names``,
+    also projects a companion VARIANT column:
+
+        try_cast(try_cast("properties" AS JSON) AS VARIANT) AS "properties_variant"
+
+    ``try_cast`` (not hard cast) so one malformed JSON value nulls only that
+    cell rather than failing the whole flush — the original string column is
+    still written, so no data is lost. Columns listed in ``variant_columns``
+    but absent from this batch are skipped (heterogeneous batches / schema
+    drift); the companion column stays NULL for those rows via the table
+    default / absent-from-INSERT BY NAME behavior.
+    """
+    active = frozenset(variant_columns or ())
+    present = set(column_names)
+    parts: list[str] = []
+    for name in column_names:
+        # Identifiers are double-quoted. Unsafe names (non-SAFE_IDENTIFIER) can
+        # still appear in the batch — CREATE TABLE AS copies them, and SELECT *
+        # historically included them. Quoting keeps the projection equivalent.
+        parts.append(f'"{name}"')
+        if name in active and name in present:
+            # Only dual-write when the source name is SQL-safe: the derived
+            # companion is added via ADD COLUMN with the same identifier rules
+            # SchemaManager uses, and an unsafe source cannot be a configured
+            # variant column (config rejects non-SAFE names at load).
+            if not SAFE_IDENTIFIER.match(name):
+                continue
+            vname = variant_column_name(name)
+            parts.append(f'try_cast(try_cast("{name}" AS JSON) AS VARIANT) AS "{vname}"')
+    parts.append("NOW() AS _inserted_at")
+    return ", ".join(parts)
 
 
 def _escape_libpq(value: str | None) -> str:
@@ -225,19 +295,58 @@ def write(
     schema_mgr: schema.SchemaManager | None = None,
     partition_by: str | None = None,
     schema_name: str = "main",
+    variant_columns: tuple[str, ...] | None = None,
 ) -> None:
-    """Write an Arrow table to DuckLake with _inserted_at timestamp."""
+    """Write an Arrow table to DuckLake with _inserted_at timestamp.
+
+    When ``variant_columns`` is set, each listed source column present in the
+    batch is dual-written: the original column is kept as-is, and a companion
+    ``{name}_variant`` column receives ``try_cast(try_cast(col AS JSON) AS
+    VARIANT)``. DuckDB auto-shreds VARIANT sub-fields on Parquet write.
+    """
     check_reserved_collision(batch.schema, RESERVED_COLUMNS)
+    check_variant_column_collision(batch.schema, variant_columns)
     _ensure_table(conn, table_name, batch, tables_ensured, partition_by, schema_name)
     if schema_mgr is not None:
         schema_mgr.evolve(batch.schema)
+        if variant_columns:
+            schema_mgr.ensure_variant_columns(variant_columns, set(batch.schema.names))
+    elif variant_columns:
+        # No SchemaManager: still need the VARIANT companion columns to exist
+        # before INSERT BY NAME, otherwise DuckDB rejects unknown targets.
+        # Callers that pass variant_columns without a schema_mgr (tests,
+        # one-shot scripts) get a best-effort ADD COLUMN here; production
+        # always goes through DuckLakeSink which owns a SchemaManager.
+        _ensure_variant_columns_raw(conn, table_name, schema_name, variant_columns, set(batch.schema.names))
+    select_list = build_insert_select_sql(list(batch.schema.names), variant_columns)
     conn.register("_arrow_batch", batch)
     try:
-        conn.execute(
-            f"INSERT INTO lake.{schema_name}.{table_name} BY NAME (SELECT *, NOW() AS _inserted_at FROM _arrow_batch)"
-        )
+        conn.execute(f"INSERT INTO lake.{schema_name}.{table_name} BY NAME (SELECT {select_list} FROM _arrow_batch)")
     finally:
         conn.unregister("_arrow_batch")
+
+
+def _ensure_variant_columns_raw(
+    conn: duckdb.DuckDBPyConnection,
+    table_name: str,
+    schema_name: str,
+    variant_columns: tuple[str, ...],
+    present_source_names: set[str],
+) -> None:
+    """ADD COLUMN IF NOT EXISTS for VARIANT companions without a SchemaManager.
+
+    Production uses SchemaManager.ensure_variant_columns (which also keeps the
+    type cache coherent). This path exists so the module-level write() helper
+    stays usable in tests that skip SchemaManager.
+    """
+    for source in variant_columns:
+        if source not in present_source_names or not SAFE_IDENTIFIER.match(source):
+            continue
+        vname = variant_column_name(source)
+        try:
+            conn.execute(f'ALTER TABLE lake.{schema_name}.{table_name} ADD COLUMN IF NOT EXISTS "{vname}" VARIANT')
+        except duckdb.Error as e:
+            log.warning("Failed to add VARIANT column %s: %s", vname, e)
 
 
 class DuckLakeSink:
@@ -282,6 +391,7 @@ class DuckLakeSink:
         self._partition_by = cfg.partition_by
         self._tables_ensured: set[str] = set()
         self._schema_mgr = schema.SchemaManager(self._conn, self._table_name, self._schema_name)
+        self._variant_columns = cfg.variant_columns
 
     def write(self, batch: pa.Table) -> None:
         write(
@@ -292,6 +402,7 @@ class DuckLakeSink:
             self._schema_mgr,
             self._partition_by,
             self._schema_name,
+            self._variant_columns,
         )
 
     def reset_caches(self) -> None:

--- a/millpond/main.py
+++ b/millpond/main.py
@@ -294,11 +294,14 @@ def _is_commit_contention(exc: BaseException) -> bool:
 
 
 def _write_with_retry(sink, consolidated):
-    """Write to the sink with exponential backoff on transient failures."""
+    """Write to the sink with exponential backoff on transient failures.
+
+    Returns the record count the sink actually wrote (0 when it skipped the
+    batch whole, e.g. every column was a VARIANT companion collision).
+    """
     for attempt in range(_WRITE_MAX_RETRIES):
         try:
-            sink.write(consolidated)
-            return
+            return sink.write(consolidated)
         except Exception as exc:
             error_type = "ducklake_commit_contention" if _is_commit_contention(exc) else "write_retry"
             metrics.errors_total.labels(type=error_type).inc()
@@ -334,7 +337,7 @@ def _flush(
     consolidated = _apply_sort(consolidated, cfg)
 
     t0 = time.monotonic()
-    _write_with_retry(sink, consolidated)
+    records_written = _write_with_retry(sink, consolidated)
     write_duration = time.monotonic() - t0
 
     # Commit offsets synchronously — at-least-once requires knowing commit succeeded
@@ -377,7 +380,9 @@ def _flush(
     metrics.flush_duration_seconds.observe(write_duration)
     metrics.flush_size_bytes.observe(pending_bytes)
     metrics.flush_size_records.observe(pending_records)
-    metrics.records_written_total.inc(pending_records)
+    # The sink's count, not pending_records: a skipped batch (all columns
+    # were companion collisions) is records_skipped, not records_written.
+    metrics.records_written_total.inc(records_written)
     metrics.batches_flushed_total.labels(trigger=trigger).inc()
     server.health.record_flush()
 

--- a/millpond/metrics.py
+++ b/millpond/metrics.py
@@ -185,6 +185,15 @@ _columns_coerced_total = Counter(
     "Columns pinned to a target type before write",
     ["pipeline", "broker_source", "target_type"],
 )
+# Counts payload columns stripped because they collide with a sink-managed
+# VARIANT dual-write companion name. Counts column-drop events per flush,
+# not records — the records themselves still land (minus the field), so
+# this is deliberately not a `records_skipped_total` reason.
+_variant_companion_columns_dropped_total = Counter(
+    "millpond_variant_companion_columns_dropped_total",
+    "Payload columns dropped for colliding with a VARIANT dual-write companion",
+    ["pipeline", "broker_source"],
+)
 
 # librdkafka internal stats (via statistics.interval.ms callback)
 _rdkafka_replyq = Gauge(
@@ -234,6 +243,7 @@ schema_columns_added_total = _schema_columns_added_total
 schema_columns_widened_total = _schema_columns_widened_total
 sort_skipped_total = _sort_skipped_total
 columns_coerced_total = _columns_coerced_total
+variant_companion_columns_dropped_total = _variant_companion_columns_dropped_total
 include_values_size = _include_values_size
 include_values_last_success_timestamp_seconds = _include_values_last_success_timestamp_seconds
 include_values_pending_removals = _include_values_pending_removals
@@ -260,7 +270,7 @@ def init(pipeline: str, broker_source: str = ""):
     global flush_size_bytes, flush_size_records
     global pending_bytes, buffer_fullness, consume_batch_size_current, consumer_lag, last_committed_offset
     global schema_columns_added_total, schema_columns_widened_total, sort_skipped_total
-    global columns_coerced_total
+    global columns_coerced_total, variant_companion_columns_dropped_total
     global include_values_size, include_values_last_success_timestamp_seconds
     global include_values_pending_removals, include_values_poll_failures_total
     global include_values_refused_total, include_values_changes_total, include_values_mode
@@ -309,6 +319,9 @@ def init(pipeline: str, broker_source: str = ""):
     consume_batch_size_current = _consume_batch_size_current.labels(pipeline=pipeline, broker_source=bs)
     schema_columns_added_total = _schema_columns_added_total.labels(pipeline=pipeline, broker_source=bs)
     schema_columns_widened_total = _schema_columns_widened_total.labels(pipeline=pipeline, broker_source=bs)
+    variant_companion_columns_dropped_total = _variant_companion_columns_dropped_total.labels(
+        pipeline=pipeline, broker_source=bs
+    )
     rdkafka_replyq = _rdkafka_replyq.labels(pipeline=pipeline, broker_source=bs)
     rdkafka_msg_cnt = _rdkafka_msg_cnt.labels(pipeline=pipeline, broker_source=bs)
     rdkafka_msg_size = _rdkafka_msg_size.labels(pipeline=pipeline, broker_source=bs)

--- a/millpond/schema.py
+++ b/millpond/schema.py
@@ -82,15 +82,18 @@ def _arrow_type_to_duckdb(arrow_type: pa.DataType) -> str:
 # Normalize to our canonical names to prevent spurious ALTER TABLE on every flush.
 _INFO_SCHEMA_TO_CANONICAL: dict[str, str] = {
     "TIMESTAMP WITH TIME ZONE": "TIMESTAMPTZ",
-    # information_schema may surface VARIANT under alternate spellings depending
-    # on catalog; normalize so ensure_variant_columns doesn't re-ADD every flush.
-    "Variant": "VARIANT",
 }
 
 
 def _normalize_duckdb_type(type_name: str) -> str:
     """Normalize a DuckDB type name from information_schema to our canonical form."""
-    return _INFO_SCHEMA_TO_CANONICAL.get(type_name, type_name)
+    if type_name in _INFO_SCHEMA_TO_CANONICAL:
+        return _INFO_SCHEMA_TO_CANONICAL[type_name]
+    # VARIANT spelling varies by catalog ("VARIANT" / "Variant"); compare
+    # case-insensitively so ensure_variant_columns never re-ADD every flush.
+    if type_name.upper() == "VARIANT":
+        return "VARIANT"
+    return type_name
 
 
 class SchemaManager:
@@ -127,16 +130,41 @@ class SchemaManager:
             self._known_columns = {}
             self._initialized = True
 
-    def evolve(self, batch_schema: pa.Schema) -> None:
-        """Compare incoming Arrow schema against table and issue DDL if needed."""
+    def _ensure_schema_loaded(self) -> bool:
+        """Load/reload known columns if needed. Returns False if the table is empty/missing."""
         if not self._initialized:
             self._load_table_schema()
-
         if not self._known_columns:
-            # Table was just created by _ensure_table, reload
+            # Table was just created by _ensure_table, or does not exist yet.
             self._load_table_schema()
             if not self._known_columns:
-                return
+                return False
+        return True
+
+    def _add_column(self, column_name: str, duckdb_type: str) -> bool:
+        """ADD COLUMN IF NOT EXISTS and update cache. Returns True on success.
+
+        On failure logs, bumps ``errors_total{type="schema"}``, and returns False
+        so callers can degrade rather than crash-loop the write path.
+        """
+        log.info("Schema evolution: adding column %s (%s)", column_name, duckdb_type)
+        try:
+            self._conn.execute(
+                f"ALTER TABLE lake.{self._schema_name}.{self._table_name} "
+                f'ADD COLUMN IF NOT EXISTS "{column_name}" {duckdb_type}'
+            )
+        except duckdb.Error as e:
+            log.warning("Failed to add column %s: %s", column_name, e)
+            metrics.errors_total.labels(type="schema").inc()
+            return False
+        self._known_columns[column_name] = duckdb_type
+        metrics.schema_columns_added_total.inc()
+        return True
+
+    def evolve(self, batch_schema: pa.Schema) -> None:
+        """Compare incoming Arrow schema against table and issue DDL if needed."""
+        if not self._ensure_schema_loaded():
+            return
 
         for field in batch_schema:
             if field.name == "_inserted_at":
@@ -150,18 +178,7 @@ class SchemaManager:
             duckdb_type = _arrow_type_to_duckdb(field.type)
 
             if field.name not in self._known_columns:
-                # New column
-                log.info("Schema evolution: adding column %s (%s)", field.name, duckdb_type)
-                try:
-                    self._conn.execute(
-                        f"ALTER TABLE lake.{self._schema_name}.{self._table_name} "
-                        f'ADD COLUMN IF NOT EXISTS "{field.name}" {duckdb_type}'
-                    )
-                    self._known_columns[field.name] = duckdb_type
-                    metrics.schema_columns_added_total.inc()
-                except duckdb.Error as e:
-                    log.warning("Failed to add column %s: %s", field.name, e)
-                    metrics.errors_total.labels(type="schema").inc()
+                self._add_column(field.name, duckdb_type)
 
             elif self._known_columns[field.name] != duckdb_type:
                 # Type mismatch — attempt widening
@@ -214,36 +231,28 @@ class SchemaManager:
         self,
         sources: tuple[str, ...],
         present_source_names: set[str],
-    ) -> None:
-        """ADD COLUMN IF NOT EXISTS for dual-write VARIANT companions.
+    ) -> frozenset[str]:
+        """Ensure VARIANT dual-write companions exist; return sources ready to project.
 
-        For each source name in ``sources`` that is present in the current
-        batch (``present_source_names``), ensure a ``{source}_variant`` column
-        of type VARIANT exists on the table. Idempotent across pods via
-        ``ADD COLUMN IF NOT EXISTS``. Sources absent from this batch are
-        skipped — no empty VARIANT column is added for columns the producer
-        never sent.
+        For each source in ``sources`` present in the batch, try to ensure a
+        ``{source}_variant`` VARIANT column. Returns the subset of sources whose
+        companion is confirmed VARIANT and safe to project on INSERT.
 
-        Fail-loud on wrong type: if the companion already exists as anything
-        other than VARIANT (manual DDL, a payload field of that name, or a
-        concurrent race), raises ``ValueError`` and does not leave the type
-        cache poisoned. DuckLake cannot ``ALTER VARCHAR → VARIANT``, so the
-        operator must fix the table before dual-write can proceed.
+        Degrades (excludes from the returned set) rather than raising when:
+        - the companion already exists as a non-VARIANT type (cannot ALTER in place)
+        - ADD COLUMN fails
+        - ADD IF NOT EXISTS no-ops on a wrong-typed column
 
-        Called from ducklake.write after evolve() so the source VARCHAR
-        columns exist first; the VARIANT companions are sink-managed and do
-        not appear in the Arrow batch schema.
+        Projection must only cover the returned set — otherwise INSERT binds a
+        missing/wrong-typed column and crash-loops the flush path. Bumps
+        ``errors_total{type="schema"}`` on every degrade so the misconfig is loud.
         """
         if not sources:
-            return
-        if not self._initialized:
-            self._load_table_schema()
-        if not self._known_columns:
-            # Table was just created — reload so we see the CTAS columns.
-            self._load_table_schema()
-            if not self._known_columns:
-                return
+            return frozenset()
+        if not self._ensure_schema_loaded():
+            return frozenset()
 
+        ready: set[str] = set()
         for source in sources:
             if source not in present_source_names:
                 continue
@@ -256,15 +265,22 @@ class SchemaManager:
             existing = self._known_columns.get(vname)
             if existing is not None:
                 if existing != "VARIANT":
-                    metrics.errors_total.labels(type="schema").inc()
-                    raise ValueError(
-                        f"VARIANT dual-write target {vname!r} exists as {existing}, "
-                        f"expected VARIANT; DuckLake cannot ALTER to VARIANT in place. "
-                        f"Drop/rename the column or remove {source!r} from "
-                        f"MILLPOND_VARIANT_COLUMNS."
+                    log.warning(
+                        "VARIANT dual-write target %s exists as %s, expected VARIANT; "
+                        "degrading to string-only for source %s (DuckLake cannot ALTER "
+                        "to VARIANT in place)",
+                        vname,
+                        existing,
+                        source,
                     )
+                    metrics.errors_total.labels(type="schema").inc()
+                    continue
+                ready.add(source)
                 continue
 
+            # Do not use _add_column's optimistic cache: ADD IF NOT EXISTS is a
+            # no-op when the column already exists under any type, so we must
+            # re-read the live type before recording VARIANT in the cache.
             log.info("Schema evolution: adding VARIANT dual-write column %s", vname)
             try:
                 self._conn.execute(
@@ -272,27 +288,33 @@ class SchemaManager:
                     f'ADD COLUMN IF NOT EXISTS "{vname}" VARIANT'
                 )
             except duckdb.Error as e:
+                log.warning(
+                    "Failed to add VARIANT column %s: %s; degrading to string-only for %s",
+                    vname,
+                    e,
+                    source,
+                )
                 metrics.errors_total.labels(type="schema").inc()
-                raise ValueError(f"Failed to add VARIANT column {vname!r}: {e}") from e
+                continue
 
-            # ADD IF NOT EXISTS is a no-op when the column already exists under
-            # any type — do not trust the statement to mean "now VARIANT".
             live = self._live_column_type(vname)
-            if live is None:
-                metrics.errors_total.labels(type="schema").inc()
-                raise ValueError(
-                    f"VARIANT dual-write target {vname!r} missing after ADD COLUMN; catalog state is inconsistent"
-                )
             if live != "VARIANT":
-                metrics.errors_total.labels(type="schema").inc()
-                raise ValueError(
-                    f"VARIANT dual-write target {vname!r} exists as {live}, "
-                    f"expected VARIANT after ADD COLUMN IF NOT EXISTS (no-op on "
-                    f"wrong-typed column). Fix the table DDL or remove {source!r} "
-                    f"from MILLPOND_VARIANT_COLUMNS."
+                if live is not None:
+                    self._known_columns[vname] = live
+                log.warning(
+                    "VARIANT dual-write target %s is %s after ADD COLUMN IF NOT EXISTS "
+                    "(expected VARIANT); degrading to string-only for source %s",
+                    vname,
+                    live,
+                    source,
                 )
+                metrics.errors_total.labels(type="schema").inc()
+                continue
             self._known_columns[vname] = "VARIANT"
             metrics.schema_columns_added_total.inc()
+            ready.add(source)
+
+        return frozenset(ready)
 
     def invalidate(self) -> None:
         """Force a reload of the table schema on next evolve() call."""

--- a/millpond/schema.py
+++ b/millpond/schema.py
@@ -190,6 +190,26 @@ class SchemaManager:
                     )
                     metrics.errors_total.labels(type="schema").inc()
 
+    def _live_column_type(self, column_name: str) -> str | None:
+        """Read one column's type from information_schema (normalized).
+
+        Used after ``ADD COLUMN IF NOT EXISTS`` so the cache never trusts a
+        no-op ADD that left a wrong-typed column in place. Returns None when
+        the column is absent.
+        """
+        try:
+            result = self._conn.execute(
+                "SELECT data_type FROM information_schema.columns "
+                "WHERE table_catalog = 'lake' AND table_schema = ? "
+                "AND table_name = ? AND column_name = ?",
+                [self._schema_name, self._table_name, column_name],
+            ).fetchone()
+        except duckdb.CatalogException:
+            return None
+        if result is None:
+            return None
+        return _normalize_duckdb_type(result[0])
+
     def ensure_variant_columns(
         self,
         sources: tuple[str, ...],
@@ -203,6 +223,12 @@ class SchemaManager:
         ``ADD COLUMN IF NOT EXISTS``. Sources absent from this batch are
         skipped — no empty VARIANT column is added for columns the producer
         never sent.
+
+        Fail-loud on wrong type: if the companion already exists as anything
+        other than VARIANT (manual DDL, a payload field of that name, or a
+        concurrent race), raises ``ValueError`` and does not leave the type
+        cache poisoned. DuckLake cannot ``ALTER VARCHAR → VARIANT``, so the
+        operator must fix the table before dual-write can proceed.
 
         Called from ducklake.write after evolve() so the source VARCHAR
         columns exist first; the VARIANT companions are sink-managed and do
@@ -230,17 +256,13 @@ class SchemaManager:
             existing = self._known_columns.get(vname)
             if existing is not None:
                 if existing != "VARIANT":
-                    # Cannot ALTER VARCHAR → VARIANT (DuckLake widening-only).
-                    # Surface via metrics/logs; INSERT will fail on type mismatch
-                    # if the operator pointed at a table with a wrong-typed column.
-                    log.warning(
-                        "VARIANT dual-write target %s exists as %s, expected VARIANT; "
-                        "refusing to alter (DuckLake widening-only). Fix the table DDL "
-                        "or rename the dual-write target.",
-                        vname,
-                        existing,
-                    )
                     metrics.errors_total.labels(type="schema").inc()
+                    raise ValueError(
+                        f"VARIANT dual-write target {vname!r} exists as {existing}, "
+                        f"expected VARIANT; DuckLake cannot ALTER to VARIANT in place. "
+                        f"Drop/rename the column or remove {source!r} from "
+                        f"MILLPOND_VARIANT_COLUMNS."
+                    )
                 continue
 
             log.info("Schema evolution: adding VARIANT dual-write column %s", vname)
@@ -249,11 +271,28 @@ class SchemaManager:
                     f"ALTER TABLE lake.{self._schema_name}.{self._table_name} "
                     f'ADD COLUMN IF NOT EXISTS "{vname}" VARIANT'
                 )
-                self._known_columns[vname] = "VARIANT"
-                metrics.schema_columns_added_total.inc()
             except duckdb.Error as e:
-                log.warning("Failed to add VARIANT column %s: %s", vname, e)
                 metrics.errors_total.labels(type="schema").inc()
+                raise ValueError(f"Failed to add VARIANT column {vname!r}: {e}") from e
+
+            # ADD IF NOT EXISTS is a no-op when the column already exists under
+            # any type — do not trust the statement to mean "now VARIANT".
+            live = self._live_column_type(vname)
+            if live is None:
+                metrics.errors_total.labels(type="schema").inc()
+                raise ValueError(
+                    f"VARIANT dual-write target {vname!r} missing after ADD COLUMN; catalog state is inconsistent"
+                )
+            if live != "VARIANT":
+                metrics.errors_total.labels(type="schema").inc()
+                raise ValueError(
+                    f"VARIANT dual-write target {vname!r} exists as {live}, "
+                    f"expected VARIANT after ADD COLUMN IF NOT EXISTS (no-op on "
+                    f"wrong-typed column). Fix the table DDL or remove {source!r} "
+                    f"from MILLPOND_VARIANT_COLUMNS."
+                )
+            self._known_columns[vname] = "VARIANT"
+            metrics.schema_columns_added_total.inc()
 
     def invalidate(self) -> None:
         """Force a reload of the table schema on next evolve() call."""

--- a/millpond/schema.py
+++ b/millpond/schema.py
@@ -22,6 +22,17 @@ from millpond import metrics
 # metric bump.
 SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
+# Dual-write suffix for VARIANT companion columns. Source `properties` →
+# sink `properties_variant`. Shared with ducklake.write so the ADD COLUMN
+# path and the INSERT projection never disagree on the derived name.
+VARIANT_COLUMN_SUFFIX = "_variant"
+
+
+def variant_column_name(source: str) -> str:
+    """Derived VARIANT companion name for a dual-written source column."""
+    return f"{source}{VARIANT_COLUMN_SUFFIX}"
+
+
 log = logging.getLogger(__name__)
 
 # PyArrow type → DuckDB SQL type
@@ -71,6 +82,9 @@ def _arrow_type_to_duckdb(arrow_type: pa.DataType) -> str:
 # Normalize to our canonical names to prevent spurious ALTER TABLE on every flush.
 _INFO_SCHEMA_TO_CANONICAL: dict[str, str] = {
     "TIMESTAMP WITH TIME ZONE": "TIMESTAMPTZ",
+    # information_schema may surface VARIANT under alternate spellings depending
+    # on catalog; normalize so ensure_variant_columns doesn't re-ADD every flush.
+    "Variant": "VARIANT",
 }
 
 
@@ -175,6 +189,71 @@ class SchemaManager:
                         e,
                     )
                     metrics.errors_total.labels(type="schema").inc()
+
+    def ensure_variant_columns(
+        self,
+        sources: tuple[str, ...],
+        present_source_names: set[str],
+    ) -> None:
+        """ADD COLUMN IF NOT EXISTS for dual-write VARIANT companions.
+
+        For each source name in ``sources`` that is present in the current
+        batch (``present_source_names``), ensure a ``{source}_variant`` column
+        of type VARIANT exists on the table. Idempotent across pods via
+        ``ADD COLUMN IF NOT EXISTS``. Sources absent from this batch are
+        skipped — no empty VARIANT column is added for columns the producer
+        never sent.
+
+        Called from ducklake.write after evolve() so the source VARCHAR
+        columns exist first; the VARIANT companions are sink-managed and do
+        not appear in the Arrow batch schema.
+        """
+        if not sources:
+            return
+        if not self._initialized:
+            self._load_table_schema()
+        if not self._known_columns:
+            # Table was just created — reload so we see the CTAS columns.
+            self._load_table_schema()
+            if not self._known_columns:
+                return
+
+        for source in sources:
+            if source not in present_source_names:
+                continue
+            if not SAFE_IDENTIFIER.match(source):
+                log.warning("Skipping VARIANT dual-write for unsafe source field name: %r", source)
+                metrics.records_skipped_total.labels(reason="unsafe_field_name").inc()
+                continue
+
+            vname = variant_column_name(source)
+            existing = self._known_columns.get(vname)
+            if existing is not None:
+                if existing != "VARIANT":
+                    # Cannot ALTER VARCHAR → VARIANT (DuckLake widening-only).
+                    # Surface via metrics/logs; INSERT will fail on type mismatch
+                    # if the operator pointed at a table with a wrong-typed column.
+                    log.warning(
+                        "VARIANT dual-write target %s exists as %s, expected VARIANT; "
+                        "refusing to alter (DuckLake widening-only). Fix the table DDL "
+                        "or rename the dual-write target.",
+                        vname,
+                        existing,
+                    )
+                    metrics.errors_total.labels(type="schema").inc()
+                continue
+
+            log.info("Schema evolution: adding VARIANT dual-write column %s", vname)
+            try:
+                self._conn.execute(
+                    f"ALTER TABLE lake.{self._schema_name}.{self._table_name} "
+                    f'ADD COLUMN IF NOT EXISTS "{vname}" VARIANT'
+                )
+                self._known_columns[vname] = "VARIANT"
+                metrics.schema_columns_added_total.inc()
+            except duckdb.Error as e:
+                log.warning("Failed to add VARIANT column %s: %s", vname, e)
+                metrics.errors_total.labels(type="schema").inc()
 
     def invalidate(self) -> None:
         """Force a reload of the table schema on next evolve() call."""

--- a/millpond/schema.py
+++ b/millpond/schema.py
@@ -141,11 +141,52 @@ class SchemaManager:
                 return False
         return True
 
-    def _add_column(self, column_name: str, duckdb_type: str) -> bool:
-        """ADD COLUMN IF NOT EXISTS and update cache. Returns True on success.
+    def _column_type(self, column_name: str) -> str | None:
+        """Cached type for a column, matched case-insensitively.
 
-        On failure logs, bumps ``errors_total{type="schema"}``, and returns False
-        so callers can degrade rather than crash-loop the write path.
+        The cache is keyed by catalog-stored casing while callers hold
+        config-cased names; DuckDB resolves identifiers case-insensitively, so
+        an exact-case get() would miss (and re-ADD) a case-differing column.
+        """
+        lname = column_name.lower()
+        for name, typ in self._known_columns.items():
+            if name.lower() == lname:
+                return typ
+        return None
+
+    def _set_column_type(self, column_name: str, duckdb_type: str) -> None:
+        """Update the cache under the existing (catalog-cased) key if one matches.
+
+        A plain ``dict[column_name] = type`` could create a second entry that
+        differs only in case, leaving _column_type to return the stale one.
+        """
+        lname = column_name.lower()
+        for name in self._known_columns:
+            if name.lower() == lname:
+                self._known_columns[name] = duckdb_type
+                return
+        self._known_columns[column_name] = duckdb_type
+
+    def _add_column(self, column_name: str, duckdb_type: str, require_verified: bool = False) -> bool:
+        """ADD COLUMN IF NOT EXISTS, re-read the live schema, and update the cache.
+
+        The live schema is re-read (via the shared _load_table_schema path)
+        rather than trusted because ADD IF NOT EXISTS is a no-op when the
+        column already exists under any type (e.g. created by another writer) —
+        caching the requested type would silently mask the mismatch.
+
+        When the advisory re-read itself fails after a successful ADD:
+        - ``require_verified=False`` (evolve's ordinary columns): trust the ADD
+          and cache the requested type — at worst a stale wrong type triggers a
+          widening attempt on a later flush.
+        - ``require_verified=True`` (VARIANT companions): return False so the
+          caller degrades for this flush — projecting into an unverified column
+          risks silently corrupting it via implicit casts.
+
+        Returns True when the column is known (or trusted) to exist as
+        ``duckdb_type``; on failure logs, bumps ``errors_total{type="schema"}``,
+        and returns False so callers degrade rather than crash-loop the write
+        path.
         """
         log.info("Schema evolution: adding column %s (%s)", column_name, duckdb_type)
         try:
@@ -157,7 +198,33 @@ class SchemaManager:
             log.warning("Failed to add column %s: %s", column_name, e)
             metrics.errors_total.labels(type="schema").inc()
             return False
-        self._known_columns[column_name] = duckdb_type
+        try:
+            self._load_table_schema()
+        except duckdb.Error as e:
+            # Transient catalog error on an advisory re-read must not fail the
+            # flush (the ADD itself succeeded).
+            metrics.errors_total.labels(type="schema").inc()
+            if require_verified:
+                log.warning("Cannot verify type of %s after ADD COLUMN: %s; degrading", column_name, e)
+                return False
+            log.warning("Schema re-read failed after adding %s: %s; trusting the ADD", column_name, e)
+            self._set_column_type(column_name, duckdb_type)
+            metrics.schema_columns_added_total.inc()
+            return True
+        live = self._column_type(column_name)
+        if live is None:
+            log.warning("Column %s missing after ADD COLUMN IF NOT EXISTS", column_name)
+            metrics.errors_total.labels(type="schema").inc()
+            return False
+        if live != duckdb_type:
+            log.warning(
+                "Column %s is %s after ADD COLUMN IF NOT EXISTS (expected %s); keeping live type",
+                column_name,
+                live,
+                duckdb_type,
+            )
+            metrics.errors_total.labels(type="schema").inc()
+            return False
         metrics.schema_columns_added_total.inc()
         return True
 
@@ -177,12 +244,12 @@ class SchemaManager:
 
             duckdb_type = _arrow_type_to_duckdb(field.type)
 
-            if field.name not in self._known_columns:
+            existing = self._column_type(field.name)
+            if existing is None:
                 self._add_column(field.name, duckdb_type)
 
-            elif self._known_columns[field.name] != duckdb_type:
+            elif existing != duckdb_type:
                 # Type mismatch — attempt widening
-                existing = self._known_columns[field.name]
                 log.info(
                     "Schema evolution: widening column %s from %s to %s",
                     field.name,
@@ -194,7 +261,7 @@ class SchemaManager:
                         f"ALTER TABLE lake.{self._schema_name}.{self._table_name} "
                         f'ALTER COLUMN "{field.name}" SET DATA TYPE {duckdb_type}'
                     )
-                    self._known_columns[field.name] = duckdb_type
+                    self._set_column_type(field.name, duckdb_type)
                     metrics.schema_columns_widened_total.inc()
                 except duckdb.Error as e:
                     # DuckLake rejects invalid promotions — log and continue
@@ -207,25 +274,17 @@ class SchemaManager:
                     )
                     metrics.errors_total.labels(type="schema").inc()
 
-    def _live_column_type(self, column_name: str) -> str | None:
-        """Read one column's type from information_schema (normalized).
+    def live_variant_column_names(self) -> frozenset[str]:
+        """Lowercased names of VARIANT columns in the live table schema.
 
-        Used after ``ADD COLUMN IF NOT EXISTS`` so the cache never trusts a
-        no-op ADD that left a wrong-typed column in place. Returns None when
-        the column is absent.
+        Only the sink creates VARIANT columns (evolve maps nested Arrow types
+        to JSON), so every VARIANT column is sink-managed. write() uses this to
+        strip colliding payload fields even when the local variant_columns
+        config is absent or stale (mixed fleet).
         """
-        try:
-            result = self._conn.execute(
-                "SELECT data_type FROM information_schema.columns "
-                "WHERE table_catalog = 'lake' AND table_schema = ? "
-                "AND table_name = ? AND column_name = ?",
-                [self._schema_name, self._table_name, column_name],
-            ).fetchone()
-        except duckdb.CatalogException:
-            return None
-        if result is None:
-            return None
-        return _normalize_duckdb_type(result[0])
+        if not self._ensure_schema_loaded():
+            return frozenset()
+        return frozenset(name.lower() for name, typ in self._known_columns.items() if typ == "VARIANT")
 
     def ensure_variant_columns(
         self,
@@ -243,76 +302,52 @@ class SchemaManager:
         - ADD COLUMN fails
         - ADD IF NOT EXISTS no-ops on a wrong-typed column
 
-        Projection must only cover the returned set — otherwise INSERT binds a
-        missing/wrong-typed column and crash-loops the flush path. Bumps
-        ``errors_total{type="schema"}`` on every degrade so the misconfig is loud.
+        Presence matching is case-insensitive: a ``Properties`` batch key feeds
+        the same DuckDB column as configured ``properties``, so it must dual-write
+        rather than silently skip. Projection must only cover the returned set —
+        otherwise INSERT binds a missing/wrong-typed column and crash-loops the
+        flush path. Bumps ``errors_total{type="schema"}`` on every degrade so
+        the misconfig is loud.
         """
         if not sources:
             return frozenset()
         if not self._ensure_schema_loaded():
             return frozenset()
 
+        present_lower = {name.lower() for name in present_source_names}
         ready: set[str] = set()
         for source in sources:
-            if source not in present_source_names:
+            if source.lower() not in present_lower:
                 continue
+            # Unreachable via config.load() (which rejects unsafe names), but
+            # kept as defense-in-depth: vname is embedded in generated DDL.
+            # No records are skipped on this path, so it's a schema error.
             if not SAFE_IDENTIFIER.match(source):
                 log.warning("Skipping VARIANT dual-write for unsafe source field name: %r", source)
-                metrics.records_skipped_total.labels(reason="unsafe_field_name").inc()
+                metrics.errors_total.labels(type="schema").inc()
                 continue
 
             vname = variant_column_name(source)
-            existing = self._known_columns.get(vname)
-            if existing is not None:
-                if existing != "VARIANT":
-                    log.warning(
-                        "VARIANT dual-write target %s exists as %s, expected VARIANT; "
-                        "degrading to string-only for source %s (DuckLake cannot ALTER "
-                        "to VARIANT in place)",
-                        vname,
-                        existing,
-                        source,
-                    )
-                    metrics.errors_total.labels(type="schema").inc()
-                    continue
+            existing = self._column_type(vname)
+            if existing == "VARIANT":
                 ready.add(source)
                 continue
-
-            # Do not use _add_column's optimistic cache: ADD IF NOT EXISTS is a
-            # no-op when the column already exists under any type, so we must
-            # re-read the live type before recording VARIANT in the cache.
-            log.info("Schema evolution: adding VARIANT dual-write column %s", vname)
-            try:
-                self._conn.execute(
-                    f"ALTER TABLE lake.{self._schema_name}.{self._table_name} "
-                    f'ADD COLUMN IF NOT EXISTS "{vname}" VARIANT'
-                )
-            except duckdb.Error as e:
+            if existing is not None:
                 log.warning(
-                    "Failed to add VARIANT column %s: %s; degrading to string-only for %s",
+                    "VARIANT dual-write target %s exists as %s, expected VARIANT; "
+                    "degrading to string-only for source %s (DuckLake cannot ALTER "
+                    "to VARIANT in place)",
                     vname,
-                    e,
+                    existing,
                     source,
                 )
                 metrics.errors_total.labels(type="schema").inc()
                 continue
 
-            live = self._live_column_type(vname)
-            if live != "VARIANT":
-                if live is not None:
-                    self._known_columns[vname] = live
-                log.warning(
-                    "VARIANT dual-write target %s is %s after ADD COLUMN IF NOT EXISTS "
-                    "(expected VARIANT); degrading to string-only for source %s",
-                    vname,
-                    live,
-                    source,
-                )
-                metrics.errors_total.labels(type="schema").inc()
-                continue
-            self._known_columns[vname] = "VARIANT"
-            metrics.schema_columns_added_total.inc()
-            ready.add(source)
+            if self._add_column(vname, "VARIANT", require_verified=True):
+                ready.add(source)
+            else:
+                log.warning("Degrading to string-only for source %s", source)
 
         return frozenset(ready)
 

--- a/tests/integration/test_write_integration.py
+++ b/tests/integration/test_write_integration.py
@@ -52,8 +52,7 @@ class TestWritePath:
         write(conn, "events", batch, cache)
 
         cols = conn.execute(
-            "SELECT column_name FROM information_schema.columns "
-            "WHERE table_catalog = 'lake' AND table_name = 'events'"
+            "SELECT column_name FROM information_schema.columns WHERE table_catalog = 'lake' AND table_name = 'events'"
         ).fetchall()
         col_names = {row[0] for row in cols}
         assert "_inserted_at" in col_names
@@ -72,8 +71,7 @@ class TestWritePath:
         write(conn, "events", batch, cache)
 
         cols = conn.execute(
-            "SELECT column_name FROM information_schema.columns "
-            "WHERE table_catalog = 'lake' AND table_name = 'events'"
+            "SELECT column_name FROM information_schema.columns WHERE table_catalog = 'lake' AND table_name = 'events'"
         ).fetchall()
         col_names = {row[0] for row in cols}
         assert "a" in col_names
@@ -151,8 +149,7 @@ class TestVariantDualWrite:
         write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
 
         rows = conn.execute(
-            "SELECT id, properties, properties_variant IS NULL AS vnull "
-            "FROM lake.main.events ORDER BY id"
+            "SELECT id, properties, properties_variant IS NULL AS vnull FROM lake.main.events ORDER BY id"
         ).fetchall()
         assert rows[0] == (1, '{"ok": true}', False)
         assert rows[1][0] == 2
@@ -222,6 +219,43 @@ class TestVariantDualWrite:
         with pytest.raises(ValueError, match="properties_variant"):
             write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
 
+    def test_wrong_typed_companion_raises(self, conn, cache):
+        """Pre-existing non-VARIANT companion must fail loud, not dual-write."""
+        conn.execute("CREATE TABLE lake.main.events (properties VARCHAR, properties_variant VARCHAR)")
+        schema_mgr = SchemaManager(conn, "events")
+        # Seed cache with the wrong type so we exercise the known-column branch.
+        schema_mgr._load_table_schema()
+        assert schema_mgr._known_columns.get("properties_variant") == "VARCHAR"
+
+        batch = pa.table({"properties": ['{"a": 1}']})
+        with pytest.raises(ValueError, match="expected VARIANT"):
+            write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
+        # Cache must not be rewritten to VARIANT after the failure.
+        assert schema_mgr._known_columns.get("properties_variant") == "VARCHAR"
+
+    def test_add_if_not_exists_noop_wrong_type_raises(self, conn, cache):
+        """ADD IF NOT EXISTS no-op on wrong-typed column must not poison the cache.
+
+        Cache starts empty for the companion so we take the ADD path; live
+        re-read after ADD must see VARCHAR and raise before caching VARIANT.
+        """
+        conn.execute("CREATE TABLE lake.main.events (properties VARCHAR, properties_variant VARCHAR)")
+        schema_mgr = SchemaManager(conn, "events")
+        # Only load properties into the cache shape by writing known_columns
+        # without the companion — simulate a stale view that will try ADD.
+        schema_mgr._known_columns = {"properties": "VARCHAR", "_inserted_at": "TIMESTAMP"}
+        schema_mgr._initialized = True
+
+        batch = pa.table({"properties": ['{"a": 1}']})
+        with pytest.raises(ValueError, match="expected VARIANT after ADD COLUMN"):
+            write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
+        assert schema_mgr._known_columns.get("properties_variant") != "VARIANT"
+
+    def test_variant_columns_requires_schema_manager(self, conn, cache):
+        batch = pa.table({"properties": ['{"a": 1}']})
+        with pytest.raises(ValueError, match="requires a SchemaManager"):
+            write(conn, "events", batch, cache, schema_mgr=None, variant_columns=("properties",))
+
 
 @pytest.mark.integration
 class TestSchemaEvolution:
@@ -235,8 +269,7 @@ class TestSchemaEvolution:
         write(conn, "events", batch2, cache, schema_mgr)
 
         cols = conn.execute(
-            "SELECT column_name FROM information_schema.columns "
-            "WHERE table_catalog = 'lake' AND table_name = 'events'"
+            "SELECT column_name FROM information_schema.columns WHERE table_catalog = 'lake' AND table_name = 'events'"
         ).fetchall()
         col_names = {row[0] for row in cols}
         assert "source" in col_names
@@ -283,8 +316,7 @@ class TestSchemaEvolution:
         write(conn, "events", batch2, cache, schema_mgr)
 
         cols = conn.execute(
-            "SELECT column_name FROM information_schema.columns "
-            "WHERE table_catalog = 'lake' AND table_name = 'events'"
+            "SELECT column_name FROM information_schema.columns WHERE table_catalog = 'lake' AND table_name = 'events'"
         ).fetchall()
         col_names = {row[0] for row in cols}
         assert {"a", "b", "c", "_inserted_at"} <= col_names
@@ -482,9 +514,7 @@ class TestTimestampCoercionWritePath:
         # Data landed and the stored value is the right instant. DuckDB renders
         # TIMESTAMPTZ in the session timezone, so compare the instant (aware
         # equality is tz-independent) rather than its string form.
-        row = conn.execute(
-            "SELECT event, timestamp FROM lake.main.events WHERE uuid = 'u1'"
-        ).fetchone()
+        row = conn.execute("SELECT event, timestamp FROM lake.main.events WHERE uuid = 'u1'").fetchone()
         assert row[0] == "$pageview"
         assert row[1] == datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
 

--- a/tests/integration/test_write_integration.py
+++ b/tests/integration/test_write_integration.py
@@ -38,6 +38,22 @@ def cache() -> set[str]:
     return set()
 
 
+def _table_columns(conn, table: str = "events") -> dict[str, str]:
+    """column_name → data_type for a lake table (catalog-stored casing).
+
+    Single home for the information_schema assertion query so a change to how
+    columns are read (schema filter, type rename) lands in one place.
+    """
+    return {
+        row[0]: row[1]
+        for row in conn.execute(
+            "SELECT column_name, data_type FROM information_schema.columns "
+            "WHERE table_catalog = 'lake' AND table_name = ?",
+            [table],
+        ).fetchall()
+    }
+
+
 @pytest.mark.integration
 class TestWritePath:
     def test_basic_write(self, conn, cache):
@@ -51,10 +67,7 @@ class TestWritePath:
         batch = pa.table({"event": ["click"]})
         write(conn, "events", batch, cache)
 
-        cols = conn.execute(
-            "SELECT column_name FROM information_schema.columns WHERE table_catalog = 'lake' AND table_name = 'events'"
-        ).fetchall()
-        col_names = {row[0] for row in cols}
+        col_names = _table_columns(conn)
         assert "_inserted_at" in col_names
 
     def test_multiple_writes_accumulate(self, conn, cache):
@@ -70,10 +83,7 @@ class TestWritePath:
         batch = pa.table({"a": pa.array([], type=pa.int64())})
         write(conn, "events", batch, cache)
 
-        cols = conn.execute(
-            "SELECT column_name FROM information_schema.columns WHERE table_catalog = 'lake' AND table_name = 'events'"
-        ).fetchall()
-        col_names = {row[0] for row in cols}
+        col_names = _table_columns(conn)
         assert "a" in col_names
         assert "_inserted_at" in col_names
 
@@ -100,13 +110,7 @@ class TestVariantDualWrite:
         )
         write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
 
-        cols = {
-            row[0]: row[1]
-            for row in conn.execute(
-                "SELECT column_name, data_type FROM information_schema.columns "
-                "WHERE table_catalog = 'lake' AND table_name = 'events'"
-            ).fetchall()
-        }
+        cols = _table_columns(conn)
         assert cols["properties"] in ("VARCHAR", "JSON")  # source stays text-ish
         assert cols[variant_column_name("properties")] == "VARIANT"
 
@@ -166,13 +170,7 @@ class TestVariantDualWrite:
         batch = pa.table({"event": ["x"]})
         write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
 
-        cols = {
-            row[0]
-            for row in conn.execute(
-                "SELECT column_name FROM information_schema.columns "
-                "WHERE table_catalog = 'lake' AND table_name = 'events'"
-            ).fetchall()
-        }
+        cols = _table_columns(conn)
         # properties absent from batch → properties_variant never ADDed
         assert "properties_variant" not in cols
         assert "event" in cols
@@ -222,13 +220,7 @@ class TestVariantDualWrite:
         )
         write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
 
-        cols = {
-            row[0]: row[1]
-            for row in conn.execute(
-                "SELECT column_name, data_type FROM information_schema.columns "
-                "WHERE table_catalog = 'lake' AND table_name = 'events'"
-            ).fetchall()
-        }
+        cols = _table_columns(conn)
         assert cols["properties_variant"] == "VARIANT"
         (props, vtype) = conn.execute(
             "SELECT properties, variant_typeof(properties_variant) FROM lake.main.events"
@@ -247,13 +239,7 @@ class TestVariantDualWrite:
             schema_mgr,
             variant_columns=("properties",),
         )
-        cols = {
-            row[0]
-            for row in conn.execute(
-                "SELECT column_name FROM information_schema.columns "
-                "WHERE table_catalog = 'lake' AND table_name = 'events'"
-            ).fetchall()
-        }
+        cols = _table_columns(conn)
         assert "properties_variant" not in cols
         assert "event" in cols
 
@@ -266,12 +252,7 @@ class TestVariantDualWrite:
             schema_mgr,
             variant_columns=("properties",),
         )
-        type_row = conn.execute(
-            "SELECT data_type FROM information_schema.columns "
-            "WHERE table_catalog = 'lake' AND table_name = 'events' "
-            "AND column_name = 'properties_variant'"
-        ).fetchone()
-        assert type_row[0] == "VARIANT"
+        assert _table_columns(conn)["properties_variant"] == "VARIANT"
 
     def test_wrong_typed_companion_degrades_to_string_only(self, conn, cache):
         """Pre-existing non-VARIANT companion: string still writes, no crash loop."""
@@ -315,6 +296,110 @@ class TestVariantDualWrite:
         with pytest.raises(ValueError, match="requires a SchemaManager"):
             write(conn, "events", batch, cache, schema_mgr=None, variant_columns=("properties",))
 
+    def test_all_companion_poison_batch_skipped_nonfatally(self, conn, cache):
+        """A batch whose every column is a companion collision must not crash-loop.
+
+        After the drop the batch has zero columns; SELECT * over a zero-column
+        relation errors, so write() must skip the flush instead of raising.
+        """
+        schema_mgr = SchemaManager(conn, "events")
+        batch = pa.table({"properties_variant": ["poison", "poison2"]})
+        written = write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
+
+        assert written == 0  # skipped records must not count as written
+        tables = conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_catalog = 'lake'"
+        ).fetchall()
+        assert tables == []  # nothing created, nothing written, no exception
+
+    def test_genuine_zero_column_batch_still_fails_loudly(self, conn, cache):
+        """A batch that arrives with zero columns did not collide — no silent skip.
+
+        The companion-collision skip is gated on the drop actually emptying the
+        batch; an upstream bug producing a 0-column batch must keep surfacing
+        as a write failure, not vanish under a misleading skip reason.
+        """
+        schema_mgr = SchemaManager(conn, "events")
+        batch = pa.table({"a": [1, 2]}).drop_columns(["a"])
+        assert batch.num_columns == 0 and batch.num_rows == 2
+        with pytest.raises(duckdb.Error):
+            write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
+
+    def test_unconfigured_writer_cannot_poison_live_variant_column(self, conn, cache):
+        """Mixed fleet: a writer without variant_columns must not write into a
+        live VARIANT companion (implicit VARCHAR→VARIANT cast would store a
+        string-wrapped variant invisible to `companion.field` queries)."""
+        schema_mgr = SchemaManager(conn, "events")
+        # Configured writer creates the VARIANT companion.
+        write(
+            conn,
+            "events",
+            pa.table({"properties": ['{"a": 1}']}),
+            cache,
+            schema_mgr,
+            variant_columns=("properties",),
+        )
+        assert _table_columns(conn)["properties_variant"] == "VARIANT"
+
+        # Unconfigured writer (fresh SchemaManager, no variant_columns) gets a
+        # poison payload carrying the companion key.
+        other_mgr = SchemaManager(conn, "events")
+        written = write(
+            conn,
+            "events",
+            pa.table({"properties": ['{"a": 2}'], "properties_variant": ["poison"]}),
+            cache,
+            other_mgr,
+        )
+        assert written == 1
+        rows = conn.execute(
+            "SELECT properties, variant_typeof(properties_variant) FROM lake.main.events "
+            "WHERE properties_variant IS NOT NULL ORDER BY properties"
+        ).fetchall()
+        # Both rows hold parsed objects — no string-wrapped variant landed.
+        assert [r[1].startswith("OBJECT") for r in rows] == [True]
+        # The unconfigured writer's row has a NULL companion (dropped field,
+        # no dual-write config), not the poison payload.
+        (companion,) = conn.execute(
+            "SELECT properties_variant IS NULL FROM lake.main.events WHERE properties = '{\"a\": 2}'"
+        ).fetchone()
+        assert companion is True
+
+    def test_write_returns_record_count(self, conn, cache):
+        schema_mgr = SchemaManager(conn, "events")
+        batch = pa.table({"properties": ['{"a": 1}', '{"b": 2}']})
+        assert write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",)) == 2
+
+    def test_case_variant_companion_key_dropped(self, conn, cache):
+        """PROPERTIES_VARIANT lands in the same catalog column — must be stripped."""
+        schema_mgr = SchemaManager(conn, "events")
+        batch = pa.table(
+            {
+                "properties": ['{"a": 1}'],
+                "PROPERTIES_VARIANT": ["poison"],
+            }
+        )
+        write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
+
+        cols = _table_columns(conn)
+        assert cols["properties_variant"] == "VARIANT"
+        (props, vtype) = conn.execute(
+            "SELECT properties, variant_typeof(properties_variant) FROM lake.main.events"
+        ).fetchone()
+        assert props == '{"a": 1}'
+        assert vtype.startswith("OBJECT")
+
+    def test_case_variant_source_key_still_dual_writes(self, conn, cache):
+        """A Properties batch key feeds the configured properties column case-insensitively."""
+        schema_mgr = SchemaManager(conn, "events")
+        batch = pa.table({"Properties": ['{"a": 1}']})
+        write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
+
+        cols = {k.lower(): v for k, v in _table_columns(conn).items()}
+        assert cols["properties_variant"] == "VARIANT"
+        (vtype,) = conn.execute("SELECT variant_typeof(properties_variant) FROM lake.main.events").fetchone()
+        assert vtype.startswith("OBJECT")
+
 
 @pytest.mark.integration
 class TestSchemaEvolution:
@@ -327,10 +412,7 @@ class TestSchemaEvolution:
         batch2 = pa.table({"event": ["view"], "source": ["web"]})
         write(conn, "events", batch2, cache, schema_mgr)
 
-        cols = conn.execute(
-            "SELECT column_name FROM information_schema.columns WHERE table_catalog = 'lake' AND table_name = 'events'"
-        ).fetchall()
-        col_names = {row[0] for row in cols}
+        col_names = _table_columns(conn)
         assert "source" in col_names
 
         # Verify data landed correctly
@@ -346,11 +428,7 @@ class TestSchemaEvolution:
         batch = pa.table({"x": pa.array([1], type=pa.int64())})
         schema_mgr.evolve(batch.schema)
 
-        type_result = conn.execute(
-            "SELECT data_type FROM information_schema.columns "
-            "WHERE table_catalog = 'lake' AND table_name = 'events' AND column_name = 'x'"
-        ).fetchone()
-        assert type_result[0] == "BIGINT"
+        assert _table_columns(conn)["x"] == "BIGINT"
 
     def test_widen_float_to_double(self, conn):
         conn.execute("CREATE TABLE lake.main.events (x FLOAT)")
@@ -359,11 +437,7 @@ class TestSchemaEvolution:
         batch = pa.table({"x": pa.array([1.0], type=pa.float64())})
         schema_mgr.evolve(batch.schema)
 
-        type_result = conn.execute(
-            "SELECT data_type FROM information_schema.columns "
-            "WHERE table_catalog = 'lake' AND table_name = 'events' AND column_name = 'x'"
-        ).fetchone()
-        assert type_result[0] == "DOUBLE"
+        assert _table_columns(conn)["x"] == "DOUBLE"
 
     def test_multiple_new_columns_at_once(self, conn, cache):
         batch1 = pa.table({"a": [1]})
@@ -374,11 +448,8 @@ class TestSchemaEvolution:
         batch2 = pa.table({"a": [2], "b": ["x"], "c": [3.0]})
         write(conn, "events", batch2, cache, schema_mgr)
 
-        cols = conn.execute(
-            "SELECT column_name FROM information_schema.columns WHERE table_catalog = 'lake' AND table_name = 'events'"
-        ).fetchall()
-        col_names = {row[0] for row in cols}
-        assert {"a", "b", "c", "_inserted_at"} <= col_names
+        col_names = _table_columns(conn)
+        assert {"a", "b", "c", "_inserted_at"} <= set(col_names)
 
         # Verify data integrity
         rows = conn.execute("SELECT a, b, c FROM lake.main.events ORDER BY a").fetchall()
@@ -583,12 +654,7 @@ class TestTimestampCoercionWritePath:
         batch = coerce_typed_columns(self._nrt_batch(), self.TS_PAIRS)
         write(conn, "events", batch, cache, SchemaManager(conn, "events"), schema_name="main")
 
-        types = dict(
-            conn.execute(
-                "SELECT column_name, data_type FROM information_schema.columns "
-                "WHERE table_catalog = 'lake' AND table_name = 'events'"
-            ).fetchall()
-        )
+        types = _table_columns(conn)
         for c in self.TS_COLS:
             assert types[c] == "TIMESTAMP WITH TIME ZONE"
 

--- a/tests/integration/test_write_integration.py
+++ b/tests/integration/test_write_integration.py
@@ -208,7 +208,11 @@ class TestVariantDualWrite:
         assert rows[0][1] is None
         assert rows[1][1] is not None
 
-    def test_source_collision_raises(self, conn, cache):
+    def test_source_companion_collision_nonfatal_still_dual_writes(self, conn, cache):
+        """Poison payload with both properties and properties_variant must not crash-loop.
+
+        Companion is stripped; source dual-writes into a real VARIANT column.
+        """
         schema_mgr = SchemaManager(conn, "events")
         batch = pa.table(
             {
@@ -216,40 +220,95 @@ class TestVariantDualWrite:
                 "properties_variant": ["already here"],
             }
         )
-        with pytest.raises(ValueError, match="properties_variant"):
-            write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
+        write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
 
-    def test_wrong_typed_companion_raises(self, conn, cache):
-        """Pre-existing non-VARIANT companion must fail loud, not dual-write."""
-        conn.execute("CREATE TABLE lake.main.events (properties VARCHAR, properties_variant VARCHAR)")
+        cols = {
+            row[0]: row[1]
+            for row in conn.execute(
+                "SELECT column_name, data_type FROM information_schema.columns "
+                "WHERE table_catalog = 'lake' AND table_name = 'events'"
+            ).fetchall()
+        }
+        assert cols["properties_variant"] == "VARIANT"
+        (props, vtype) = conn.execute(
+            "SELECT properties, variant_typeof(properties_variant) FROM lake.main.events"
+        ).fetchone()
+        assert props == '{"a": 1}'
+        assert vtype.startswith("OBJECT")
+
+    def test_orphan_companion_payload_does_not_create_varchar_column(self, conn, cache):
+        """properties_variant alone in a batch must not evolve() as VARCHAR."""
         schema_mgr = SchemaManager(conn, "events")
-        # Seed cache with the wrong type so we exercise the known-column branch.
+        write(
+            conn,
+            "events",
+            pa.table({"event": ["x"], "properties_variant": ["poison"]}),
+            cache,
+            schema_mgr,
+            variant_columns=("properties",),
+        )
+        cols = {
+            row[0]
+            for row in conn.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_catalog = 'lake' AND table_name = 'events'"
+            ).fetchall()
+        }
+        assert "properties_variant" not in cols
+        assert "event" in cols
+
+        # Later real dual-write still works and creates VARIANT, not VARCHAR.
+        write(
+            conn,
+            "events",
+            pa.table({"event": ["y"], "properties": ['{"a": 1}']}),
+            cache,
+            schema_mgr,
+            variant_columns=("properties",),
+        )
+        type_row = conn.execute(
+            "SELECT data_type FROM information_schema.columns "
+            "WHERE table_catalog = 'lake' AND table_name = 'events' "
+            "AND column_name = 'properties_variant'"
+        ).fetchone()
+        assert type_row[0] == "VARIANT"
+
+    def test_wrong_typed_companion_degrades_to_string_only(self, conn, cache):
+        """Pre-existing non-VARIANT companion: string still writes, no crash loop."""
+        conn.execute(
+            "CREATE TABLE lake.main.events ("
+            "properties VARCHAR, properties_variant VARCHAR, _inserted_at TIMESTAMP)"
+        )
+        schema_mgr = SchemaManager(conn, "events")
         schema_mgr._load_table_schema()
         assert schema_mgr._known_columns.get("properties_variant") == "VARCHAR"
 
         batch = pa.table({"properties": ['{"a": 1}']})
-        with pytest.raises(ValueError, match="expected VARIANT"):
-            write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
-        # Cache must not be rewritten to VARIANT after the failure.
+        write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
+
+        # Source landed; companion left alone (NULL for this insert — not projected).
+        (props, companion) = conn.execute("SELECT properties, properties_variant FROM lake.main.events").fetchone()
+        assert props == '{"a": 1}'
+        assert companion is None
+        # Cache still reflects VARCHAR — not poisoned to VARIANT.
         assert schema_mgr._known_columns.get("properties_variant") == "VARCHAR"
 
-    def test_add_if_not_exists_noop_wrong_type_raises(self, conn, cache):
-        """ADD IF NOT EXISTS no-op on wrong-typed column must not poison the cache.
-
-        Cache starts empty for the companion so we take the ADD path; live
-        re-read after ADD must see VARCHAR and raise before caching VARIANT.
-        """
-        conn.execute("CREATE TABLE lake.main.events (properties VARCHAR, properties_variant VARCHAR)")
+    def test_add_if_not_exists_noop_wrong_type_degrades(self, conn, cache):
+        """ADD IF NOT EXISTS no-op on wrong type: no cache poison, string-only write."""
+        conn.execute(
+            "CREATE TABLE lake.main.events ("
+            "properties VARCHAR, properties_variant VARCHAR, _inserted_at TIMESTAMP)"
+        )
         schema_mgr = SchemaManager(conn, "events")
-        # Only load properties into the cache shape by writing known_columns
-        # without the companion — simulate a stale view that will try ADD.
         schema_mgr._known_columns = {"properties": "VARCHAR", "_inserted_at": "TIMESTAMP"}
         schema_mgr._initialized = True
 
         batch = pa.table({"properties": ['{"a": 1}']})
-        with pytest.raises(ValueError, match="expected VARIANT after ADD COLUMN"):
-            write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
-        assert schema_mgr._known_columns.get("properties_variant") != "VARIANT"
+        write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
+
+        assert schema_mgr._known_columns.get("properties_variant") == "VARCHAR"
+        (props,) = conn.execute("SELECT properties FROM lake.main.events").fetchone()
+        assert props == '{"a": 1}'
 
     def test_variant_columns_requires_schema_manager(self, conn, cache):
         batch = pa.table({"properties": ['{"a": 1}']})

--- a/tests/integration/test_write_integration.py
+++ b/tests/integration/test_write_integration.py
@@ -15,7 +15,7 @@ import pytest
 
 from millpond.arrow_converter import coerce_typed_columns, convert
 from millpond.ducklake import write
-from millpond.schema import SchemaManager
+from millpond.schema import SchemaManager, variant_column_name
 
 
 @pytest.fixture()
@@ -78,6 +78,149 @@ class TestWritePath:
         col_names = {row[0] for row in cols}
         assert "a" in col_names
         assert "_inserted_at" in col_names
+
+
+@pytest.mark.integration
+class TestVariantDualWrite:
+    """Dual-write JSON/VARCHAR source columns as VARIANT companions.
+
+    Keeps the original string column and adds `{name}_variant` via
+    try_cast(try_cast(col AS JSON) AS VARIANT). Uses SchemaManager so
+    ADD COLUMN + type-cache stay coherent across flushes.
+    """
+
+    def test_dual_writes_properties_variant(self, conn, cache):
+        schema_mgr = SchemaManager(conn, "events")
+        batch = pa.table(
+            {
+                "event": ["$pageview", "click"],
+                "properties": [
+                    '{"$browser": "Chrome", "width": 1920}',
+                    '{"$browser": "Firefox", "width": 1440}',
+                ],
+            }
+        )
+        write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
+
+        cols = {
+            row[0]: row[1]
+            for row in conn.execute(
+                "SELECT column_name, data_type FROM information_schema.columns "
+                "WHERE table_catalog = 'lake' AND table_name = 'events'"
+            ).fetchall()
+        }
+        assert cols["properties"] in ("VARCHAR", "JSON")  # source stays text-ish
+        assert cols[variant_column_name("properties")] == "VARIANT"
+
+        rows = conn.execute(
+            "SELECT event, properties, "
+            "variant_typeof(properties_variant), "
+            'properties_variant."$browser", '
+            "properties_variant.width "
+            "FROM lake.main.events ORDER BY event"
+        ).fetchall()
+        assert len(rows) == 2
+        by_event = {r[0]: r for r in rows}
+        # Original string preserved on the source column
+        assert '"Chrome"' in by_event["$pageview"][1]
+        assert '"Firefox"' in by_event["click"][1]
+        # VARIANT is a parsed object (not VARCHAR holding JSON text)
+        assert by_event["$pageview"][2].startswith("OBJECT")
+        assert by_event["$pageview"][3] == "Chrome"
+        assert by_event["$pageview"][4] == 1920
+        assert by_event["click"][3] == "Firefox"
+        assert by_event["click"][4] == 1440
+
+    def test_original_string_column_unchanged(self, conn, cache):
+        schema_mgr = SchemaManager(conn, "events")
+        raw = '{"a": 1, "b": "two"}'
+        batch = pa.table({"properties": [raw]})
+        write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
+
+        (stored,) = conn.execute("SELECT properties FROM lake.main.events").fetchone()
+        assert stored == raw
+
+    def test_malformed_json_nulls_variant_keeps_string(self, conn, cache):
+        schema_mgr = SchemaManager(conn, "events")
+        batch = pa.table(
+            {
+                "id": [1, 2, 3],
+                "properties": ['{"ok": true}', "not json{{{", '{"ok": false}'],
+            }
+        )
+        write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
+
+        rows = conn.execute(
+            "SELECT id, properties, properties_variant IS NULL AS vnull "
+            "FROM lake.main.events ORDER BY id"
+        ).fetchall()
+        assert rows[0] == (1, '{"ok": true}', False)
+        assert rows[1][0] == 2
+        assert rows[1][1] == "not json{{{"
+        assert rows[1][2] is True  # variant nulled
+        assert rows[2] == (3, '{"ok": false}', False)
+
+    def test_absent_source_column_skips_dual_write(self, conn, cache):
+        """Configured source missing from this batch → no companion projected.
+
+        Column may still exist from a prior batch; rows just get NULL there.
+        """
+        schema_mgr = SchemaManager(conn, "events")
+        batch = pa.table({"event": ["x"]})
+        write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
+
+        cols = {
+            row[0]
+            for row in conn.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_catalog = 'lake' AND table_name = 'events'"
+            ).fetchall()
+        }
+        # properties absent from batch → properties_variant never ADDed
+        assert "properties_variant" not in cols
+        assert "event" in cols
+
+    def test_existing_table_gains_variant_column_on_evolve(self, conn, cache):
+        schema_mgr = SchemaManager(conn, "events")
+        # First write without dual-write — table has properties VARCHAR only
+        write(
+            conn,
+            "events",
+            pa.table({"properties": ['{"a": 1}']}),
+            cache,
+            schema_mgr,
+        )
+        assert "properties_variant" not in schema_mgr._known_columns
+
+        # Second write enables dual-write — ADD COLUMN + populate
+        write(
+            conn,
+            "events",
+            pa.table({"properties": ['{"a": 2}']}),
+            cache,
+            schema_mgr,
+            variant_columns=("properties",),
+        )
+        assert schema_mgr._known_columns.get("properties_variant") == "VARIANT"
+
+        rows = conn.execute(
+            "SELECT properties, properties_variant FROM lake.main.events ORDER BY properties"
+        ).fetchall()
+        assert len(rows) == 2
+        # First row pre-dates the VARIANT column → NULL companion
+        assert rows[0][1] is None
+        assert rows[1][1] is not None
+
+    def test_source_collision_raises(self, conn, cache):
+        schema_mgr = SchemaManager(conn, "events")
+        batch = pa.table(
+            {
+                "properties": ['{"a": 1}'],
+                "properties_variant": ["already here"],
+            }
+        )
+        with pytest.raises(ValueError, match="properties_variant"):
+            write(conn, "events", batch, cache, schema_mgr, variant_columns=("properties",))
 
 
 @pytest.mark.integration

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -580,6 +580,69 @@ class TestTypedColumnsConfig:
         assert any("Coerce typed columns: timestamp:timestamptz, project_id:bigint" in m for m in msgs)
 
 
+class TestVariantColumnsConfig:
+    """MILLPOND_VARIANT_COLUMNS — dual-write JSON/VARCHAR sources as VARIANT."""
+
+    @pytest.fixture(autouse=True)
+    def _env(self, monkeypatch):
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+        monkeypatch.setenv("KAFKA_TOPIC", "test-topic")
+        monkeypatch.setenv("REPLICA_COUNT", "1")
+        monkeypatch.setenv("POD_NAME", "millpond-events-0")
+        monkeypatch.setenv("DUCKLAKE_TABLE", "events")
+        monkeypatch.setenv("DUCKLAKE_DATA_PATH", "s3://bucket/data")
+        monkeypatch.setenv("DUCKLAKE_RDS_HOST", "host")
+        monkeypatch.setenv("DUCKLAKE_RDS_PASSWORD", "pass")
+        monkeypatch.setenv("DUCKLAKE_CONNECTION", ":memory:")
+
+    def test_unset_yields_none(self):
+        cfg = load()
+        assert cfg.variant_columns is None
+
+    def test_single_column(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_VARIANT_COLUMNS", "properties")
+        cfg = load()
+        assert cfg.variant_columns == ("properties",)
+
+    def test_multiple_columns_order_preserved(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_VARIANT_COLUMNS", "properties,person_properties")
+        cfg = load()
+        assert cfg.variant_columns == ("properties", "person_properties")
+
+    def test_whitespace_and_dedup(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_VARIANT_COLUMNS", " properties , , properties , person_properties ")
+        cfg = load()
+        assert cfg.variant_columns == ("properties", "person_properties")
+
+    def test_whitespace_only_yields_none(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_VARIANT_COLUMNS", "   ")
+        cfg = load()
+        assert cfg.variant_columns is None
+
+    def test_unsafe_name_rejected(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_VARIANT_COLUMNS", "foo; DROP")
+        with pytest.raises(RuntimeError, match="unsafe characters"):
+            load()
+
+    def test_suffix_name_rejected(self, monkeypatch):
+        monkeypatch.setenv("MILLPOND_VARIANT_COLUMNS", "properties_variant")
+        with pytest.raises(RuntimeError, match="already ends with '_variant'"):
+            load()
+
+    def test_log_lists_mappings(self, monkeypatch, caplog):
+        import logging
+
+        monkeypatch.setenv("MILLPOND_VARIANT_COLUMNS", "properties,person_properties")
+        with caplog.at_level(logging.INFO, logger="millpond.config"):
+            load()
+        msgs = [r.message for r in caplog.records]
+        assert any(
+            "Dual-write VARIANT columns: properties -> properties_variant, "
+            "person_properties -> person_properties_variant" in m
+            for m in msgs
+        )
+
+
 class TestIncludeValuesConfig:
     """MILLPOND_INCLUDE_VALUES_* — the dynamic include-set source knobs and
     their validation against the static filter config."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -629,6 +629,13 @@ class TestVariantColumnsConfig:
         with pytest.raises(RuntimeError, match="already ends with"):
             load()
 
+    def test_suffix_name_rejected_case_insensitive(self, monkeypatch):
+        # DuckDB identifiers are case-insensitive, so properties_VARIANT names
+        # the same sink column — the misconfiguration guard must still fire.
+        monkeypatch.setenv("MILLPOND_VARIANT_COLUMNS", "properties_VARIANT")
+        with pytest.raises(RuntimeError, match="already ends with"):
+            load()
+
     def test_log_lists_mappings(self, monkeypatch, caplog):
         import logging
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -626,7 +626,7 @@ class TestVariantColumnsConfig:
 
     def test_suffix_name_rejected(self, monkeypatch):
         monkeypatch.setenv("MILLPOND_VARIANT_COLUMNS", "properties_variant")
-        with pytest.raises(RuntimeError, match="already ends with '_variant'"):
+        with pytest.raises(RuntimeError, match="already ends with"):
             load()
 
     def test_log_lists_mappings(self, monkeypatch, caplog):

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -170,6 +170,7 @@ def _make_cfg(**overrides) -> Config:
         include_values_auth_token=None,
         sort_by=None,
         typed_columns=None,
+        variant_columns=None,
         kafka_config_overrides=(("security.protocol", "SSL"),),
     )
     defaults.update(overrides)

--- a/tests/unit/test_ducklake.py
+++ b/tests/unit/test_ducklake.py
@@ -236,6 +236,19 @@ class TestBuildInsertSelectSql:
         sql = build_insert_select_sql(['weir"d', "properties"], ("properties",))
         assert '"weir""d"' in sql
 
+    def test_case_insensitive_source_match(self):
+        # DuckDB resolves identifiers case-insensitively — a Properties batch
+        # key feeds the same column as configured properties, so it must
+        # dual-write. Alias uses the configured source's casing.
+        sql = build_insert_select_sql(["Properties", "event"], ("properties",))
+        assert 'try_cast(try_cast("Properties" AS JSON) AS VARIANT) AS "properties_variant"' in sql
+
+    def test_case_variant_duplicates_project_companion_once(self):
+        # Two batch keys that casefold to the same source must not emit two
+        # companion aliases (duplicate alias would fail the INSERT).
+        sql = build_insert_select_sql(["Properties", "properties"], ("properties",))
+        assert sql.count('AS "properties_variant"') == 1
+
 
 class TestDropVariantCompanionColumns:
     def test_no_config_unchanged(self):
@@ -259,3 +272,10 @@ class TestDropVariantCompanionColumns:
         batch = pa.table({"properties": ["{}"], "event": ["x"]})
         out = drop_variant_companion_columns(batch, ("properties",))
         assert out.schema.names == ["properties", "event"]
+
+    def test_drops_case_variant_companion(self):
+        # DuckDB identifiers are case-insensitive: PROPERTIES_VARIANT would
+        # land in (and poison) the same catalog column as properties_variant.
+        batch = pa.table({"properties": ["{}"], "PROPERTIES_VARIANT": ["x"], "Properties_Variant": ["y"]})
+        out = drop_variant_companion_columns(batch, ("properties",))
+        assert out.schema.names == ["properties"]

--- a/tests/unit/test_ducklake.py
+++ b/tests/unit/test_ducklake.py
@@ -10,6 +10,9 @@ from millpond.ducklake import (
     _sanitize_setting_value,
     _table_exists,
     _validate_partition_expr,
+    build_insert_select_sql,
+    check_variant_column_collision,
+    variant_column_name,
 )
 
 
@@ -185,3 +188,69 @@ class TestEnsureTable:
         conn.execute.side_effect = execute_side_effect
         _ensure_table(conn, "events", _sample_batch(), cache, partition_by="team_id")
         assert "events" in cache
+
+
+class TestVariantColumnName:
+    def test_suffix(self):
+        assert variant_column_name("properties") == "properties_variant"
+
+    def test_person_properties(self):
+        assert variant_column_name("person_properties") == "person_properties_variant"
+
+
+class TestBuildInsertSelectSql:
+    def test_no_variant_columns_matches_historical_shape(self):
+        sql = build_insert_select_sql(["event", "team_id"], None)
+        assert sql == '"event", "team_id", NOW() AS _inserted_at'
+
+    def test_empty_variant_tuple_is_noop(self):
+        sql = build_insert_select_sql(["event"], ())
+        assert sql == '"event", NOW() AS _inserted_at'
+
+    def test_dual_writes_configured_source(self):
+        sql = build_insert_select_sql(
+            ["event", "properties", "team_id"],
+            ("properties",),
+        )
+        assert '"properties"' in sql
+        assert (
+            'try_cast(try_cast("properties" AS JSON) AS VARIANT) AS "properties_variant"'
+            in sql
+        )
+        assert sql.endswith('NOW() AS _inserted_at')
+        # Original column still present (dual-write, not replace).
+        assert sql.index('"properties"') < sql.index("properties_variant")
+
+    def test_source_absent_from_batch_skipped(self):
+        sql = build_insert_select_sql(["event"], ("properties",))
+        assert "properties_variant" not in sql
+        assert sql == '"event", NOW() AS _inserted_at'
+
+    def test_multiple_sources(self):
+        sql = build_insert_select_sql(
+            ["properties", "person_properties"],
+            ("properties", "person_properties"),
+        )
+        assert 'AS "properties_variant"' in sql
+        assert 'AS "person_properties_variant"' in sql
+
+
+class TestCheckVariantColumnCollision:
+    def test_no_config_ok(self):
+        batch = pa.table({"properties": ["{}"], "properties_variant": ["x"]})
+        check_variant_column_collision(batch.schema, None)  # no raise
+
+    def test_collision_raises(self):
+        batch = pa.table({"properties": ["{}"], "properties_variant": ["x"]})
+        with pytest.raises(ValueError, match="properties_variant"):
+            check_variant_column_collision(batch.schema, ("properties",))
+
+    def test_no_collision_when_source_absent(self):
+        # Batch has the derived name but not the source — dual-write is skipped
+        # for that source, so no collision to report.
+        batch = pa.table({"event": ["x"], "properties_variant": ["y"]})
+        check_variant_column_collision(batch.schema, ("properties",))
+
+    def test_clean_batch_ok(self):
+        batch = pa.table({"properties": ["{}"], "event": ["x"]})
+        check_variant_column_collision(batch.schema, ("properties",))

--- a/tests/unit/test_ducklake.py
+++ b/tests/unit/test_ducklake.py
@@ -144,9 +144,7 @@ class TestEnsureTable:
         conn = MagicMock()
         _ensure_table(conn, "events", _sample_batch(), cache, partition_by="team_id,year(ts)")
         # Find the ALTER PARTITIONED BY call
-        alter_calls = [
-            call for call in conn.execute.call_args_list if "PARTITIONED BY" in str(call)
-        ]
+        alter_calls = [call for call in conn.execute.call_args_list if "PARTITIONED BY" in str(call)]
         assert len(alter_calls) == 1
         assert "team_id,year(ts)" in str(alter_calls[0])
 
@@ -199,13 +197,19 @@ class TestVariantColumnName:
 
 
 class TestBuildInsertSelectSql:
-    def test_no_variant_columns_matches_historical_shape(self):
+    def test_no_variant_columns_uses_star(self):
+        # Opt-in dual-write must not rewrite every writer's INSERT.
         sql = build_insert_select_sql(["event", "team_id"], None)
-        assert sql == '"event", "team_id", NOW() AS _inserted_at'
+        assert sql == "*, NOW() AS _inserted_at"
 
-    def test_empty_variant_tuple_is_noop(self):
+    def test_empty_variant_tuple_uses_star(self):
         sql = build_insert_select_sql(["event"], ())
-        assert sql == '"event", NOW() AS _inserted_at'
+        assert sql == "*, NOW() AS _inserted_at"
+
+    def test_configured_source_absent_from_batch_uses_star(self):
+        sql = build_insert_select_sql(["event"], ("properties",))
+        assert "properties_variant" not in sql
+        assert sql == "*, NOW() AS _inserted_at"
 
     def test_dual_writes_configured_source(self):
         sql = build_insert_select_sql(
@@ -213,18 +217,12 @@ class TestBuildInsertSelectSql:
             ("properties",),
         )
         assert '"properties"' in sql
-        assert (
-            'try_cast(try_cast("properties" AS JSON) AS VARIANT) AS "properties_variant"'
-            in sql
-        )
-        assert sql.endswith('NOW() AS _inserted_at')
+        assert 'try_cast(try_cast("properties" AS JSON) AS VARIANT) AS "properties_variant"' in sql
+        assert sql.endswith("NOW() AS _inserted_at")
         # Original column still present (dual-write, not replace).
         assert sql.index('"properties"') < sql.index("properties_variant")
-
-    def test_source_absent_from_batch_skipped(self):
-        sql = build_insert_select_sql(["event"], ("properties",))
-        assert "properties_variant" not in sql
-        assert sql == '"event", NOW() AS _inserted_at'
+        # Not the star form when dual-write is active.
+        assert not sql.startswith("*")
 
     def test_multiple_sources(self):
         sql = build_insert_select_sql(
@@ -233,6 +231,10 @@ class TestBuildInsertSelectSql:
         )
         assert 'AS "properties_variant"' in sql
         assert 'AS "person_properties_variant"' in sql
+
+    def test_escapes_embedded_quotes_in_identifiers(self):
+        sql = build_insert_select_sql(['weir"d', "properties"], ("properties",))
+        assert '"weir""d"' in sql
 
 
 class TestCheckVariantColumnCollision:

--- a/tests/unit/test_ducklake.py
+++ b/tests/unit/test_ducklake.py
@@ -11,7 +11,7 @@ from millpond.ducklake import (
     _table_exists,
     _validate_partition_expr,
     build_insert_select_sql,
-    check_variant_column_collision,
+    drop_variant_companion_columns,
     variant_column_name,
 )
 
@@ -237,22 +237,25 @@ class TestBuildInsertSelectSql:
         assert '"weir""d"' in sql
 
 
-class TestCheckVariantColumnCollision:
-    def test_no_config_ok(self):
+class TestDropVariantCompanionColumns:
+    def test_no_config_unchanged(self):
         batch = pa.table({"properties": ["{}"], "properties_variant": ["x"]})
-        check_variant_column_collision(batch.schema, None)  # no raise
+        out = drop_variant_companion_columns(batch, None)
+        assert out.schema.names == ["properties", "properties_variant"]
 
-    def test_collision_raises(self):
-        batch = pa.table({"properties": ["{}"], "properties_variant": ["x"]})
-        with pytest.raises(ValueError, match="properties_variant"):
-            check_variant_column_collision(batch.schema, ("properties",))
+    def test_drops_companion_keeps_source(self):
+        batch = pa.table({"properties": ["{}"], "properties_variant": ["x"], "event": ["e"]})
+        out = drop_variant_companion_columns(batch, ("properties",))
+        assert out.schema.names == ["properties", "event"]
+        assert out.column("properties").to_pylist() == ["{}"]
 
-    def test_no_collision_when_source_absent(self):
-        # Batch has the derived name but not the source — dual-write is skipped
-        # for that source, so no collision to report.
+    def test_drops_orphan_companion_without_source(self):
+        # Companion alone would otherwise evolve() as VARCHAR — strip it.
         batch = pa.table({"event": ["x"], "properties_variant": ["y"]})
-        check_variant_column_collision(batch.schema, ("properties",))
+        out = drop_variant_companion_columns(batch, ("properties",))
+        assert out.schema.names == ["event"]
 
-    def test_clean_batch_ok(self):
+    def test_clean_batch_unchanged(self):
         batch = pa.table({"properties": ["{}"], "event": ["x"]})
-        check_variant_column_collision(batch.schema, ("properties",))
+        out = drop_variant_companion_columns(batch, ("properties",))
+        assert out.schema.names == ["properties", "event"]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -173,6 +173,9 @@ class TestFlushErrorDistinction:
         cfg.sort_by = None
         kafka = MagicMock()
         table = pa.table({"a": [1, 2]})
+        # Sinks return the count actually written; _flush feeds it to
+        # records_written_total.
+        sink.write.return_value = table.num_rows
         offsets = {("topic", 0): 42}
         return sink, cfg, kafka, table, offsets
 

--- a/tests/unit/test_millpond_logging_config.py
+++ b/tests/unit/test_millpond_logging_config.py
@@ -74,6 +74,7 @@ def _minimal_config() -> Config:
         include_values_auth_token=None,
         sort_by=None,
         typed_columns=None,
+        variant_columns=None,
         kafka_config_overrides=(),
     )
 


### PR DESCRIPTION
## Summary

- Opt-in `MILLPOND_VARIANT_COLUMNS` dual-writes listed JSON/VARCHAR sources (e.g. `properties`) as companion `{name}_variant` DuckLake `VARIANT` columns while keeping the original string columns unchanged.
- INSERT projects `try_cast(try_cast(col AS JSON) AS VARIANT)` so malformed JSON nulls only the VARIANT side; DuckDB auto-shreds VARIANT on Parquet write.
- Schema evolution `ADD COLUMN IF NOT EXISTS … VARIANT` on first dual-write flush so existing tables pick up companions without in-place `ALTER VARCHAR → VARIANT` (not supported).

## Enable

```bash
MILLPOND_VARIANT_COLUMNS=properties,person_properties
```

Query the companion as `properties_variant."$browser"` (etc.). Historical rows written before enable keep a NULL companion until rewritten.

## Test plan

- [x] `just lint` / `just fmt-check`
- [x] `just test` (668 passed, 1 xfailed)
- [x] `just test-integration` (29 passed, including `TestVariantDualWrite`)
- [ ] Deploy with `MILLPOND_VARIANT_COLUMNS=properties` on a canary table and confirm `properties_variant` appears, shred stats look sane, and original `properties` still matches