### PR TITLE
Add bounded DuckLake metadata metrics

### DIFF
--- a/tests/integration/test_ducklake_metrics_integration.py
+++ b/tests/integration/test_ducklake_metrics_integration.py
@@ -80,6 +80,12 @@ def _stub_full_catalog(c: duckdb.DuckDBPyConnection) -> None:
         "CREATE TABLE __ducklake_metadata_lake.ducklake_inlined_data_tables ("
         "table_id BIGINT, schema_version BIGINT, table_name VARCHAR)"
     )
+    c.execute(
+        "CREATE TABLE __ducklake_metadata_lake.ducklake_file_column_stats ("
+        "data_file_id BIGINT, table_id BIGINT, column_id BIGINT, column_size_bytes BIGINT, "
+        "value_count BIGINT, null_count BIGINT, min_value VARCHAR, max_value VARCHAR, "
+        "contains_nan BOOLEAN, extra_stats VARCHAR)"
+    )
     # Seed: enough rows that every metric has a non-zero value.
     c.execute(
         "INSERT INTO __ducklake_metadata_lake.ducklake_data_file VALUES "
@@ -114,6 +120,11 @@ def _stub_full_catalog(c: duckdb.DuckDBPyConnection) -> None:
         "INSERT INTO __ducklake_metadata_lake.ducklake_inlined_data_tables VALUES "
         "(1, 1, 'ducklake_inlined_data_1_1'),"  # parent live → reachable
         "(99, 1, 'ducklake_inlined_data_99_1')"  # no parent ducklake_table row → unreachable
+    )
+    c.execute(
+        "INSERT INTO __ducklake_metadata_lake.ducklake_file_column_stats VALUES "
+        "(1, 1, 0, 1024, 1000, 10, 'a', 'z', false, NULL),"
+        "(1, 1, 1, 2048, 1000, 0, '0', '9', false, NULL)"
     )
 
 

--- a/tests/unit/test_ducklake_metrics.py
+++ b/tests/unit/test_ducklake_metrics.py
@@ -316,6 +316,10 @@ def _stub_catalog(conn):
         "data_file_id BIGINT, table_id BIGINT, partition_key_index BIGINT, partition_value VARCHAR)"
     )
     conn.execute(
+        "CREATE TABLE __ducklake_metadata_lake.ducklake_file_column_stats ("
+        "data_file_id BIGINT, table_id BIGINT, column_id BIGINT)"
+    )
+    conn.execute(
         "CREATE TABLE __ducklake_metadata_lake.ducklake_snapshot ("
         "snapshot_id BIGINT, snapshot_time VARCHAR, schema_version BIGINT)"
     )
@@ -327,6 +331,42 @@ def _stub_catalog(conn):
 
 def _builtin(name):
     return next(q for q in dm.load_queries(None, set()) if q.name == name)
+
+
+class TestBuiltinMetadataLookups:
+    @pytest.mark.parametrize(
+        ("query_name", "metric_name", "expected"),
+        [
+            ("ducklake_metadata_live_file_lookup", "files", 1),
+            ("ducklake_metadata_partition_value_lookup", "values", 2),
+            ("ducklake_metadata_file_column_stats_lookup", "stats", 2),
+        ],
+    )
+    def test_reads_only_metadata_for_one_live_file(self, conn, registry, query_name, metric_name, expected):
+        _stub_catalog(conn)
+        conn.execute(
+            "INSERT INTO __ducklake_metadata_lake.ducklake_data_file VALUES "
+            "(1, 1, 0, NULL, 'live', 100, 10),"
+            "(2, 1, 0, 1, 'expired', 100, 10)"
+        )
+        conn.execute(
+            "INSERT INTO __ducklake_metadata_lake.ducklake_file_partition_value VALUES "
+            "(1, 1, 0, '2026-01-01'),"
+            "(1, 1, 1, '00'),"
+            "(2, 1, 0, 'expired')"
+        )
+        conn.execute(
+            "INSERT INTO __ducklake_metadata_lake.ducklake_file_column_stats VALUES (1, 1, 10),(1, 1, 11),(2, 1, 10)"
+        )
+
+        q = _builtin(query_name)
+        assert q.interval_seconds == 60 * 60
+        assert "LIMIT 256" in q.sql
+        gauges = dm._build_query_gauges([q], registry=registry)
+        sm = dm._build_self_metrics(registry=registry)
+        _run(conn, q, gauges[q.name], sm)
+
+        assert _gauge_value(registry, f"{query_name}_{metric_name}") == expected
 
 
 class TestBuiltinFilesPerBand:

--- a/tools/README.md
+++ b/tools/README.md
@@ -87,6 +87,9 @@ Built-in queries (lake-wide; no `table_name` label by design):
 | `ducklake_compaction_candidates` | `tier` | `count` | `ducklake_data_file`; tier buckets match `ducklake_maintenance.py`'s `TIERS` (`tier1` < 1 MiB, `tier2` [1, 10) MiB, `tier3` [10, 64) MiB, `large` ≥ 64 MiB, plus `total`) |
 | `ducklake_snapshots` | — | `count`, `oldest_seconds_ago`, `newest_seconds_ago` | `ducklake_snapshot`; CASTs `snapshot_time` (VARCHAR) to TIMESTAMPTZ before time arithmetic |
 | `ducklake_files_per_partition_top20` | `partition` | `count` | Composite partition values joined with `/`; live files without partition_value rows surface as `<none>` |
+| `ducklake_metadata_live_file_lookup` | — | `files` | Hourly, bounded lookup of one live data-file metadata row; no data-file read or identifiers emitted |
+| `ducklake_metadata_partition_value_lookup` | — | `values` | Hourly, bounded lookup of partition metadata for one live data file; no partition values emitted |
+| `ducklake_metadata_file_column_stats_lookup` | — | `stats` | Hourly, bounded lookup of column-statistics metadata for one live data file; no statistics emitted |
 | `ducklake_catalog` | `suffix` | `format_version` | `ducklake_metadata` row with `key='version'` and `scope IS NULL`. Numeric `major.minor` (extracted via `regexp_extract`) lands in the gauge value; any trailing tag DuckLake attaches (`-dev1` on main after `MigrateV10`, future `-rcN`/`-betaN` shapes) lands in the `suffix` label. Empty `suffix=""` for clean releases. Polled every 60 minutes — value changes only on a DuckLake upgrade |
 
 Self-metrics (always on):

--- a/tools/ducklake_metrics.py
+++ b/tools/ducklake_metrics.py
@@ -254,6 +254,73 @@ queries:
       ORDER BY count DESC
       LIMIT 20
 
+  - name: ducklake_metadata_live_file_lookup
+    help: |
+      Hourly bounded metadata lookup for one live data file. This exercises
+      the catalog read path DuckLake uses after selecting a visible file,
+      without reading the file itself or exposing table/customer identifiers.
+    interval_mins: 60
+    values: [files]
+    sql: |
+      WITH target AS (
+        SELECT data_file_id
+        FROM __ducklake_metadata_lake.ducklake_data_file
+        WHERE end_snapshot IS NULL
+        LIMIT 1
+      )
+      SELECT COUNT(*) AS files
+      FROM (
+        SELECT df.data_file_id
+        FROM __ducklake_metadata_lake.ducklake_data_file df
+        JOIN target USING (data_file_id)
+        WHERE df.end_snapshot IS NULL
+        LIMIT 256
+      ) AS lookup_rows
+
+  - name: ducklake_metadata_partition_value_lookup
+    help: |
+      Hourly bounded metadata lookup for partition values of one live data
+      file. It exercises DuckLake's file-to-partition metadata read path
+      without querying data files or emitting partition values.
+    interval_mins: 60
+    values: [values]
+    sql: |
+      WITH target AS (
+        SELECT data_file_id
+        FROM __ducklake_metadata_lake.ducklake_data_file
+        WHERE end_snapshot IS NULL
+        LIMIT 1
+      )
+      SELECT COUNT(*) AS values
+      FROM (
+        SELECT fpv.partition_key_index
+        FROM __ducklake_metadata_lake.ducklake_file_partition_value fpv
+        JOIN target USING (data_file_id)
+        LIMIT 256
+      ) AS lookup_rows
+
+  - name: ducklake_metadata_file_column_stats_lookup
+    help: |
+      Hourly bounded metadata lookup for column statistics of one live data
+      file. It exercises DuckLake's file-statistics read path without reading
+      Parquet data or emitting column identifiers or statistics.
+    interval_mins: 60
+    values: [stats]
+    sql: |
+      WITH target AS (
+        SELECT data_file_id
+        FROM __ducklake_metadata_lake.ducklake_data_file
+        WHERE end_snapshot IS NULL
+        LIMIT 1
+      )
+      SELECT COUNT(*) AS stats
+      FROM (
+        SELECT fcs.column_id
+        FROM __ducklake_metadata_lake.ducklake_file_column_stats fcs
+        JOIN target USING (data_file_id)
+        LIMIT 256
+      ) AS lookup_rows
+
   - name: ducklake_catalog
     help: |
       DuckLake catalog format version. The numeric major.minor lands in the


### PR DESCRIPTION
## Summary

- add three built-in hourly DuckLake metadata lookup metrics
- bound each lookup to one live data file and at most 256 metadata rows
- document the metrics and cover them with catalog-schema unit tests

The queries read only DuckLake catalog metadata. They do not read Parquet data or emit table, partition, column, or statistic values.

## Testing

- `just fmt-check`
- `just lint`
- `just test` (676 passed, 1 xfailed)
