### PR TITLE
deps: duckdb 1.5.5 + pyducklake 1.0.17 — leak-free ducklake channel, drift-gated

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,8 +50,10 @@ jobs:
         #   - googleapis-common-*  Apache-2.0
         #   - opentelemetry-*      Apache-2.0
         #   - protobuf             BSD-3-Clause
+        #   - pyducklake           Apache-2.0 (ours; PEP 639-only metadata)
         # Remove entries here as the action's PEP 639 parser catches up.
         allow-dependencies-licenses: >-
+          pkg:pypi/pyducklake,
           pkg:pypi/googleapis-common-protos,
           pkg:pypi/opentelemetry-api,
           pkg:pypi/opentelemetry-exporter-otlp-proto-common,

--- a/AGENT.md
+++ b/AGENT.md
@@ -473,7 +473,8 @@ Prometheus metrics and health checks on port 8000 via a custom `http.server.HTTP
 | Package | Why |
 |---------|-----|
 | `confluent-kafka>=2.6` | librdkafka Python wrapper |
-| `duckdb==1.5.2` | DuckDB Python client (pinned; the ducklake extension is sensitive to minor-version moves) |
+| `duckdb==1.5.5` | DuckDB Python client (pinned; the ducklake extension is sensitive to minor-version moves) |
+| `pyducklake>=1.0.17` | Our DuckLake Python API (unused yet; lockstep canary for the duckdb pin) |
 | `pyarrow>=18.0` | Arrow tables, zero-copy DuckDB integration |
 | `orjson>=3.10` | Fast JSON parsing (Rust) |
 | `prometheus-client>=0.21` | Metrics exposition |

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,13 +70,18 @@ USER millpond
 #
 # The DuckLake extension cannot be version-pinned at install time — the extension
 # repository doesn't expose pinned versions for it (INSTALL ducklake VERSION '...'
-# returns 404). The DuckDB Python pin (1.5.2 in pyproject.toml) locks the
-# DuckLake major line, and tests/unit/test_ducklake_pin.py asserts the loaded
-# extension's build SHA at runtime so a drift trips in CI rather than in prod.
+# returns 404), and the channel the duckdb pin selects is LIVE: it can re-serve
+# a new ducklake build under the same URL at any time. So the build SHA is
+# asserted HERE, failing the image build on drift — the release workflow runs
+# in parallel with CI, so the CI canary (tests/unit/test_ducklake_pin.py,
+# same SHA constant; update both together) alone cannot stop a drifted build
+# from reaching the fleet via the mutable tag. An unexpected ducklake build
+# must be unable to produce an image at all.
 # aws: required by CREATE SECRET (TYPE s3, PROVIDER credential_chain) — the
 # Pod-Identity path the tenant maintenance crons use. Without it DuckDB
 # auto-installs at runtime, which dies on a read-only root filesystem.
-RUN python -c "import duckdb; c = duckdb.connect(); c.execute('INSTALL httpfs'); c.execute('INSTALL ducklake'); c.execute('INSTALL postgres'); c.execute('INSTALL aws')"
+ARG DUCKLAKE_SHA=d8a1881e
+RUN python -c "import duckdb, os; c = duckdb.connect(); c.execute('INSTALL httpfs'); c.execute('INSTALL ducklake'); c.execute('INSTALL postgres'); c.execute('INSTALL aws'); c.execute('LOAD ducklake'); v = c.execute(\"SELECT extension_version FROM duckdb_extensions() WHERE extension_name = 'ducklake'\").fetchone()[0]; want = os.environ['DUCKLAKE_SHA']; assert v == want, f'ducklake extension channel drift: channel serves {v}, image validated against {want}'"
 
 # Build-time smoke test for the duckdb CLI as the runtime user. Catches any
 # regression where the CLI is installed somewhere the `millpond` user can't

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,15 +16,27 @@ license = {file = "LICENSE"}
 requires-python = ">=3.12"
 dependencies = [
     "confluent-kafka>=2.6",
-    # Pinned exactly. 1.5.2 is the DuckDB release that ships DuckLake 1.0,
-    # the breaking-change rev of the ducklake extension that millpond/ducklake.py
-    # has been aligned against. The DuckLake 1.x line is pre-stable, and the
-    # extension repository does not expose installable version specifiers for
+    # Pinned exactly, and matched to pyducklake's own duckdb pin. The DuckDB
+    # version selects the ducklake extension channel: 1.5.2's channel is
+    # frozen at build 415a9ebd (2026-04-09), whose per-connection
+    # stats/schemas caches grow unbounded as catalog snapshots advance —
+    # the leak that OOM-killed viaduck every 4-6h (A/B-verified there:
+    # 415a9ebd leaks ~1MiB per snapshot-advancing bind; the 1.5.5-channel
+    # build is flat). The DuckLake 1.x line is pre-stable, and the extension
+    # repository does not expose installable version specifiers for
     # ducklake — INSTALL ducklake VERSION '...' returns 404. To compensate,
     # tests/unit/test_ducklake_pin.py asserts the build SHA of the loaded
     # extension as a drift canary. Bumping this DuckDB pin (or letting the
     # extension SHA move) requires updating that canary explicitly.
-    "duckdb==1.5.2",
+    "duckdb==1.5.5",
+    # Our DuckLake Python API (jghoman/pyducklake). Nothing imports it yet —
+    # it is here as a deliberate lockstep canary: pyducklake hard-pins its
+    # duckdb version (==1.5.5 as of 1.0.17, the first release on the safe
+    # extension channel above), so a future bump of either duckdb or
+    # pyducklake that the other hasn't matched makes `uv lock` unresolvable
+    # instead of silently splitting the two DuckLake stacks. Adoption of the
+    # API itself comes later.
+    "pyducklake>=1.0.17",
     "pyarrow>=18.0",
     "orjson>=3.10",
     "prometheus-client>=0.21",
@@ -84,6 +96,12 @@ norecursedirs = ["lakekeeper", ".venv", "node_modules"]
 
 [tool.uv]
 exclude-newer = "7 days"
+# Cooldown carve-out for our own package (jghoman/pyducklake): 1.0.17 was
+# published 2026-08-13 and is needed now for the safe ducklake extension
+# channel. Fixed date, not a rolling window — future pyducklake releases
+# re-enter the cooldown until this date is bumped alongside an intentional
+# version bump.
+exclude-newer-package = { pyducklake = "2026-08-14T00:00:00Z" }
 constraint-dependencies = [
     "pygments>=2.20.0",
     "requests>=2.33.0",

--- a/tests/integration/test_compaction_isolation_integration.py
+++ b/tests/integration/test_compaction_isolation_integration.py
@@ -17,8 +17,8 @@ Asserts the per-table compact() loop:
 
 These tests also pin the load-bearing recovery property: the DuckDB
 connection survives the extension's InternalException, so the loop can keep
-going (verified on duckdb 1.5.2; a future duckdb that invalidates the
-instance on INTERNAL errors would fail here, loudly).
+going (verified on duckdb 1.5.2 and 1.5.5; a future duckdb that invalidates
+the instance on INTERNAL errors would fail here, loudly).
 
 Skips when the ducklake extension can't be installed (offline CI).
 """
@@ -65,7 +65,10 @@ def _poison_tables(conn: duckdb.DuckDBPyConnection, attach: str, table_names: tu
     is a substring of the other and the compactor's containment check fails
     regardless of which file leads the group). Direct UPDATE on the metadata
     duckdb file, with the lake detached."""
-    meta_path = conn.execute(f"SELECT path FROM duckdb_databases() WHERE database_name = '{META_SCHEMA}'").fetchone()[0]
+    # duckdb 1.5.5: the ducklake attach no longer lists the metadata db as
+    # its own duckdb_databases() row (formerly under META_SCHEMA); the
+    # attach's own row now carries the metadata file path.
+    meta_path = conn.execute(f"SELECT path FROM duckdb_databases() WHERE database_name = '{LAKE}'").fetchone()[0]
     conn.execute(f"DETACH {LAKE}")
     meta_conn = duckdb.connect(meta_path)
     for table_name in table_names:

--- a/tests/integration/test_ducklake_engine_contract.py
+++ b/tests/integration/test_ducklake_engine_contract.py
@@ -1,0 +1,137 @@
+"""Engine-behavior contract for the pinned DuckDB + DuckLake build.
+
+`tests/unit/test_ducklake_pin.py` pins WHICH build we run;
+this file pins the physical behaviors millpond's variant guard ASSUMES of
+that build, probed the way the 2026-08-12 incident actually executed:
+raw `try_cast(... AS VARIANT)` INSERTs against a real DuckLake catalog,
+with millpond's guard deliberately bypassed.
+
+The load-bearing invariant is set containment, not any specific boundary:
+
+    every value the engine refuses to shred is a value
+    `sanitize_variant_sources` rewrites first
+
+If a version bump shifts the rejection window (wider: prod crash-loops on
+values the prefilter never flags; narrower: the guard is stringifying
+values that now shred fine), or changes the failure's error signature so
+`_is_unshreddable_value_error` stops matching (write-time backstop goes
+blind), this file fails at the bump PR instead of on the running fleet.
+The 1.5.2 -> 1.5.5 bump is the motivating example: it changed the inlined
+failure's reported width (UINT64 -> INT128) and the out-of-range
+representation (VARCHAR -> DOUBLE) — both invisible to in-memory tests.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pyarrow as pa
+import pytest
+
+from millpond.ducklake import (
+    _is_unshreddable_value_error,
+    sanitize_variant_sources,
+)
+
+
+def _doc(value_literal: str) -> str:
+    return f'{{"v": {value_literal}}}'
+
+
+# JSON-document probes around every edge the guard's window logic and Arrow
+# prefilter are shaped to, plus non-scalar shapes (shredding is per-path, so
+# nested/array rejection behavior can diverge from top-level independently).
+# `shreds` is what the CURRENT pinned build does with the raw document; the
+# containment assertion below is what running millponds actually depend on.
+# Probes are pre-rendered JSON strings so no Python-repr formatting (floats,
+# bools) can leak into the SQL literal.
+_PROBES = [
+    pytest.param(_doc(str(2**63 - 1)), True, id="int64-max-shreds"),
+    pytest.param(_doc(str(2**63)), False, id="window-start-rejected"),
+    pytest.param(_doc("9223372036854775999"), False, id="incident-shape-rejected"),
+    pytest.param(_doc(str(2**64 - 1)), False, id="uint64-max-rejected"),
+    pytest.param(_doc(str(2**64)), True, id="above-uint64-shreds-as-double"),
+    pytest.param(_doc(str(10**30)), True, id="huge-shreds-as-double"),
+    pytest.param(_doc(str(-(2**63))), True, id="int64-min-shreds"),
+    pytest.param(_doc(str(-(2**63) - 1)), True, id="below-int64-min-shreds-as-double"),
+    pytest.param(_doc("1723526400000000000"), True, id="ns-timestamp-shreds"),
+    pytest.param(_doc("1234567890123456789"), True, id="snowflake-id-shreds"),
+    # JSON's reader types any decimal/exponent form as DOUBLE, so these shred
+    # regardless of magnitude — and the guard must NOT rewrite them.
+    pytest.param(_doc("9.3e18"), True, id="sci-notation-shreds-as-double"),
+    pytest.param(_doc("9223372036854775808.5"), True, id="decimal-shreds-as-double"),
+    # Window values below the top level: rejected and guarded identically
+    # today; pinned separately because per-path shredding could change one
+    # without the other.
+    pytest.param(f'{{"outer": {{"inner": {2**63}}}}}', False, id="nested-window-rejected"),
+    pytest.param(f'{{"arr": [{2**63}]}}', False, id="array-window-rejected"),
+]
+
+
+def _raw_variant_insert(conn: duckdb.DuckDBPyConnection, doc: str) -> None:
+    """The incident's execution shape: guard bypassed, shredded Parquet write."""
+    conn.execute("CREATE TABLE IF NOT EXISTS lake.main.contract (id INT, v VARIANT)")
+    conn.execute(f"INSERT INTO lake.main.contract SELECT 1, try_cast('{doc}'::JSON AS VARIANT)")
+
+
+def _guard_rewrites(doc: str) -> bool:
+    """Does the REAL production guard chain (Arrow prefilter -> precise JSON
+    pass) rewrite this document? Testing through sanitize_variant_sources
+    rather than _coerce_unshreddable_ints so a prefilter miss counts as a
+    miss."""
+    batch = pa.table({"properties": [doc]})
+    _, projection_map = sanitize_variant_sources(batch, ("properties",))
+    return "properties" in projection_map
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(("doc", "shreds"), _PROBES)
+def test_engine_rejections_are_a_subset_of_guard_rewrites(ducklake_conn, doc, shreds):
+    conn = ducklake_conn
+    try:
+        _raw_variant_insert(conn, doc)
+        engine_rejects = False
+    except Exception as exc:  # noqa: BLE001 — classified below, not swallowed
+        engine_rejects = True
+        # The write-time backstop must recognize the failure, whatever
+        # integer width this build reports it as.
+        assert _is_unshreddable_value_error(exc), f"unmatched signature: {exc}"
+
+    assert engine_rejects == (not shreds), (
+        f"pinned build changed shred behavior for {doc}: "
+        f"expected shreds={shreds}. Re-derive the danger window and realign "
+        f"_INT64_MAX/_UINT64_MAX and _MAYBE_UNSHEDDABLE_DIGITS in ducklake.py."
+    )
+
+    # THE contract: anything the engine rejects, the guard must have
+    # rewritten before it ever reaches the engine. The converse is pinned
+    # too — a guard false-positive on a shreddable value costs companion
+    # typing fidelity (ns timestamps as strings was the pre-#118 heuristic's
+    # failure mode), so these probe docs must round-trip untouched.
+    if engine_rejects:
+        assert _guard_rewrites(doc), (
+            f"{doc} fails the shredded write but escapes "
+            f"sanitize_variant_sources — running millponds would crash-loop "
+            f"on it (2026-08-12 shape)."
+        )
+    else:
+        assert not _guard_rewrites(doc), (
+            f"{doc} shreds fine but the guard rewrites it — companion typing "
+            f"fidelity lost for a value the engine accepts."
+        )
+
+
+@pytest.mark.integration
+def test_inlined_commit_detonates_at_flush_with_matched_signature(ducklake_conn_inlining):
+    """The deferred failure mode: an unshreddable value COMMITS when the write
+    is small enough to inline, then fails ducklake_flush_inlined_data later —
+    where no write-time retry can reach it. Running millponds rely on the
+    per-row guard being the only defense here; this pins that the mode still
+    exists, still commits silently, and still reports a signature the matcher
+    recognizes (1.5.5 changed its reported width to INT128)."""
+    conn = ducklake_conn_inlining
+    _raw_variant_insert(conn, _doc(str(2**63)))  # window start; commits inlined
+    with pytest.raises(Exception) as excinfo:
+        conn.execute("CALL ducklake_flush_inlined_data('lake')")
+    assert _is_unshreddable_value_error(excinfo.value), (
+        f"inlined-flush failure signature no longer matched: {excinfo.value}"
+    )

--- a/tests/integration/test_write_integration.py
+++ b/tests/integration/test_write_integration.py
@@ -164,9 +164,10 @@ class TestVariantDualWrite:
 
     # The ONLY window DuckDB accepts into a VARIANT but cannot shred is
     # (INT64_MAX, UINT64_MAX]. Verified against a real catalog: ns timestamps,
-    # snowflake ids, INT64_MAX itself, values above UINT64_MAX (kept as a
-    # VARIANT string) and negatives all shred fine. Getting this boundary wrong
-    # in either direction is the whole hazard, so the cases below pin it.
+    # snowflake ids, INT64_MAX itself, values outside [INT64_MIN, UINT64_MAX]
+    # (DOUBLE since duckdb 1.5.5; digit-preserving VARCHAR before) and
+    # negatives all shred fine. Getting this boundary wrong in either
+    # direction is the whole hazard, so the cases below pin it.
     _POISON_JSON = '{"n": 9223372036854775999}'  # INT64_MAX < n <= UINT64_MAX
 
     def test_unshreddable_integer_is_coerced_keeping_the_rest_of_the_row(self, ducklake_conn, cache):
@@ -228,12 +229,20 @@ class TestVariantDualWrite:
         # The three inside INT64's range keep numeric typing — a digit-count
         # heuristic would have stringified or nulled these.
         assert [r[2] for r in rows[:3]] == ["INT64"] * 3, rows
-        # Rows 4-5 read back as VARCHAR because that is how DuckDB itself
-        # represents out-of-INT64-range literals in a VARIANT; the sanitizer
-        # leaves them alone (they shred fine), and the digits survive.
+        # Rows 4-5 track DuckDB's own representation for numbers outside
+        # [INT64_MIN, UINT64_MAX]: DOUBLE since duckdb 1.5.5 (VARCHAR with
+        # digits preserved on 1.5.2 and earlier). Deliberate policy: the
+        # companion follows native DuckLake semantics — lossy for these
+        # pathological magnitudes — and exact digits live in the
+        # authoritative string column, asserted below. The sanitizer leaves
+        # them alone (they shred fine either way).
+        assert [r[2] for r in rows[3:]] == ["DOUBLE"] * 2, rows
+        assert conn.execute("SELECT properties_variant.v::DOUBLE FROM lake.main.events WHERE id = 5").fetchone()[
+            0
+        ] == float("-9223372036854775809")
         assert (
-            conn.execute("SELECT properties_variant.v FROM lake.main.events WHERE id = 5").fetchone()[0]
-            == "-9223372036854775809"
+            conn.execute("SELECT properties FROM lake.main.events WHERE id = 5").fetchone()[0]
+            == '{"v": -9223372036854775809}'
         )
 
     def test_digits_inside_a_string_value_are_untouched(self, ducklake_conn, cache):

--- a/tests/unit/test_ducklake_pin.py
+++ b/tests/unit/test_ducklake_pin.py
@@ -36,8 +36,8 @@ import duckdb
 # Update both constants together when revalidating against a new release.
 # The DuckDB version is exact; the DuckLake SHA is whatever the core
 # extension repo currently serves for that DuckDB version's platform.
-_VERIFIED_DUCKDB_VERSION = "1.5.2"
-_VERIFIED_DUCKLAKE_SHA = "415a9ebd"
+_VERIFIED_DUCKDB_VERSION = "1.5.5"
+_VERIFIED_DUCKLAKE_SHA = "d8a1881e"
 
 
 def test_duckdb_version_is_pinned():

--- a/tools/ducklake_maintenance.py
+++ b/tools/ducklake_maintenance.py
@@ -2194,8 +2194,8 @@ def compact(
                         break
                     except Exception:
                         # Continue-on-error relies on the connection SURVIVING
-                        # the failed CALL (verified on duckdb 1.5.2 even for
-                        # InternalException, and pinned end-to-end by
+                        # the failed CALL (verified on duckdb 1.5.2 and 1.5.5,
+                        # even for InternalException, and pinned end-to-end by
                         # test_compaction_isolation_integration). If a future
                         # duckdb bump invalidates the instance on INTERNAL
                         # errors, every table fails, the failure summary +

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,9 @@ requires-python = ">=3.12"
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
+[options.exclude-newer-package]
+pyducklake = "2026-08-14T00:00:00Z"
+
 [manifest]
 constraints = [
     { name = "pygments", specifier = ">=2.20.0" },
@@ -196,31 +199,31 @@ wheels = [
 
 [[package]]
 name = "duckdb"
-version = "1.5.2"
+version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0c/66/744b4931b799a42f8cb9bc7a6f169e7b8e51195b62b246db407fd90bf15f/duckdb-1.5.2.tar.gz", hash = "sha256:638da0d5102b6cb6f7d47f83d0600708ac1d3cb46c5e9aaabc845f9ba4d69246", size = 18017166, upload-time = "2026-04-13T11:30:09.065Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/19/e57151753576373c6696a12022648546cca6038e8833fda2908ee2342d9b/duckdb-1.5.5.tar.gz", hash = "sha256:72f33ee57ca7595b23957671a2cc7f7fe2be0ecc2d68f63abedcfcaa3a5c1238", size = 18066741, upload-time = "2026-07-22T10:55:17.819Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/de/ebe66bbe78125fc610f4fd415447a65349d94245950f3b3dfb31d028af02/duckdb-1.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e6495b00cad16888384119842797c49316a96ae1cb132bb03856d980d95afee1", size = 30064950, upload-time = "2026-04-13T11:29:11.468Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/8a/3e25b5d03bcf1fb99d189912f8ce92b1db4f9c8778e1b1f55745973a855a/duckdb-1.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d72b8856b1839d35648f38301b058f6232f4d36b463fe4dc8f4d3fdff2df1a2e", size = 15969113, upload-time = "2026-04-13T11:29:14.139Z" },
-    { url = "https://files.pythonhosted.org/packages/19/bb/58001f0815002b1a93431bf907f77854085c7d049b83d521814a07b9db0b/duckdb-1.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2a1de4f4d454b8c97aec546c82003fc834d3422ce4bc6a19902f3462ef293bed", size = 14224774, upload-time = "2026-04-13T11:29:16.758Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/2f/a7f0de9509d1cef35608aeb382919041cdd70f58c173865c3da6a0d87979/duckdb-1.5.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce0b8141a10d37ecef729c45bc41d334854013f4389f1488bd6035c5579aaac1", size = 19313510, upload-time = "2026-04-13T11:29:19.574Z" },
-    { url = "https://files.pythonhosted.org/packages/26/78/eb1e064ea8b9df3b87b167bfd7a407b2f615a4291e06cba756727adfa06c/duckdb-1.5.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c99ef73a277c8921bc0a1f16dee38d924484251d9cfd20951748c20fcd5ed855", size = 21429692, upload-time = "2026-04-13T11:29:22.575Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/12/05b0c47d14839925c5e35b79081d918ca82e3f236bb724a6f58409dd5291/duckdb-1.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:8d599758b4e48bf12e18c9b960cf491d219f0c4972d19a45489c05cc5ab36f83", size = 13107594, upload-time = "2026-04-13T11:29:25.43Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/2c/80558a82b236e044330e84a154b96aacddb343316b479f3d49be03ea11cb/duckdb-1.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:fc85a5dbcbe6eccac1113c72370d1d3aacfdd49198d63950bdf7d8638a307f00", size = 13927537, upload-time = "2026-04-13T11:29:27.842Z" },
-    { url = "https://files.pythonhosted.org/packages/98/f2/e3d742808f138d374be4bb516fade3d1f33749b813650810ab7885cdc363/duckdb-1.5.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4420b3f47027a7849d0e1815532007f377fa95ee5810b47ea717d35525c12f79", size = 30064879, upload-time = "2026-04-13T11:29:30.763Z" },
-    { url = "https://files.pythonhosted.org/packages/72/0d/f3dc1cf97e1267ca15e4307d456f96ce583961f0703fd75e62b2ad8d64fa/duckdb-1.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:bb42e6ed543902e14eae647850da24103a89f0bc2587dec5601b1c1f213bd2ed", size = 15969327, upload-time = "2026-04-13T11:29:33.481Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/e0/d5418def53ae4e05a63075705ff44ed5af5a1a5932627eb2b600c5df1c93/duckdb-1.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98c0535cd6d901f61a5ea3c2e26a1fd28482953d794deb183daf568e3aa5dda6", size = 14225107, upload-time = "2026-04-13T11:29:35.882Z" },
-    { url = "https://files.pythonhosted.org/packages/16/a7/15aaa59dbecc35e9711980fcdbf525b32a52470b32d18ef678193a146213/duckdb-1.5.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:486c862bf7f163c0110b6d85b3e5c031d224a671cca468f12ebb1d3a348f6b39", size = 19313433, upload-time = "2026-04-13T11:29:38.367Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/21/d903cc63a5140c822b7b62b373a87dc557e60c29b321dfb435061c5e67cf/duckdb-1.5.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70631c847ca918ee710ec874241b00cf9d2e5be90762cbb2a0389f17823c08f7", size = 21429837, upload-time = "2026-04-13T11:29:41.135Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/0a/b770d1f60c70597302130d6247f418549b7094251a02348fbaf1c7e147ae/duckdb-1.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:52a21823f3fbb52f0f0e5425e20b07391ad882464b955879499b5ff0b45a376b", size = 13107699, upload-time = "2026-04-13T11:29:43.905Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/cf/e200fe431d700962d1a908d2ce89f53ccee1cc8db260174ae663ba09686b/duckdb-1.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:411ad438bd4140f189a10e7f515781335962c5d18bd07837dc6d202e3985253d", size = 13927646, upload-time = "2026-04-13T11:29:46.598Z" },
-    { url = "https://files.pythonhosted.org/packages/83/a1/f6286c67726cc1ea60a6e3c0d9fbc66527dde24ae089a51bbe298b13ca78/duckdb-1.5.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6b0fe75c148000f060aa1a27b293cacc0ea08cc1cad724fbf2143d56070a3785", size = 30078598, upload-time = "2026-04-13T11:29:49.828Z" },
-    { url = "https://files.pythonhosted.org/packages/de/6a/59febb02f21a4a5c6b0b0099ef7c965fdd5e61e4904cf813809bb792e35f/duckdb-1.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:35579b8e3a064b5eaf15b0eafc558056a13f79a0a62e34cc4baf57119daecfec", size = 15975120, upload-time = "2026-04-13T11:29:52.631Z" },
-    { url = "https://files.pythonhosted.org/packages/09/70/ce750854d37bb5a45cccbb2c3cb04df4af56aea8fc30a2499bb643b4a9c0/duckdb-1.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ea58ff5b0880593a280cf5511734b17711b32ee1f58b47d726e8600848358160", size = 14227762, upload-time = "2026-04-13T11:29:55.564Z" },
-    { url = "https://files.pythonhosted.org/packages/28/dc/ad45ac3c0b6c4687dc649e8f6cf01af1c8b0443932a39b2abb4ebcb3babd/duckdb-1.5.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef461bca07313412dc09961c4a4757a851f56b95ac01c58fac6007632b7b94f2", size = 19315668, upload-time = "2026-04-13T11:29:58.427Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/b1/1464f468d2e5813f5808de95df9d3113a645a5bfa2ffcaecbc542ddae272/duckdb-1.5.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be37680ddb380015cb37318e378c53511c45c4f0d8fac5599d22b7d092b9217a", size = 21434056, upload-time = "2026-04-13T11:30:01.238Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/32/6673607e024722473fa7aafdd29c0e3dd231dd528f6cd8b5797fbeeb229d/duckdb-1.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:0b291786014df1133f8f18b9df4d004484613146e858d71a21791e0fcca16cf4", size = 13633667, upload-time = "2026-04-13T11:30:04.05Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/e3/9d34173ec068631faea3ea6e73050700729363e7e33306a9a3218e5cdc61/duckdb-1.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:c9f3e0b71b8a50fccfb42794899285d9d318ce2503782b9dd54868e5ecd0ad31", size = 14402513, upload-time = "2026-04-13T11:30:06.609Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/40/2e05d324400fdaa5656c9f48d6298da421cb034d85e509fa0e6e325cf04b/duckdb-1.5.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d4dd65f8941a604b947e0b9b4b4f7165988e29a23ec0b69b4038520956d9933e", size = 32753858, upload-time = "2026-07-22T10:54:05.514Z" },
+    { url = "https://files.pythonhosted.org/packages/79/15/5ceb58ffb5bb8a62b3fd7abb39c41467cdf94850ece02e6d88664dfc75ce/duckdb-1.5.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33db46679b071f108d57139493dee2d37e1f5efcf5c5c039c2969eed11a6c8a7", size = 17368293, upload-time = "2026-07-22T10:54:09.139Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/5c/bf02da0b354fe83cca4f95a4fbf762181af466f7d551ab2a093f7698882a/duckdb-1.5.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f0b88535a5d86fdd63dba6ea02ab68c003dfb9e4892b11256ef24c4da208baae", size = 15509131, upload-time = "2026-07-22T10:54:12.228Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a9/5f1f09da421d8e930e0b063d11c1b3f90363f40ede74438cd188afdd13a2/duckdb-1.5.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f316eae2323d9a851883fdf2dee91c1f9efe251ab33e14a2272f82a913422ed6", size = 19391959, upload-time = "2026-07-22T10:54:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/98/6549769f158126fa64fd6c1ac2eb59a18282146c939867a3eb31b7c1db07/duckdb-1.5.5-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7a6d2d11859d82a936ebdcb30ce3d8a1cbb3e990bff05c12abb9b54c44fa7bd1", size = 21510909, upload-time = "2026-07-22T10:54:19.681Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b7/5753b41d3124838f868f9f523362812d9fc45409e9e4dd70dcbb0a25826e/duckdb-1.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:ddfbdb096c11d51ee22492397d342c90a82e62c5d09961477895934d0a25372f", size = 13168544, upload-time = "2026-07-22T10:54:22.789Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/28/44b679c7d46245f8398feae7edac959d1b83d4eb143e25b3fce0630b78bd/duckdb-1.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:2725d2b9ace3a4e75d72fc5a239f6a44b502c580edadb8fb2676db772c5f9282", size = 13988684, upload-time = "2026-07-22T10:54:26.003Z" },
+    { url = "https://files.pythonhosted.org/packages/47/37/4a38116e7700720fd152c666292214fd3abdf916496991296d8d1f66efbf/duckdb-1.5.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd98829b67788609017e65c761bd42a5dd0f9129441bed8bda4d6881ccf819f0", size = 32754294, upload-time = "2026-07-22T10:54:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/66/42/7d392f1ba1eee0eaf4ab4c8c7a604bfe3536cd63f979cf5c98798664f807/duckdb-1.5.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:feead93c56679b79592d437c62975d39cb67adedffa7592c763baf8160ac7366", size = 17368211, upload-time = "2026-07-22T10:54:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a5/0a6f4fa60562faa615e55e15bd1953a2f2b17a8edd8105e5cda215e43457/duckdb-1.5.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:49c963d9469373d7aba8d750d9ea565ab823e94166efed953f184dd9b169b98c", size = 15509136, upload-time = "2026-07-22T10:54:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/cb/023c89f51978545b9fab318581bba0c457a58e7530d2d933e54ae7d8647c/duckdb-1.5.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a736217825461732b5442d05a220f3da2e23a0dae114efbf08c9bf171b53098a", size = 19392147, upload-time = "2026-07-22T10:54:39.551Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c5/41bef391fb8b23dbc133c9f2ba016e7a7a8124513d2cc1b430f1897d87e4/duckdb-1.5.5-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:078e6a60dd8eedde5832f45422ca5c4a6b8c837aeabd8a56ca0b7d933f588053", size = 21511060, upload-time = "2026-07-22T10:54:42.788Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9f/c44dfc1f924ac29b3252dc1b91393c01d009dbfe9f8ed33f10b986151bd1/duckdb-1.5.5-cp313-cp313-win_amd64.whl", hash = "sha256:6826504277dba513c0c5d71d828456c94d729c9d2482f94b2e289f90a9167e28", size = 13168028, upload-time = "2026-07-22T10:54:46.127Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/88/591384b2cd59abddd6f5dc175e60374f9abae6064429f0c4402854c10f44/duckdb-1.5.5-cp313-cp313-win_arm64.whl", hash = "sha256:baa9c5702002fabb559ded2a39008f9f421fcbc7237d388b8213eff1e08858de", size = 13989955, upload-time = "2026-07-22T10:54:49.262Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/56/12c65bfa2d2605b81981b264788891bcf11ec72227889554cead5d8d13b9/duckdb-1.5.5-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8e6413dd40facb7b8ab21bd844450cd8f549b29e138635be9cf090ef4d2049e2", size = 32761946, upload-time = "2026-07-22T10:54:53.412Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/46/682ce155f17e0d2822d4f13ee3db9ca4b5b7c2da61b841b2629035e1f4bc/duckdb-1.5.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:64078acfd16541132ac6e191eb81b2845554444a0305cc1aa581ba107e514aa8", size = 17375069, upload-time = "2026-07-22T10:54:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ce/a24bcbd3289c8f305a430759c5fc12242740b4af3e17f7593f3a34e333d2/duckdb-1.5.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8c11775cc99a447618d5f1840126db17f2652f3eae05529df4f81f40e2df7151", size = 15519791, upload-time = "2026-07-22T10:55:00.681Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/76/3a01afbc615c1d418c0de58a6b68ac5ce2a8563232c0464bfbc2ce552398/duckdb-1.5.5-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77bbc1e6ba12e1e06f9020117bdf848627ecfdf36f907550e62e008e6109dece", size = 19398251, upload-time = "2026-07-22T10:55:04.168Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/43/3a5e81d1728f4d234c79bfe385808ee7c04834f7c37a4b5c257459c25614/duckdb-1.5.5-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fbf0f2d48b43c6c304d00463b463c27ead6c4b01c3c1816b750f728decf71afe", size = 21513851, upload-time = "2026-07-22T10:55:07.864Z" },
+    { url = "https://files.pythonhosted.org/packages/91/41/fc7c829172c60ca22485251eab285f4f1a0d87b486a024c726f21471d86e/duckdb-1.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:9dc826c4b50e64f6c4e4d07a3a9cb075ef70ba3899dc43ec5493dc3d7b04b353", size = 13691858, upload-time = "2026-07-22T10:55:11.181Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2c/95d9216b79e9273689d7ebce125a54503ed0c9bd7da931f0265888e99779/duckdb-1.5.5-cp314-cp314-win_arm64.whl", hash = "sha256:63e48d4b74b15aeacd688976432a7225163df8c226eddeb8536bba2d4d4ff433", size = 14470180, upload-time = "2026-07-22T10:55:14.445Z" },
 ]
 
 [[package]]
@@ -274,6 +277,7 @@ dependencies = [
     { name = "orjson" },
     { name = "prometheus-client" },
     { name = "pyarrow" },
+    { name = "pyducklake" },
     { name = "pytz" },
     { name = "pyyaml" },
 ]
@@ -294,13 +298,14 @@ dev = [
 requires-dist = [
     { name = "aws-msk-iam-sasl-signer-python", marker = "extra == 'msk-iam'", specifier = ">=1.0.0" },
     { name = "confluent-kafka", specifier = ">=2.6" },
-    { name = "duckdb", specifier = "==1.5.2" },
+    { name = "duckdb", specifier = "==1.5.5" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.30" },
     { name = "opentelemetry-instrumentation-logging", specifier = ">=0.50b0,<0.64" },
     { name = "opentelemetry-sdk", specifier = ">=1.30" },
     { name = "orjson", specifier = ">=3.10" },
     { name = "prometheus-client", specifier = ">=0.21" },
     { name = "pyarrow", specifier = ">=18.0" },
+    { name = "pyducklake", specifier = ">=1.0.17" },
     { name = "pytz", specifier = ">=2024.1" },
     { name = "pyyaml", specifier = ">=6.0.3" },
 ]
@@ -559,6 +564,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
     { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
     { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
+]
+
+[[package]]
+name = "pyducklake"
+version = "1.0.17"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "duckdb" },
+    { name = "pyarrow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/7c/8d7d490b82d571344d57b8422bd039eba287fb7e3bacdd5594d60fc7828c/pyducklake-1.0.17.tar.gz", hash = "sha256:e161de7b6191d896ce70a507bdddae63344f854c3619fce48e3ac7d916ab6dad", size = 287687, upload-time = "2026-08-13T19:23:37.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/7f/cfbde07a44128741e00927029505324d6a02daeb8188dc56d8c21d09a321/pyducklake-1.0.17-py3-none-any.whl", hash = "sha256:ab2e0fb115b93826bb3725478f090668d5d505da606844a38fe5e5d3b7fa961e", size = 53030, upload-time = "2026-08-13T19:23:35.547Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

The 1.5.2 extension channel is frozen at ducklake build `415a9ebd`, which leaks per-connection native memory proportional to catalog metadata churn (A/B-verified in viaduck: ~1MiB per snapshot-advancing bind; OOM every 4-6h there). Millpond's long-lived writer connections against a busy shared catalog have the same exposure. The 1.5.5 channel serves `d8a1881e`, which is flat. `pyducklake` (ours) rides along as a deliberate lockstep canary — it hard-pins duckdb, so a one-sided bump of either package fails `uv lock` instead of silently splitting the two DuckLake stacks. Nothing imports it yet.

## The drift gate

The frozen 1.5.2 channel was *accidental* drift protection; 1.5.5's channel is live and can re-serve new builds under the same URL. The release workflow runs in parallel with CI, so the test canary alone can't stop a drifted build from reaching the fleet via the mutable tag + autobounce. The Dockerfile now asserts the ducklake build SHA in the extension-install layer: **an unexpected ducklake build cannot produce an image at all.** Verified both directions (correct SHA builds; `--build-arg DUCKLAKE_SHA=deadbeef` fails the layer with the drift message).

## Behavior changes under d8a1881e (all verified against real catalogs)

- The `(INT64_MAX, UINT64_MAX]` shred-rejection window and write-time error signature are **unchanged** — the #118 guard and backstop hold. The inlined-path deferred failure now reports `INT128` (was `UINT64`); the width-agnostic matcher still catches it.
- JSON numbers outside `[INT64_MIN, UINT64_MAX]` in a VARIANT become lossy `DOUBLE` (were digit-preserving `VARCHAR`). Deliberate policy: follow native DuckLake semantics; the string column stays authoritative (now asserted). Rows written across the version boundary mix both representations in the companion permanently.
- **No catalog metadata migration**: old/new builds read and write the same catalogs interchangeably (probed both directions, incl. shredded Parquet and inlined data), so mixed fleets and co-readers (viaduck, duckgres) are unaffected.
- `duckdb_databases()` no longer lists the attach's metadata db as its own row — test-fixture-only; no prod code touches it.

## New engine-behavior contract test

`tests/integration/test_ducklake_engine_contract.py` pins what the variant guard assumes of the pinned build, probed the way the 2026-08-12 incident executed (guard bypassed, real shredded Parquet writes): the containment invariant (engine-rejected ⊆ guard-rewritten, through the real `sanitize_variant_sources` chain), its converse (shreddable probes round-trip untouched), both window boundaries exactly, nested/array/sci-notation shapes, error-signature recognition, and the inlined commit-then-detonate path. The next bump that shifts any of this fails at the PR instead of on the fleet.

## Supply chain

pyducklake 1.0.17 published 2026-08-13 → fixed-date `exclude-newer-package` carve-out from the 7-day cooldown (future releases re-enter it until deliberately bumped); sha256-pinned in uv.lock. Added to the dependency-review allow-list (PEP 639-only license metadata, same class as the opentelemetry entries; Apache-2.0).

## Testing

- 740 unit+integration tests pass, including the new 16 contract cases; e2e suite (4/4) against the built image; ruff clean.
- Image built locally for arm64 with the gate; negative build verified to fail.
- Cross-version probes run in side-by-side 1.5.2/1.5.5 environments (linux containers) for the mixed-fleet analysis.

Authored with agent assistance; two adversarial review passes (correctness + prod-impact/deployment) ran over the diff and their findings are incorporated (drift gate, allow-list entry, lockstep comment, nested/array probes, stale-comment sweep).