### PR TITLE
compact: recover from wedged duckdb instances instead of dying at the deadline

### DIFF
--- a/tests/integration/test_compaction_isolation_integration.py
+++ b/tests/integration/test_compaction_isolation_integration.py
@@ -13,12 +13,14 @@ Asserts the per-table compact() loop:
   * still merges the healthy table's files,
   * reports (does NOT raise on) the poisoned table,
   * leaves the poisoned table's files untouched,
-  * raises only when EVERY table fails (systemic).
+  * never raises for per-table failures, even when every table fails.
 
-These tests also pin the load-bearing recovery property: the DuckDB
-connection survives the extension's InternalException, so the loop can keep
-going (verified on duckdb 1.5.2 and 1.5.5; a future duckdb that invalidates
-the instance on INTERNAL errors would fail here, loudly).
+These tests also pin the survivable half of the instance-fatal handling:
+this InternalException leaves the instance usable, the liveness probe
+passes, and the loop continues on the SAME connection. A duckdb where this
+error instead invalidated the instance would take the rebuild path, whose
+connect() has no environment here — the healthy-table assertion would then
+fail, loudly.
 
 Skips when the ducklake extension can't be installed (offline CI).
 """

--- a/tests/unit/test_ducklake_maintenance.py
+++ b/tests/unit/test_ducklake_maintenance.py
@@ -1199,6 +1199,119 @@ class TestCompactPerTable:
         # target_file_size restored despite the partial failure.
         assert any("ducklake_set_option" in c.args[0] and "128MiB" in c.args[0] for c in conn.execute.call_args_list)
 
+    def test_survivable_instance_fatal_error_continues_on_same_connection(self, monkeypatch):
+        # Most InternalExceptions (the hive-path assertion included) leave the
+        # instance usable: the probe passes and the run must NOT rebuild.
+        conn = _compact_conn(
+            [("posthog", "events"), ("posthog", "persons")],
+            merge_rows_seq={
+                "events": [
+                    duckdb.InternalException(
+                        "INTERNAL Error: DuckLakeCompactor: Files have different hive partition path"
+                    ),
+                ]
+            },
+            merge_rows={"persons": [("posthog", "persons", 4, 1)]},
+        )
+        monkeypatch.setattr(
+            ducklake_maintenance,
+            "connect",
+            lambda debug=False: pytest.fail("must not rebuild when the instance is alive"),
+        )
+
+        n_failed = ducklake_maintenance.compact(
+            conn, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+        )
+
+        assert n_failed == 1
+        assert any("'persons'" in c for c in _merge_calls(conn))
+        conn.close.assert_not_called()
+
+    def test_wedged_connection_is_rebuilt_and_run_continues(self, monkeypatch):
+        # The production wedge: after the InternalException every query on the
+        # old instance blocks. Simulated by failing the liveness probe for the
+        # first connection only.
+        conn1 = _compact_conn(
+            [("posthog", "events"), ("posthog", "persons")],
+            merge_rows_seq={"events": [duckdb.InternalException("INTERNAL Error: boom")]},
+        )
+        conn2 = _compact_conn(
+            [("posthog", "events"), ("posthog", "persons")],
+            merge_rows={"persons": [("posthog", "persons", 4, 1)]},
+        )
+        monkeypatch.setattr(ducklake_maintenance, "connect", lambda debug=False: conn2)
+        monkeypatch.setattr(ducklake_maintenance, "_connection_alive", lambda c, timeout_s=5.0: c is not conn1)
+
+        n_failed = ducklake_maintenance.compact(
+            conn1, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+        )
+
+        assert n_failed == 1
+        # The failed table's CALL went to the old connection; the survivor's
+        # CALL and the target_file_size restore went to the fresh one.
+        assert any("'events'" in c for c in _merge_calls(conn1))
+        assert not any("'persons'" in c for c in _merge_calls(conn1))
+        assert any("'persons'" in c for c in _merge_calls(conn2))
+        assert any("ducklake_set_option" in c.args[0] and "128MiB" in c.args[0] for c in conn2.execute.call_args_list)
+        # Fresh connection got the compaction tuning reapplied.
+        assert any("SET threads" in c.args[0] for c in conn2.execute.call_args_list)
+        conn1.close.assert_called_once()
+        assert ducklake_maintenance._last_compact_rebuilds == 1
+
+    def test_repeated_wedges_abandon_the_run_without_raising(self, monkeypatch):
+        tables = [("posthog", f"t{i}") for i in range(6)]
+
+        def _poisoned():
+            return _compact_conn(
+                tables,
+                merge_rows_seq={f"t{i}": [duckdb.InternalException("INTERNAL Error: boom")] for i in range(6)},
+            )
+
+        rebuilt: list[MagicMock] = []
+
+        def _connect(debug=False):
+            conn = _poisoned()
+            rebuilt.append(conn)
+            return conn
+
+        monkeypatch.setattr(ducklake_maintenance, "connect", _connect)
+        monkeypatch.setattr(ducklake_maintenance, "_connection_alive", lambda c, timeout_s=5.0: False)
+
+        n_failed = ducklake_maintenance.compact(
+            _poisoned(), tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+        )
+
+        # Bounded: one rebuild, then the remaining tables are marked failed
+        # and the run returns (exit 0; the failure gauges tell the story).
+        assert len(rebuilt) == ducklake_maintenance._MAX_CONNECTION_REBUILDS
+        assert n_failed == len(tables)
+        assert ducklake_maintenance._last_compact_rebuilds == ducklake_maintenance._MAX_CONNECTION_REBUILDS + 1
+
+    def test_rebuild_failure_abandons_run_and_skips_restore(self, monkeypatch, caplog):
+        conn1 = _compact_conn(
+            [("posthog", "events"), ("posthog", "persons")],
+            merge_rows_seq={"events": [duckdb.InternalException("INTERNAL Error: boom")]},
+        )
+
+        def _connect(debug=False):
+            raise RuntimeError("duckgres unreachable")
+
+        monkeypatch.setattr(ducklake_maintenance, "connect", _connect)
+        monkeypatch.setattr(ducklake_maintenance, "_connection_alive", lambda c, timeout_s=5.0: False)
+
+        with caplog.at_level(logging.WARNING, logger="maintenance"):
+            n_failed = ducklake_maintenance.compact(
+                conn1, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
+            )
+
+        # Both tables count as failed, nothing raises, and the restore is
+        # skipped rather than executed on the abandoned connection: the only
+        # set_option on conn1 is the scope-entry SET, never the finally-restore.
+        assert n_failed == 2
+        assert "target_file_size restore skipped" in caplog.text
+        set_option_calls = [c.args[0] for c in conn1.execute.call_args_list if "ducklake_set_option" in c.args[0]]
+        assert len(set_option_calls) == 1
+
     def test_all_tables_failed_does_not_raise(self, caplog):
         """Per-table failures NEVER raise — the poison-set attractor: with
         candidate-driven enumeration, healthy tables drain OUT of the table
@@ -1395,7 +1508,7 @@ class TestScopedTargetFileSize:
         # equals the default — that's a healthy install, not a failure.
         conn = self._conn("134217728")
         with caplog.at_level(logging.WARNING, logger="maintenance"):
-            with ducklake_maintenance._scoped_target_file_size(conn, "5MiB"):
+            with ducklake_maintenance._scoped_target_file_size(lambda: conn, "5MiB"):
                 pass
         warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
         assert warnings == [], "no warning expected on a clean default-value round-trip"
@@ -1404,7 +1517,7 @@ class TestScopedTargetFileSize:
         # 64 MiB — operator value, not the default.
         conn = self._conn("67108864")
         with caplog.at_level(logging.WARNING, logger="maintenance"):
-            with ducklake_maintenance._scoped_target_file_size(conn, "5MiB"):
+            with ducklake_maintenance._scoped_target_file_size(lambda: conn, "5MiB"):
                 pass
         assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
 
@@ -1414,7 +1527,7 @@ class TestScopedTargetFileSize:
         # the warning is informative.
         conn = self._conn("12345678")
         with caplog.at_level(logging.WARNING, logger="maintenance"):
-            with ducklake_maintenance._scoped_target_file_size(conn, "5MiB"):
+            with ducklake_maintenance._scoped_target_file_size(lambda: conn, "5MiB"):
                 pass
         warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
         assert len(warnings) == 1
@@ -1424,13 +1537,13 @@ class TestScopedTargetFileSize:
     def test_no_warning_when_prior_unset(self, caplog):
         conn = self._conn(None)
         with caplog.at_level(logging.WARNING, logger="maintenance"):
-            with ducklake_maintenance._scoped_target_file_size(conn, "5MiB"):
+            with ducklake_maintenance._scoped_target_file_size(lambda: conn, "5MiB"):
                 pass
         assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
 
     def test_restores_to_converted_prior(self):
         conn = self._conn("67108864")
-        with ducklake_maintenance._scoped_target_file_size(conn, "5MiB"):
+        with ducklake_maintenance._scoped_target_file_size(lambda: conn, "5MiB"):
             pass
         # The last execute call should be the restore SET to '64MiB'.
         last_sql = conn.execute.call_args_list[-1].args[0]
@@ -1439,7 +1552,7 @@ class TestScopedTargetFileSize:
 
     def test_restores_to_default_when_prior_unset(self):
         conn = self._conn(None)
-        with ducklake_maintenance._scoped_target_file_size(conn, "5MiB"):
+        with ducklake_maintenance._scoped_target_file_size(lambda: conn, "5MiB"):
             pass
         last_sql = conn.execute.call_args_list[-1].args[0]
         assert f"'{ducklake_maintenance.DEFAULT_TARGET_FILE_SIZE}'" in last_sql

--- a/tools/ducklake_maintenance.py
+++ b/tools/ducklake_maintenance.py
@@ -37,6 +37,7 @@ import sys
 import threading
 import time
 from collections import defaultdict
+from collections.abc import Callable
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Literal
@@ -1726,7 +1727,7 @@ def _bytes_to_human(stored_value: str) -> str | None:
 
 
 @contextlib.contextmanager
-def _scoped_target_file_size(conn: duckdb.DuckDBPyConnection, value: str):
+def _scoped_target_file_size(conn_getter: Callable[[], duckdb.DuckDBPyConnection | None], value: str):
     """Set target_file_size for the body, restore the prior catalog value on exit.
 
     Reads the prior GLOBAL value before the body runs and restores it in the
@@ -1748,10 +1749,14 @@ def _scoped_target_file_size(conn: duckdb.DuckDBPyConnection, value: str):
       tier-specific value we set during the body.
     """
     _sanitize_setting_value(value)
-    prior_row = conn.execute(
-        f"SELECT value FROM ducklake_options('{ATTACH_NAME}') "
-        f"WHERE option_name = 'target_file_size' AND scope = 'GLOBAL'"
-    ).fetchone()
+    prior_row = (
+        conn_getter()
+        .execute(
+            f"SELECT value FROM ducklake_options('{ATTACH_NAME}') "
+            f"WHERE option_name = 'target_file_size' AND scope = 'GLOBAL'"
+        )
+        .fetchone()
+    )
     # Distinguish three cases so we only warn on a genuine conversion failure
     # (a prior GLOBAL value of 134217728 converts to '128MiB' which equals
     # DEFAULT_TARGET_FILE_SIZE — without this distinction we'd emit a noisy
@@ -1771,12 +1776,22 @@ def _scoped_target_file_size(conn: duckdb.DuckDBPyConnection, value: str):
         else:
             restore = converted
     _sanitize_setting_value(restore)
-    conn.execute(f"CALL ducklake_set_option('{ATTACH_NAME}', 'target_file_size', '{value}')")
+    conn_getter().execute(f"CALL ducklake_set_option('{ATTACH_NAME}', 'target_file_size', '{value}')")
     try:
         yield
     finally:
-        conn.execute(f"CALL ducklake_set_option('{ATTACH_NAME}', 'target_file_size', '{restore}')")
-        log.info("target_file_size restored to %s", restore)
+        # conn_getter (not a bound conn): compact() may replace its connection
+        # mid-run after an instance-fatal error, and the restore must land on
+        # whichever connection is live at exit — or be skipped when none is.
+        current = conn_getter()
+        if current is None:
+            # A skipped restore leaves the tier target set; every tier target
+            # and the default are the same value in practice, and skipping
+            # beats blocking on a wedged instance.
+            log.warning("target_file_size restore skipped: no live connection")
+        else:
+            current.execute(f"CALL ducklake_set_option('{ATTACH_NAME}', 'target_file_size', '{restore}')")
+            log.info("target_file_size restored to %s", restore)
 
 
 def _set_compaction_tuning(conn: duckdb.DuckDBPyConnection, threads: int, memory_limit: str) -> None:
@@ -1802,6 +1817,81 @@ def _set_compaction_tuning(conn: duckdb.DuckDBPyConnection, threads: int, memory
         threads,
         memory_limit,
     )
+
+
+# Errors after which the DuckDB instance must be treated as unusable. The
+# per-table continue-on-error contract assumed the connection survives a
+# failed CALL; production wedges (a hive-path compaction assertion followed by
+# total silence — no per-table logs, no heartbeats — until the activeDeadline
+# killed the run) showed an InternalException can leave the instance blocking
+# every later query without raising. Rebuilding the connection is the only
+# safe continuation.
+_INSTANCE_FATAL_ERRORS = (duckdb.InternalException, duckdb.FatalException)
+# One rebuild per run: duckdb memory_limit is per INSTANCE and a wedged
+# instance's buffers may never free (its close can hang), so every additional
+# live instance stacks another memory_limit against the pod cgroup. A second
+# invalidation in one run is systemic poison, not bad luck — stop compacting
+# and let the (exit-0) failure gauges tell the story.
+_MAX_CONNECTION_REBUILDS = 1
+
+# Rebuild count of the last compact() run, exported by main() as the
+# maintenance_compact_connection_rebuilds gauge. Module state rather than a
+# richer compact() return type so the existing int contract (failed tables)
+# and its callers stay untouched.
+_last_compact_rebuilds = 0
+
+
+def _connection_alive(conn: duckdb.DuckDBPyConnection, timeout_s: float = 5.0) -> bool:
+    """Probe the instance from a side thread so a wedged one can't hang us.
+
+    Most InternalExceptions (e.g. the hive-path compaction assertion) leave
+    the instance fully usable; the probe distinguishes those from the
+    production wedge where every later query blocks without raising.
+    """
+    alive: list[bool] = []
+
+    def _probe() -> None:
+        with contextlib.suppress(Exception):
+            conn.execute("SELECT 1").fetchone()
+            alive.append(True)
+
+    prober = threading.Thread(target=_probe, daemon=True)
+    prober.start()
+    prober.join(timeout=timeout_s)
+    return bool(alive)
+
+
+def _quiet_close(conn: duckdb.DuckDBPyConnection) -> None:
+    with contextlib.suppress(Exception):
+        conn.close()
+
+
+def _abandon_connection(conn: duckdb.DuckDBPyConnection) -> None:
+    """Close a possibly-wedged connection without risking a hang.
+
+    close() on an instance that just failed an internal assertion can block on
+    the same internal state that wedged it; run it from a daemon thread with a
+    short grace period and otherwise leak the object — the process is a
+    short-lived cron step.
+    """
+    with contextlib.suppress(Exception):
+        # Cancel any in-flight work first: it materially raises the odds the
+        # close completes, which is what actually frees the instance's buffers
+        # and rolls back its Postgres-side metadata session.
+        conn.interrupt()
+    closer = threading.Thread(target=_quiet_close, args=(conn,), daemon=True)
+    closer.start()
+    closer.join(timeout=5.0)
+    if closer.is_alive():
+        log.warning("abandoned a wedged duckdb connection without close()")
+
+
+def _fresh_compaction_connection(threads: int, memory_limit: str, target: str) -> duckdb.DuckDBPyConnection:
+    conn = connect()
+    _set_compaction_tuning(conn, threads, memory_limit)
+    _sanitize_setting_value(target)
+    conn.execute(f"CALL ducklake_set_option('{ATTACH_NAME}', 'target_file_size', '{target}')")
+    return conn
 
 
 def _rss_bytes() -> int | None:
@@ -2033,6 +2123,8 @@ def compact(
         candidate_count,
         candidate_bytes,
     )
+    global _last_compact_rebuilds
+    _last_compact_rebuilds = 0
 
     if dry_run:
         return 0
@@ -2055,6 +2147,7 @@ def compact(
     failed: list[str] = []
     table_total = 1
     noop_tables = 0
+    rebuilds = 0
 
     if table:
         # Single-table invocation. Errors propagate raw, exactly as before.
@@ -2063,7 +2156,7 @@ def compact(
         # issue exactly the giant single txn the knob exists to prevent).
         heartbeat = _start_heartbeat(conn, f"compact tier-{tier} merge")
         try:
-            with _scoped_target_file_size(conn, target):
+            with _scoped_target_file_size(lambda: conn, target):
                 remaining = max_compacted_files
                 while remaining > 0:
                     call_cap = remaining if max_outputs_per_call is None else min(max_outputs_per_call, remaining)
@@ -2111,7 +2204,9 @@ def compact(
                 tier,
                 candidate_count,
             )
-        with _scoped_target_file_size(conn, target):
+        conn_dead = [False]
+        abort_run = False
+        with _scoped_target_file_size(lambda: None if conn_dead[0] else conn, target):
             # max_compacted_files stays a GLOBAL budget across the run — the
             # same bound as the old catalog-scope call — so run duration
             # stays predictable. Leftover tables wait for the next cron tick.
@@ -2124,7 +2219,7 @@ def compact(
             # served. Biggest backlog still gets the biggest cut; it just
             # can't take the whole pie.
             remaining = max_compacted_files
-            for schema_name, table_name in tables:
+            for table_index, (schema_name, table_name) in enumerate(tables):
                 if remaining <= 0:
                     log.info(
                         "compact tier-%d: file budget exhausted; remaining tables wait for the next run",
@@ -2192,16 +2287,63 @@ def compact(
                             table_name,
                         )
                         break
+                    except _INSTANCE_FATAL_ERRORS:
+                        failed.append(f"{schema_name}.{table_name}")
+                        heartbeat.set()
+                        if _connection_alive(conn):
+                            # The common case: the error was table-local and
+                            # the instance is fine — keep the long-standing
+                            # continue-on-error contract on the same conn.
+                            log.exception(
+                                "compact tier-%d: %s.%s failed; connection alive, continuing with remaining tables",
+                                tier,
+                                schema_name,
+                                table_name,
+                            )
+                            break
+                        # The production wedge: every later query would block
+                        # without raising, silencing the run until the
+                        # activeDeadline. Abandon the instance; progress
+                        # committed by earlier calls is durable.
+                        rebuilds += 1
+                        log.exception(
+                            "compact tier-%d: %s.%s left the connection unresponsive; rebuilding (%d/%d)",
+                            tier,
+                            schema_name,
+                            table_name,
+                            rebuilds,
+                            _MAX_CONNECTION_REBUILDS,
+                        )
+                        _abandon_connection(conn)
+                        if rebuilds > _MAX_CONNECTION_REBUILDS:
+                            log.error(
+                                "compact tier-%d: connection invalidated %d times in one run; "
+                                "abandoning the remaining tables (they count as failed)",
+                                tier,
+                                rebuilds,
+                            )
+                            conn_dead[0] = True
+                            abort_run = True
+                            break
+                        try:
+                            conn = _fresh_compaction_connection(threads, memory_limit, target)
+                        except Exception:
+                            # Correlated failure is likely (the catalog just
+                            # misbehaved); never let the rebuild's own error
+                            # wedge the run or land the restore on a dead conn.
+                            log.exception(
+                                "compact tier-%d: connection rebuild failed; "
+                                "abandoning the remaining tables (they count as failed)",
+                                tier,
+                            )
+                            conn_dead[0] = True
+                            abort_run = True
+                        break
                     except Exception:
-                        # Continue-on-error relies on the connection SURVIVING
-                        # the failed CALL (verified on duckdb 1.5.2 and 1.5.5,
-                        # even for InternalException, and pinned end-to-end by
-                        # test_compaction_isolation_integration). If a future
-                        # duckdb bump invalidates the instance on INTERNAL
-                        # errors, every table fails, the failure summary +
-                        # gauge spike, and the target_file_size restore raises
-                        # — noisy, not silent. A mid-loop failure keeps the
-                        # progress already committed by earlier calls.
+                        # Non-fatal per-table failure: the connection survives
+                        # the failed CALL and the loop continues on it. A
+                        # mid-loop failure keeps the progress already
+                        # committed by earlier calls.
                         failed.append(f"{schema_name}.{table_name}")
                         log.exception(
                             "compact tier-%d: %s.%s failed; continuing with remaining tables",
@@ -2215,6 +2357,10 @@ def compact(
                     call_idx += 1
                     if max_outputs_per_call is None:
                         break
+                if abort_run:
+                    failed.extend(f"{s}.{t}" for s, t in tables[table_index + 1 :])
+                    break
+    _last_compact_rebuilds = rebuilds
     elapsed = time.monotonic() - t0
 
     # Aggregate result rows (one per output group: schema, table, input_files, output_files)
@@ -2513,6 +2659,15 @@ def main(argv: list[str] | None = None) -> None:
         ["tier"],
         registry=registry,
     )
+    # A rebuild means the duckdb instance wedged mid-run and the tool
+    # recovered — a fork-bug signal worth alerting on at >= 1, distinct from
+    # ordinary per-table failures.
+    compact_connection_rebuilds = Gauge(
+        "maintenance_compact_connection_rebuilds",
+        "DuckDB instance invalidations handled (rebuilt or abandoned) in the last compact run",
+        ["tier"],
+        registry=registry,
+    )
     operation = args.command
     if hasattr(args, "days") and args.days < 1:
         parser.error("--days must be >= 1")
@@ -2572,6 +2727,7 @@ def main(argv: list[str] | None = None) -> None:
                     max_outputs_per_call=args.max_outputs_per_call,
                 )
                 compact_tables_failed.labels(tier=str(args.tier)).set(n_failed)
+                compact_connection_rebuilds.labels(tier=str(args.tier)).set(_last_compact_rebuilds)
             case "compact-probe":
                 compact_probe(conn, args.table, args.max_compacted_files)
     except Exception:
@@ -2581,10 +2737,15 @@ def main(argv: list[str] | None = None) -> None:
     finally:
         elapsed = time.monotonic() - t0
         duration.labels(operation=operation, status=status).set(elapsed)
-        if conn is not None:
-            conn.close()
+        # Push BEFORE close: closing a wedged instance can block, and the
+        # metrics for a completed run must not be hostage to teardown.
         if pushgateway:
             _push(registry, pushgateway)
+        if conn is not None:
+            # Guarded close: after a mid-run rebuild this is the abandoned
+            # original (compact() owns the fresh one; process exit reaps it),
+            # and its close may hang on the wedged instance state.
+            _abandon_connection(conn)
         log.info("Operation %s finished: status=%s duration=%.1fs", operation, status, elapsed)
 
 


### PR DESCRIPTION
## Problem

Twice this week team-2's compaction run hit `INTERNAL Error: DuckLakeCompactor: Files have different hive partition path` and then went completely silent — no per-table failure logs, no heartbeats — until the activeDeadline killed the pod hours later (5h08m and ~4h wedges). The per-table continue-on-error loop assumed the connection survives a failed CALL. The integration tests prove that assumption holds for the common case on stock duckdb, but production showed an InternalException can leave the instance blocking every subsequent query without raising. One wedge cost the whole run's remaining budget plus the chain slot, every tick, for a week (`lastSuccessfulTime` sat at 2026-08-14 until the hive metadata was repaired by hand).

## Changes

- **Probe, then decide**: on `InternalException`/`FatalException`, a side-thread `SELECT 1` (5s timeout) distinguishes the survivable class (probe passes → identical old behavior: record failure, continue on the same connection — the integration suite passes unchanged) from the wedge (probe hangs/fails).
- **Wedge recovery**: `interrupt()` + guarded daemon-thread close abandons the dead instance; the run continues on **one** fresh connection with compaction tuning and `target_file_size` reapplied. Cap is 1 because `memory_limit` is per-instance and additive against the pod cgroup (at the 24GB prod setting a second live instance already fills a 48Gi pod).
- **Never wedge on the recovery path**: a second invalidation or a rebuild failure marks the remaining tables failed and returns normally — exit 0 keeps the cron chain's other steps running, and the failure gauges spike instead. A dead-connection sentinel makes the `target_file_size` restore skip (warning log) rather than block on a dead instance; all tier targets equal the default today so the skip is a no-op in practice.
- **Metrics can't be eaten by teardown**: `main()` pushes to the gateway *before* closing, and closes via the guarded helper. New gauge `maintenance_compact_connection_rebuilds{tier}` (instance invalidations handled) — worth alerting at ≥ 1, since a true wedge is a fork-bug signal relevant to the open commit-invalidation hunt.

## Testing

- Unit: 683 passed (4 new: survivable-continue on same conn without rebuild; wedge → rebuild → survivor compacted on the fresh conn with tuning reapplied; bounded second-wedge abort without raising, all remaining tables counted failed; rebuild-failure containment with restore skipped).
- Integration (`test_compaction_isolation_integration.py`, real ducklake extension): 3 passed **unchanged** — the real hive-path error takes the survivable path, exactly as always pinned; docstring updated to describe the probe design.
- Empirical duckdb 1.5.5 checks during review: side-thread probe on an idle shared conn is safe; `interrupt()` from another thread cancels a blocked query; `close()` from another thread doesn't block; abandon of an already-closed conn is safely suppressed.
- Two adversarial review rounds (5 reviewer passes total) drove the design: round 1 rejected treat-every-InternalException-as-fatal (it would have broken the CI integration suite and aborted catalogs with several survivable-poisoned tables); round 2 confirmed path-by-path failed-table accounting and found only doc-level nits, all applied.