### PR TITLE
compact: enumerate only tables with a mergeable partition group

### DIFF
--- a/tests/integration/test_compaction_isolation_integration.py
+++ b/tests/integration/test_compaction_isolation_integration.py
@@ -179,3 +179,25 @@ def test_biggest_backlog_served_first_within_budget(lake):
 
     assert _live_file_count(conn, "zzz_big") < 6, "biggest backlog must be served first"
     assert _live_file_count(conn, "aaa_small") == 2, "budget must exhaust before the small table"
+
+
+def test_partition_singleton_only_table_is_not_enumerated(lake, caplog):
+    """The patch's core property: a table whose in-band files are ALL
+    partition singletons (one file per partition value — the hourly-import
+    shape) must not be enumerated at all, while a table with a >= 2-file
+    partition group still is."""
+    conn, _attach = lake
+    conn.execute(f"CREATE TABLE {LAKE}.main.hourly (h INTEGER, v VARCHAR)")
+    conn.execute(f"ALTER TABLE {LAKE}.main.hourly SET PARTITIONED BY (h)")
+    for h in range(4):  # every file its own partition -> zero mergeable groups
+        conn.execute(f"INSERT INTO {LAKE}.main.hourly VALUES ({h}, 'x')")
+    _seed_partitioned_table(conn, "mergeable", n_files=3)  # all files share y=2026
+
+    with caplog.at_level(logging.INFO, logger="maintenance"):
+        tables = ducklake_maintenance._enumerate_compaction_tables(conn, None, 1 << 20)
+
+    assert ("main", "hourly") not in tables
+    assert ("main", "mergeable") in tables
+    # File-backed lakes have no pg attach: the server-side attempt must fall
+    # back (a tightened except that breaks the fallback fails here).
+    assert "server-side enumeration unavailable" in caplog.text

--- a/tests/unit/test_ducklake_maintenance.py
+++ b/tests/unit/test_ducklake_maintenance.py
@@ -1326,11 +1326,11 @@ class TestCompactPerTable:
 
     def test_enumeration_is_candidate_driven_backlog_first(self):
         """The table list must come from the tier's candidate files — sized to
-        the tier band, >= 2 files per table (singletons can't merge), most
-        backlogged first — NOT information_schema. Alphabetical enumeration
-        over all live tables let 2-file cosmetic merges starve the real
-        backlog out of the budget (observed: 3,074 tables, budget gone on
-        five billing tables, the 15k-candidate events table never reached)."""
+        the tier band, grouped by partition values with >= 2 files per GROUP
+        (partition singletons can't merge, whatever the per-table count), most
+        mergeable-backlogged first — NOT information_schema. Per-table >= 2
+        let hourly-partitioned import catalogs (86% partition singletons
+        measured) keep the compactor grinding no-op CALLs forever."""
         conn = _compact_conn([("posthog", "events")])
         ducklake_maintenance.compact(
             conn, tier=1, table=None, dry_run=False, threads=2, memory_limit="16GB", max_compacted_files=10
@@ -1339,14 +1339,22 @@ class TestCompactPerTable:
         assert len(enum_calls) == 1
         sql = enum_calls[0]
         assert "ducklake_data_file" in sql and "ducklake_table" in sql and "ducklake_schema" in sql
-        assert "ORDER BY COUNT(*) DESC" in sql, "most backlogged table must be served first"
+        # Mergeability is judged per (table, partition-values) group — the
+        # extension's own merge unit.
+        assert "ducklake_file_partition_value" in sql
+        assert "GROUP BY table_id, pk" in sql
+        assert "HAVING COUNT(*) >= 2" in sql
+        assert "ORDER BY SUM(m.n_mergeable) DESC" in sql, "most mergeable-backlogged table must be served first"
+        # The server-side statement (postgres_query wrapping the SQL as a
+        # quoted literal) must stay syntactically valid duckdb — a quote-
+        # doubling or composition regression fails here, not in prod.
+        assert len(duckdb.extract_statements(sql)) == 1
         assert "file_size_bytes < 1048576" in sql, "enumeration must be scoped to the tier's size band"
-        # Liveness on ALL FOUR relations: file, table, schema, and the
-        # delete-file anti-join. Dropping the table one silently enumerates
-        # renamed tables under stale names (perpetual CatalogException noise);
-        # dropping the delete-file one lets unmergeable delete-laden whales
-        # rank first and no-op forever.
-        assert sql.count("end_snapshot IS NULL") == 4
+        # Liveness everywhere it matters: file/table/schema in the candidate
+        # scan, the delete-file anti-join, and table/schema again in the
+        # final name resolution (a renamed table must not be enumerated
+        # under its stale name).
+        assert sql.count("end_snapshot IS NULL") == 6
         assert "NOT EXISTS" in sql and "ducklake_delete_file" in sql
         assert not any("information_schema" in c.args[0] for c in conn.execute.call_args_list)
 
@@ -1359,7 +1367,7 @@ class TestCompactPerTable:
         assert "file_size_bytes >= 1048576" in sql and "file_size_bytes < 10485760" in sql
 
     def test_all_singleton_candidates_logs_info_not_warning(self, caplog):
-        """Candidates exist but no table qualifies (all per-table singletons,
+        """Candidates exist but no table qualifies (all partition singletons,
         or delete-laden files excluded): benign INFO, zero merge CALLs, no
         raise — NOT a warning-level anomaly."""
         conn = _compact_conn([], candidates=(5, 1000))

--- a/tools/ducklake_maintenance.py
+++ b/tools/ducklake_maintenance.py
@@ -1891,7 +1891,7 @@ def _start_heartbeat(conn: duckdb.DuckDBPyConnection, label: str, interval_s: fl
 def _enumerate_compaction_tables(
     conn: duckdb.DuckDBPyConnection, min_b: int | None, max_b: int
 ) -> list[tuple[str, str]]:
-    """Tables with >= 2 live files in the tier's size band, biggest backlog first.
+    """Tables with a MERGEABLE group in the tier's band, biggest backlog first.
 
     Candidate-driven (from ducklake_data_file), NOT information_schema: a
     catalog can carry thousands of live tables (dlt/Fivetran staging) with
@@ -1901,46 +1901,93 @@ def _enumerate_compaction_tables(
     early-alphabet tables (2-file cosmetic merges) eat the global file
     budget every run while the real backlog starved. Observed in prod:
     3,074 live tables, the budget exhausted on five 2-file billing tables,
-    and the 15k-candidate events table never reached. Candidate-count DESC
+    and the 15k-candidate events table never reached. Mergeable-count DESC
     serves the most backlogged table first; ties break by name for
-    determinism. Single-candidate tables can't merge and are excluded.
+    determinism.
+
+    Mergeability is judged per (table, partition values) group, matching the
+    extension's own grouping: merge_adjacent can never combine files from
+    different partitions, so a table whose in-band files are all partition
+    singletons is a guaranteed zero-group no-op. Enumerating those anyway is
+    what kept the compactor grinding an hourly-partitioned import catalog
+    forever (one measured catalog: 86% of 126k tier-1 candidates were
+    partition singletons), holding catalog contention against the tenant's
+    writer with zero merges to show for it. Row-id non-contiguity within a
+    group can still no-op an enumerated table — the caller's zero-group
+    accounting stays.
 
     Catalog-derived names are ordinary-DDL-controlled and get interpolated
     into the per-table CALL statements below, so anything outside the
     conservative identifier shape is skipped LOUDLY rather than quoted
     heroically (same defense as repair-partition-values discovery).
     """
-    where = [
-        "df.end_snapshot IS NULL",
-        "t.end_snapshot IS NULL",
-        "sch.end_snapshot IS NULL",
-        f"df.file_size_bytes < {max_b}",
-        # Mirror the compactor's own selection: merge_adjacent skips any file
-        # carrying live delete files, so counting them here would let an
-        # unmergeable-but-huge table rank first and no-op at the top of every
-        # run (rank inflated by files the extension refuses to touch).
-        (
-            f"NOT EXISTS (SELECT 1 FROM {METADATA_SCHEMA}.ducklake_delete_file dl "
-            "WHERE dl.data_file_id = df.data_file_id AND dl.end_snapshot IS NULL)"
-        ),
-    ]
-    if min_b is not None:
-        where.append(f"df.file_size_bytes >= {min_b}")
-    # NOTE: COUNT(*) >= 2 is per-TABLE; the extension merges per
-    # (partition_id, partition_values) group, so 2 candidates in different
-    # partitions still yield a zero-group no-op CALL. That's a wasted bind
-    # scan, not a correctness issue — do not read >= 2 as a mergeability
-    # guarantee. Zero-group CALLs are counted and logged by the caller.
-    rows = conn.execute(
-        "SELECT sch.schema_name, t.table_name "
-        f"FROM {METADATA_SCHEMA}.ducklake_data_file df "
-        f"JOIN {METADATA_SCHEMA}.ducklake_table t USING (table_id) "
-        f"JOIN {METADATA_SCHEMA}.ducklake_schema sch ON sch.schema_id = t.schema_id "
-        f"WHERE {' AND '.join(where)} "
-        "GROUP BY sch.schema_name, t.table_name "
-        "HAVING COUNT(*) >= 2 "
-        "ORDER BY COUNT(*) DESC, sch.schema_name, t.table_name"
-    ).fetchall()
+
+    def _enumeration_sql(schema: str) -> str:
+        where = [
+            "df.end_snapshot IS NULL",
+            "t.end_snapshot IS NULL",
+            "sch.end_snapshot IS NULL",
+            f"df.file_size_bytes < {max_b}",
+            # Mirror the compactor's own selection: merge_adjacent skips any file
+            # carrying live delete files, so counting them here would let an
+            # unmergeable-but-huge table rank first and no-op at the top of every
+            # run (rank inflated by files the extension refuses to touch).
+            (
+                f"NOT EXISTS (SELECT 1 FROM {schema}.ducklake_delete_file dl "
+                "WHERE dl.data_file_id = df.data_file_id AND dl.end_snapshot IS NULL)"
+            ),
+        ]
+        if min_b is not None:
+            where.append(f"df.file_size_bytes >= {min_b}")
+        return (
+            "WITH band_files AS ("
+            "  SELECT df.table_id, df.data_file_id "
+            f" FROM {schema}.ducklake_data_file df "
+            f" JOIN {schema}.ducklake_table t USING (table_id) "
+            f" JOIN {schema}.ducklake_schema sch ON sch.schema_id = t.schema_id "
+            f" WHERE {' AND '.join(where)} "
+            "), file_groups AS ("
+            "  SELECT bf.table_id, bf.data_file_id, "
+            "         COALESCE(string_agg(fpv.partition_value, '/' ORDER BY fpv.partition_key_index), '') AS pk "
+            f" FROM band_files bf "
+            f" LEFT JOIN {schema}.ducklake_file_partition_value fpv "
+            "    ON fpv.data_file_id = bf.data_file_id AND fpv.table_id = bf.table_id "
+            "  GROUP BY bf.table_id, bf.data_file_id "
+            "), mergeable AS ("
+            "  SELECT table_id, COUNT(*) AS n_mergeable "
+            "  FROM file_groups "
+            "  GROUP BY table_id, pk "
+            "  HAVING COUNT(*) >= 2 "
+            ") "
+            "SELECT sch.schema_name, t.table_name "
+            f"FROM mergeable m "
+            f"JOIN {schema}.ducklake_table t ON t.table_id = m.table_id AND t.end_snapshot IS NULL "
+            f"JOIN {schema}.ducklake_schema sch ON sch.schema_id = t.schema_id AND sch.end_snapshot IS NULL "
+            "GROUP BY sch.schema_name, t.table_name "
+            "ORDER BY SUM(m.n_mergeable) DESC, sch.schema_name, t.table_name"
+        )
+
+    # Server-side first: through the duckdb postgres scanner this query pulls
+    # the ENTIRE file_partition_value table client-side per call (projection
+    # pushdown only — measured), which is tens-to-hundreds of MB per tier on
+    # a megaduck-sized catalog. postgres_query ships the aggregation to the
+    # catalog (the bootstrap indexes cover it) and only (schema, table) rows
+    # cross the wire.
+    try:
+        rows = conn.execute(
+            f"SELECT * FROM postgres_query('{PG_ATTACH_NAME}', "
+            f"{_sql_string_literal(_enumeration_sql(PG_CATALOG_SCHEMA))})"
+        ).fetchall()
+    except duckdb.BinderException as error:
+        # No pg attach: the dev/file-backed lake shape. Expected there; the
+        # local form is identical modulo the schema prefix.
+        log.info("compact: server-side enumeration unavailable (%s); using local metadata attach", error)
+        rows = conn.execute(_enumeration_sql(METADATA_SCHEMA)).fetchall()
+    except duckdb.Error as error:
+        # The pg attach exists but the server-side query failed — every prod
+        # run degrading to the full client-side pull is worth alarming on.
+        log.warning("compact: server-side enumeration failed (%s); using local metadata attach", error)
+        rows = conn.execute(_enumeration_sql(METADATA_SCHEMA)).fetchall()
     tables: list[tuple[str, str]] = []
     for schema_name, table_name in rows:
         # _CATALOG_TABLE_NAME_RE (strict [A-Za-z0-9_]+, fullmatch): these names
@@ -2097,17 +2144,19 @@ def compact(
         tables = _enumerate_compaction_tables(conn, min_b, max_b)
         table_total = len(tables)
         log.info(
-            "compact tier-%d: %d table(s) with >= 2 tier candidates, biggest backlog first",
+            "compact tier-%d: %d table(s) with a mergeable partition group, biggest mergeable backlog first",
             tier,
             table_total,
         )
         if not tables and candidate_count > 0:
             # Candidates exist but no table qualified: every candidate is a
-            # per-table singleton (nothing to merge with — benign), or the
-            # holders were skipped by the identifier gate (per-table WARNs
-            # above say which). INFO, not a failure.
+            # partition singleton (nothing shares its partition values —
+            # benign, however many candidates a table holds), or the holders
+            # were skipped by the identifier gate (per-table WARNs above say
+            # which). INFO, not a failure.
             log.info(
-                "compact tier-%d: %d candidate file(s) but no table has >= 2 — nothing mergeable this run",
+                "compact tier-%d: %d candidate file(s) but none form a >= 2-file partition group — "
+                "nothing mergeable this run",
                 tier,
                 candidate_count,
             )


### PR DESCRIPTION
## Problem

The compaction enumeration requires ≥ 2 in-band candidate files **per table**, but `ducklake_merge_adjacent_files` merges per (partition_id, partition_values) **group** — so a table whose in-band files are all partition singletons is a guaranteed zero-group no-op CALL. On team-2's catalog, 86% of 126K tier-1 candidates are partition singletons (hourly-partitioned import tables): the compactor ran continuously with near-zero output, and its catalog commits contended with the tenant's viaduck writer. Measured on 2026-08-21: flushes at 20-40s with the compactor idle vs 80-160s while it ground no-ops — the contention is steady-state because the singleton "backlog" never drains.

## Changes

- **Enumerate per merge unit**: group in-band candidates by their full partition-value tuple; only tables owning a ≥ 2-file group are scheduled, ranked by mergeable file count (budget goes where merges happen). Singleton-only tables never get a CALL. Grouping collisions (NULL-skipping, `/`-delimiter ambiguity) are one-sided: they can merge distinct groups (harmless no-op, still counted by `noop_tables`) but never split a real group — no mergeable table is ever missed.
- **Server-side execution**: through the duckdb postgres scanner the new query would pull the entire `file_partition_value` table client-side per call (projection pushdown only — empirically traced; ~50-100MB per tier on a megaduck-sized catalog). `postgres_query` ships the aggregation to the catalog Postgres — covered by the #121 bootstrap indexes — and only `(schema, table)` rows return. Missing pg attach (dev/file-backed lakes) falls back to the identical local form at INFO; any other server-side failure falls back at WARN so prod degradation is alertable.
- Caller log lines reworded to per-group language; rowid-non-contiguity no-ops still handled by the existing accounting.

## Testing

- 676 unit + 4 integration (real ducklake extension) pass; ruff/format clean.
- New integration test pins the core property: a one-file-per-partition table is **excluded** while a mergeable table is included; it also asserts the file-backed fallback fires (so a future over-tightened `except` fails a test).
- Shape test now asserts the composed `postgres_query` statement parses (`duckdb.extract_statements`) — quote-doubling regressions fail in CI, not prod.
- Two adversarial review rounds; round 2 stood up a real PostgreSQL 16, bootstrapped a DuckLake catalog via the extension, and verified the **server-side path end-to-end**: `EXPLAIN`-validated SQL, singleton exclusion + unpartitioned-table inclusion through `postgres_query`, exception taxonomy for all three fallback triggers, and row/order parity between the two paths.
- No conflicts with #124 (verified via merge-tree); the branches touch different functions and compose.

## Expected effect

Tenant compactors go idle when there is no real work: team-2's steady-state run drops from grinding ~1,095 tables of no-ops every 15 minutes to touching only tables with actual merges — per the natural experiment above, that keeps writer flushes near their 20-40s floor. Megaduck's enumeration becomes one indexed server-side aggregate per tier.