### PR TITLE
metrics: mergeable-only compaction band gauge, shipped server-side

### DIFF
--- a/tests/integration/test_ducklake_metrics_integration.py
+++ b/tests/integration/test_ducklake_metrics_integration.py
@@ -57,7 +57,7 @@ def _stub_full_catalog(c: duckdb.DuckDBPyConnection) -> None:
     c.execute(
         "CREATE TABLE __ducklake_metadata_lake.ducklake_delete_file ("
         "delete_file_id BIGINT, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, "
-        "path VARCHAR, file_size_bytes BIGINT)"
+        "data_file_id BIGINT, path VARCHAR, file_size_bytes BIGINT)"
     )
     c.execute(
         "CREATE TABLE __ducklake_metadata_lake.ducklake_file_partition_value ("
@@ -91,14 +91,20 @@ def _stub_full_catalog(c: duckdb.DuckDBPyConnection) -> None:
         "INSERT INTO __ducklake_metadata_lake.ducklake_data_file VALUES "
         "(1, 1, 0, NULL, 'a', 500000, 100, 1000),"
         "(2, 1, 0, NULL, 'b', 50000000, 100, 50000),"
-        "(3, 1, 0, NULL, 'c', 200000000, 200, 200000)"
+        "(3, 1, 0, NULL, 'c', 200000000, 200, 200000),"
+        # 4 pairs with 1 (same partition, both tier1) so the mergeable
+        # band metric has a non-zero group to report.
+        "(4, 1, 0, NULL, 'e', 400000, 100, 800)"
     )
-    c.execute("INSERT INTO __ducklake_metadata_lake.ducklake_delete_file VALUES (1, 1, 0, NULL, 'd1', 1024)")
+    # data_file_id=2: pins the delete-file exclusion to the tier3 file so
+    # the tier1 mergeable pair above stays clean.
+    c.execute("INSERT INTO __ducklake_metadata_lake.ducklake_delete_file VALUES (1, 1, 0, NULL, 2, 'd1', 1024)")
     c.execute(
         "INSERT INTO __ducklake_metadata_lake.ducklake_file_partition_value VALUES "
         "(1, 1, 0, '2026-05-01'),"
         "(2, 1, 0, '2026-05-01'),"
-        "(3, 1, 0, '2026-05-02')"
+        "(3, 1, 0, '2026-05-02'),"
+        "(4, 1, 0, '2026-05-01')"
     )
     c.execute("INSERT INTO __ducklake_metadata_lake.ducklake_snapshot VALUES (0, '2026-05-01 12:00:00+00', 0)")
     c.execute(
@@ -228,6 +234,9 @@ class TestDaemonHTTP:
                     "ducklake_delete_files_bytes",
                     "ducklake_files_per_band_count",
                     "ducklake_files_per_band_bytes",
+                    "ducklake_mergeable_files_per_band_count",
+                    "ducklake_mergeable_files_per_band_bytes",
+                    "ducklake_mergeable_files_per_band_groups",
                     "ducklake_snapshots_count",
                     "ducklake_snapshots_oldest_seconds_ago",
                     "ducklake_snapshots_newest_seconds_ago",

--- a/tests/unit/test_ducklake_metrics.py
+++ b/tests/unit/test_ducklake_metrics.py
@@ -1007,3 +1007,127 @@ class TestRunOnce:
         # the filesystem — the semgrep dynamic-urllib hardening.
         monkeypatch.setattr(dm, "_connect_once", lambda _ml: conn)
         assert dm._run_once([_once_query()], TENANT, "file:///etc/passwd", None) == 1
+
+
+# ---------------------------------------------------------------------------
+# server_sql: loader plumbing, fallback execution, and the mergeable-band
+# builtin's semantics (the only builtin that carries a server_sql form)
+# ---------------------------------------------------------------------------
+
+
+class TestServerSql:
+    def test_loader_accepts_server_sql(self):
+        q = dm._query_from_dict(
+            {
+                "name": "t_srv",
+                "help": "t",
+                "interval_mins": 1,
+                "sql": "SELECT 1 AS n",
+                "server_sql": "SELECT 1 AS n",
+                "values": ["n"],
+            },
+            "test",
+        )
+        assert q.server_sql == "SELECT 1 AS n"
+
+    def test_loader_defaults_server_sql_none(self):
+        q = dm._query_from_dict(
+            {"name": "t_srv", "help": "t", "interval_mins": 1, "sql": "SELECT 1 AS n", "values": ["n"]},
+            "test",
+        )
+        assert q.server_sql is None
+
+    def test_loader_rejects_non_string_server_sql(self):
+        with pytest.raises(ValueError, match="server_sql must be a string"):
+            dm._query_from_dict(
+                {
+                    "name": "t_srv",
+                    "help": "t",
+                    "interval_mins": 1,
+                    "sql": "SELECT 1 AS n",
+                    "server_sql": ["not", "a", "string"],
+                    "values": ["n"],
+                },
+                "test",
+            )
+
+    def test_falls_back_to_local_sql_without_pg_attach(self, conn, registry):
+        # Plain in-memory duckdb has no postgres_query table function, which
+        # is exactly the dev/file-lake + test-stub shape: the server form
+        # must degrade to the local form, still succeed, and only log once.
+        conn.execute("CREATE TABLE t (n BIGINT)")
+        conn.execute("INSERT INTO t VALUES (7)")
+        q = dm.Query(
+            name="t_fallback",
+            help="t",
+            sql="SELECT n FROM t",
+            interval_seconds=60,
+            labels=[],
+            values=["n"],
+            server_sql="SELECT n FROM public.t",
+        )
+        gauges = dm._build_query_gauges([q], registry=registry)
+        sm = dm._build_self_metrics(registry=registry)
+
+        assert _run(conn, q, gauges[q.name], sm) is True
+        assert _gauge_value(registry, "t_fallback_n") == 7
+        # Error counter untouched: the fallback is an expected shape, not a failure.
+        errors = _gauge_value(registry, "ducklake_metrics_query_errors_total", {"query": "t_fallback"})
+        assert errors is None or errors == 0
+
+    def test_mergeable_builtin_semantics(self, conn, registry):
+        # Executable-SQL test of the ducklake_mergeable_files_per_band
+        # builtin against a mimicked metadata schema: a tier1 pair in one
+        # partition group counts; a tier1 singleton partition does not; a
+        # file carrying a live delete file is excluded; `large` never
+        # appears.
+        conn.execute("CREATE SCHEMA __ducklake_metadata_lake")
+        conn.execute(
+            "CREATE TABLE __ducklake_metadata_lake.ducklake_data_file ("
+            "data_file_id BIGINT, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, "
+            "path VARCHAR, file_size_bytes BIGINT, partition_id BIGINT, record_count BIGINT)"
+        )
+        conn.execute(
+            "CREATE TABLE __ducklake_metadata_lake.ducklake_delete_file ("
+            "delete_file_id BIGINT, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, "
+            "data_file_id BIGINT, path VARCHAR, file_size_bytes BIGINT)"
+        )
+        conn.execute(
+            "CREATE TABLE __ducklake_metadata_lake.ducklake_file_partition_value ("
+            "data_file_id BIGINT, table_id BIGINT, partition_key_index BIGINT, partition_value VARCHAR)"
+        )
+        conn.execute(
+            "INSERT INTO __ducklake_metadata_lake.ducklake_data_file VALUES "
+            # tier1 pair, same partition -> mergeable (2 files, 1 group)
+            "(1, 1, 0, NULL, 'a', 100, 10, 1), (2, 1, 0, NULL, 'b', 200, 10, 1),"
+            # tier1 singleton partition -> excluded
+            "(3, 1, 0, NULL, 'c', 300, 10, 1),"
+            # tier1 pair BUT one carries a live delete file -> both drop
+            # (survivor becomes a singleton)
+            "(4, 1, 0, NULL, 'd', 400, 10, 1), (5, 1, 0, NULL, 'e', 500, 10, 1),"
+            # large pair, same partition -> band excluded entirely
+            "(6, 1, 0, NULL, 'f', 100000000, 10, 1), (7, 1, 0, NULL, 'g', 100000000, 10, 1),"
+            # dropped file (end_snapshot set) -> excluded
+            "(8, 1, 0, 5, 'h', 150, 10, 1)"
+        )
+        conn.execute("INSERT INTO __ducklake_metadata_lake.ducklake_delete_file VALUES (1, 1, 0, NULL, 4, 'dv', 10)")
+        conn.execute(
+            "INSERT INTO __ducklake_metadata_lake.ducklake_file_partition_value VALUES "
+            "(1, 1, 0, 'p1'), (2, 1, 0, 'p1'),"
+            "(3, 1, 0, 'p2'),"
+            "(4, 1, 0, 'p3'), (5, 1, 0, 'p3'),"
+            "(6, 1, 0, 'p4'), (7, 1, 0, 'p4'),"
+            "(8, 1, 0, 'p1')"
+        )
+        queries = {q.name: q for q in dm.load_queries(None, set())}
+        q = queries["ducklake_mergeable_files_per_band"]
+        assert q.server_sql is not None  # ships the join to the catalog in prod
+        gauges = dm._build_query_gauges([q], registry=registry)
+        sm = dm._build_self_metrics(registry=registry)
+
+        assert _run(conn, q, gauges[q.name], sm) is True
+        assert _gauge_value(registry, "ducklake_mergeable_files_per_band_count", {"band": "tier1"}) == 2
+        assert _gauge_value(registry, "ducklake_mergeable_files_per_band_bytes", {"band": "tier1"}) == 300
+        assert _gauge_value(registry, "ducklake_mergeable_files_per_band_groups", {"band": "tier1"}) == 1
+        for band in ("tier2", "tier3", "large"):
+            assert _gauge_value(registry, "ducklake_mergeable_files_per_band_count", {"band": band}) is None

--- a/tools/ducklake_metrics.py
+++ b/tools/ducklake_metrics.py
@@ -72,6 +72,11 @@ from prometheus_client import (
 
 log = logging.getLogger("ducklake_metrics")
 
+# Query names whose server_sql fallback has already been logged — the
+# fallback is retried every run (self-healing if the attach appears after
+# a reconnect) but only worth one log line per process.
+_SERVER_SQL_FALLBACK_LOGGED: set[str] = set()
+
 
 # Built-in queries are embedded so the binary is self-contained; they parse
 # through the same loader as user YAML so the two paths can't diverge.
@@ -153,6 +158,93 @@ queries:
         COALESCE(SUM(file_size_bytes), 0) AS bytes
       FROM __ducklake_metadata_lake.ducklake_data_file
       WHERE end_snapshot IS NULL
+      GROUP BY band
+
+  - name: ducklake_mergeable_files_per_band
+    help: |
+      Compaction-tier files that are actually MERGEABLE: in-band files that
+      share a (table, partition-values) group with at least one other
+      in-band file, and carry no live delete files. Mirrors
+      `ducklake_maintenance.py`'s enumeration semantics (merge_adjacent
+      merges per partition group), so `ducklake_files_per_band` minus this
+      is the structural singleton floor compaction can never shrink —
+      graph THIS as the compaction queue, not the raw band count.
+      `groups` approximates the post-merge output file count. `large` is
+      excluded (never a compaction target). The partition-value join is
+      shipped to the catalog via `server_sql` where a direct Postgres
+      attach exists; the local form is the dev/file-lake fallback.
+    interval_mins: 15
+    labels: [band]
+    values: [count, bytes, groups]
+    sql: |
+      WITH band_files AS (
+        SELECT df.table_id, df.data_file_id, df.file_size_bytes,
+          CASE
+            WHEN df.file_size_bytes < 1048576  THEN 'tier1'
+            WHEN df.file_size_bytes < 10485760 THEN 'tier2'
+            ELSE 'tier3'
+          END AS band
+        FROM __ducklake_metadata_lake.ducklake_data_file df
+        WHERE df.end_snapshot IS NULL
+          AND df.file_size_bytes < 67108864
+          AND NOT EXISTS (
+            SELECT 1 FROM __ducklake_metadata_lake.ducklake_delete_file dl
+            WHERE dl.data_file_id = df.data_file_id AND dl.end_snapshot IS NULL
+          )
+      ), file_groups AS (
+        SELECT bf.band, bf.table_id, bf.data_file_id, bf.file_size_bytes,
+          COALESCE(string_agg(fpv.partition_value, '/' ORDER BY fpv.partition_key_index), '') AS pk
+        FROM band_files bf
+        LEFT JOIN __ducklake_metadata_lake.ducklake_file_partition_value fpv
+          ON fpv.data_file_id = bf.data_file_id AND fpv.table_id = bf.table_id
+        GROUP BY bf.band, bf.table_id, bf.data_file_id, bf.file_size_bytes
+      ), mergeable AS (
+        SELECT band, table_id, pk,
+          COUNT(*) AS n_files, SUM(file_size_bytes) AS n_bytes
+        FROM file_groups
+        GROUP BY band, table_id, pk
+        HAVING COUNT(*) >= 2
+      )
+      SELECT band,
+        COALESCE(SUM(n_files), 0) AS count,
+        COALESCE(SUM(n_bytes), 0) AS bytes,
+        COUNT(*) AS "groups"
+      FROM mergeable
+      GROUP BY band
+    server_sql: |
+      WITH band_files AS (
+        SELECT df.table_id, df.data_file_id, df.file_size_bytes,
+          CASE
+            WHEN df.file_size_bytes < 1048576  THEN 'tier1'
+            WHEN df.file_size_bytes < 10485760 THEN 'tier2'
+            ELSE 'tier3'
+          END AS band
+        FROM public.ducklake_data_file df
+        WHERE df.end_snapshot IS NULL
+          AND df.file_size_bytes < 67108864
+          AND NOT EXISTS (
+            SELECT 1 FROM public.ducklake_delete_file dl
+            WHERE dl.data_file_id = df.data_file_id AND dl.end_snapshot IS NULL
+          )
+      ), file_groups AS (
+        SELECT bf.band, bf.table_id, bf.data_file_id, bf.file_size_bytes,
+          COALESCE(string_agg(fpv.partition_value, '/' ORDER BY fpv.partition_key_index), '') AS pk
+        FROM band_files bf
+        LEFT JOIN public.ducklake_file_partition_value fpv
+          ON fpv.data_file_id = bf.data_file_id AND fpv.table_id = bf.table_id
+        GROUP BY bf.band, bf.table_id, bf.data_file_id, bf.file_size_bytes
+      ), mergeable AS (
+        SELECT band, table_id, pk,
+          COUNT(*) AS n_files, SUM(file_size_bytes) AS n_bytes
+        FROM file_groups
+        GROUP BY band, table_id, pk
+        HAVING COUNT(*) >= 2
+      )
+      SELECT band,
+        COALESCE(SUM(n_files), 0) AS count,
+        COALESCE(SUM(n_bytes), 0) AS bytes,
+        COUNT(*) AS "groups"
+      FROM mergeable
       GROUP BY band
 
   - name: ducklake_snapshots
@@ -387,6 +479,15 @@ class Query:
     interval_seconds: int
     labels: list[str] = field(default_factory=list)
     values: list[str] = field(default_factory=list)
+    # Optional Postgres-dialect form of the same query, shipped to the
+    # catalog via postgres_query() when the connection has the direct pg
+    # attach (same rationale as ducklake_maintenance's server-side
+    # enumeration: the duckdb postgres scanner pulls whole tables with
+    # projection pushdown only, so join-heavy metadata queries are
+    # tens-to-hundreds of MB per run client-side on a big catalog).
+    # Must return the same column names as `sql`. Falls back to `sql`
+    # on lakes without the attach (dev/file lakes, unit-test stubs).
+    server_sql: str | None = None
 
 
 def _validate_interval_mins(v: object) -> int:
@@ -427,6 +528,9 @@ def _query_from_dict(d: dict, source: str) -> Query:
         raise ValueError(f"{source}: query {name!r} labels must be a list of strings")
     if not isinstance(values, list) or not all(isinstance(x, str) for x in values):
         raise ValueError(f"{source}: query {name!r} values must be a list of strings")
+    server_sql = d.get("server_sql")
+    if server_sql is not None and not isinstance(server_sql, str):
+        raise ValueError(f"{source}: query {name!r} server_sql must be a string")
     return Query(
         name=name,
         help=d["help"],
@@ -434,6 +538,7 @@ def _query_from_dict(d: dict, source: str) -> Query:
         interval_seconds=_validate_interval_mins(d["interval_mins"]),
         labels=labels,
         values=values,
+        server_sql=server_sql,
     )
 
 
@@ -644,7 +749,23 @@ def _run_query(
     if liveness is not None:
         liveness.current_query_start = t0
     try:
-        cur = conn.execute(q.sql)
+        cur = None
+        if q.server_sql is not None:
+            # Server-side first (see Query.server_sql). Bind/catalog errors
+            # mean "this lake has no direct pg attach" (dev/file lakes,
+            # test stubs) — expected shape, fall back to the local form.
+            # Any other error is a real failure and takes the normal path.
+            try:
+                cur = conn.execute(
+                    f"SELECT * FROM postgres_query('{ducklake_maintenance.PG_ATTACH_NAME}', "
+                    f"{ducklake_maintenance._sql_string_literal(q.server_sql)})"
+                )
+            except (duckdb.BinderException, duckdb.CatalogException) as e:
+                if q.name not in _SERVER_SQL_FALLBACK_LOGGED:
+                    _SERVER_SQL_FALLBACK_LOGGED.add(q.name)
+                    log.info("query %s: server-side form unavailable (%s); using local metadata attach", q.name, e)
+        if cur is None:
+            cur = conn.execute(q.sql)
         cols = [d[0] for d in cur.description]
         rows = cur.fetchall()
         try:


### PR DESCRIPTION
## Problem

`ducklake_files_per_band` counts every in-band file, but on a big tenant ~86-90% of the tier-1 band is per-partition singletons (hourly-partitioned imports) that `merge_adjacent` can never merge. The dashboard's compaction-queue panels therefore read as a permanently enormous backlog — the singleton floor drowned the actionable signal (this week's team-2 catalog work made that painfully concrete: 118K "candidates" of which only a few hundred files were actually mergeable).

## Changes

- New built-in metric `ducklake_mergeable_files_per_band{band}` with `count` / `bytes` / `groups` values: in-band (tier1/2/3) files that share a (table, partition-values) group with ≥ 2 members and carry no live delete files — the same semantics as the compact enumeration from #125. `groups` approximates the post-merge output file count. `large` is excluded (never a compaction target). 15-min interval.
- Queries gain an optional `server_sql` field: a Postgres-dialect form shipped to the catalog via `postgres_query()` when the direct pg attach exists. The partition-value join here is the exact query #125 measured as a whole-table client-side pull through the postgres scanner (projection pushdown only), so running it client-side every 15 min on a megaduck-sized catalog is not acceptable. Falls back to the local metadata-attach form on dev/file lakes and test stubs, logged once per process, self-healing on reconnect, error counter untouched.
- Integration-test stub catalog gains the `data_file_id` column the real `ducklake_delete_file` has, plus a seeded mergeable pair so the new gauges are non-zero in the daemon test.

Dashboard companion (merge after this ships to :prod): PostHog/grafana-dashboards PR pointing the ducklake-state compaction-queue panels at the new metric.

## How did you test this code?

Agent-prepared; checks actually run:
- `pytest tests/unit tests/integration/test_ducklake_metrics_integration.py` — 685 unit + integration pass (new: loader plumbing for `server_sql`, fallback execution on a conn without `postgres_query`, executable-SQL semantics test — mergeable pair counted, singleton partition excluded, delete-file-carrier excluded, `large` never emitted).
- `ruff check` / `ruff format --check` clean (pre-commit hook also ran both).