### PR TITLE
bootstrap: index ducklake_name_mapping (mapping_id)

### DIFF
--- a/tools/justfile
+++ b/tools/justfile
@@ -442,9 +442,23 @@ bootstrap-index-file-partition-value-table-file: _confirm-target
     @echo ">>> ducklake_file_partition_value_table_file_idx"
     @{{ _psql }} -c "CREATE INDEX CONCURRENTLY IF NOT EXISTS ducklake_file_partition_value_table_file_idx ON public.ducklake_file_partition_value USING btree (table_id, data_file_id);"
 
+# Name-mapping lookup key for externally registered parquet (field-id
+# mapping, written by ducklake_add_data_files): readers fetch all rows for
+# a file's data_file.mapping_id. Upstream ships the table with NO indexes
+# and NO snapshot lineage (no begin/end_snapshot columns), so it is
+# invisible to expire and lookups on a registration-churned catalog are
+# full seq scans (observed: 2.27M rows / 169MB on duckling-posthog, >90%
+# orphaned mappings).
+#
+# Name-mapping lookup key for registered-parquet field-id mapping reads
+[group('bootstrap')]
+bootstrap-index-name-mapping: _confirm-target
+    @echo ">>> ducklake_name_mapping_mapping_idx"
+    @{{ _psql }} -c "CREATE INDEX CONCURRENTLY IF NOT EXISTS ducklake_name_mapping_mapping_idx ON public.ducklake_name_mapping USING btree (mapping_id);"
+
 # Create every DuckLake catalog btree, sequentially (same-relation builds serialize anyway)
 [group('bootstrap')]
-bootstrap-indexes: bootstrap-index-data-file-compaction bootstrap-index-data-file-compaction-order bootstrap-index-data-file-snapshot-read bootstrap-index-delete-file-snapshot-read bootstrap-index-delete-file-table bootstrap-index-delete-file-metrics bootstrap-index-file-column-stats bootstrap-index-file-column-stats-table-file bootstrap-index-file-partition-value-file bootstrap-index-file-partition-value-table bootstrap-index-file-partition-value-table-file bootstrap-index-file-partition-value-cover
+bootstrap-indexes: bootstrap-index-data-file-compaction bootstrap-index-data-file-compaction-order bootstrap-index-data-file-snapshot-read bootstrap-index-delete-file-snapshot-read bootstrap-index-delete-file-table bootstrap-index-delete-file-metrics bootstrap-index-file-column-stats bootstrap-index-file-column-stats-table-file bootstrap-index-file-partition-value-file bootstrap-index-file-partition-value-table bootstrap-index-file-partition-value-table-file bootstrap-index-file-partition-value-cover bootstrap-index-name-mapping
 
 # ----------------------------------------------------------------------------
 # state-metrics daemon


### PR DESCRIPTION
## Problem

`ducklake_name_mapping` (field-id mapping for externally registered parquet, written by `ducklake_add_data_files`) ships from upstream with **no indexes** and no snapshot-lineage columns. Reads fetch all rows for a file's `data_file.mapping_id` — a full seq scan. On duckling-posthog the table has grown to 2.27M rows / 169MB under imports registration churn (91,396 distinct mappings, of which ~90% are strandings from expires that ran before upstream's column_mapping cleanup existed), so every mapping lookup pays a 169MB scan.

## Changes

- New `bootstrap-index-name-mapping` recipe: `CREATE INDEX CONCURRENTLY IF NOT EXISTS ducklake_name_mapping_mapping_idx ON public.ducklake_name_mapping (mapping_id)`, same `_psql`/`_confirm-target`/idempotency pattern as the sibling recipes.
- Added to the `bootstrap-indexes` umbrella, so every tenant maintenance chain (team-2, megaduck, portola, fleet) self-heals on its next cron cycle once the image promotes.

A follow-up will add the one-time purge of stranded mappings (rows whose `table_id` no longer exists in `ducklake_table` — the pre-cleanup-era legacy); this index makes both the purge's reference checks and steady-state reads cheap.

## How did you test this code?

Agent-prepared; checks actually run: `just -f tools/justfile --list` parses and shows the new recipe with its doc line; recipe body is byte-pattern-identical to the existing bootstrap recipes (psql -c, CONCURRENTLY, IF NOT EXISTS); verified live on duckling-posthog that the target table/column exist and the index is absent.