### PR TITLE
bootstrap: index ducklake_file_column_stats (table_id, column_id)

### DIFF
--- a/tools/justfile
+++ b/tools/justfile
@@ -405,6 +405,18 @@ bootstrap-index-file-column-stats: _confirm-target
     @echo ">>> ducklake_file_column_stats_file_idx"
     @{{ _psql }} -c "CREATE INDEX CONCURRENTLY IF NOT EXISTS ducklake_file_column_stats_file_idx ON public.ducklake_file_column_stats USING btree (data_file_id);"
 
+# Per-column stats scope: (table_id, column_id) drives global column-stat
+# recomputation and per-column reads (top observed index on
+# duckling-posthog: 337K scans, ahead of every script-defined btree — it
+# existed there only as a hand-created stray, codified here so every
+# tenant gets it and rebuilds don't silently lose it).
+#
+# Per-column stats scope for global column-stat recomputation
+[group('bootstrap')]
+bootstrap-index-file-column-stats-table-column: _confirm-target
+    @echo ">>> ducklake_file_column_stats_table_column_idx"
+    @{{ _psql }} -c "CREATE INDEX CONCURRENTLY IF NOT EXISTS ducklake_file_column_stats_table_column_idx ON public.ducklake_file_column_stats USING btree (table_id, column_id);"
+
 # Partition-value join key for per-file lookups
 [group('bootstrap')]
 bootstrap-index-file-partition-value-file: _confirm-target
@@ -444,7 +456,7 @@ bootstrap-index-file-partition-value-table-file: _confirm-target
 
 # Create every DuckLake catalog btree, sequentially (same-relation builds serialize anyway)
 [group('bootstrap')]
-bootstrap-indexes: bootstrap-index-data-file-compaction bootstrap-index-data-file-compaction-order bootstrap-index-data-file-snapshot-read bootstrap-index-delete-file-snapshot-read bootstrap-index-delete-file-table bootstrap-index-delete-file-metrics bootstrap-index-file-column-stats bootstrap-index-file-column-stats-table-file bootstrap-index-file-partition-value-file bootstrap-index-file-partition-value-table bootstrap-index-file-partition-value-table-file bootstrap-index-file-partition-value-cover
+bootstrap-indexes: bootstrap-index-data-file-compaction bootstrap-index-data-file-compaction-order bootstrap-index-data-file-snapshot-read bootstrap-index-delete-file-snapshot-read bootstrap-index-delete-file-table bootstrap-index-delete-file-metrics bootstrap-index-file-column-stats bootstrap-index-file-column-stats-table-file bootstrap-index-file-column-stats-table-column bootstrap-index-file-partition-value-file bootstrap-index-file-partition-value-table bootstrap-index-file-partition-value-table-file bootstrap-index-file-partition-value-cover
 
 # ----------------------------------------------------------------------------
 # state-metrics daemon


### PR DESCRIPTION
## Problem

The `(table_id, column_id)` btree on `ducklake_file_column_stats` is the single most-used index on duckling-posthog's catalog — 337K scans, ahead of every script-defined index — but it exists only as a hand-created stray (`idx_ducklake_file_col_stats_tbl_col`). No other tenant has it, and any catalog rebuild loses it silently. It drives global column-stat recomputation and per-column stat reads.

## Changes

- New `bootstrap-index-file-column-stats-table-column` recipe creating `ducklake_file_column_stats_table_column_idx` (`table_id, column_id`), canonical naming, same CONCURRENTLY/IF NOT EXISTS pattern; added to the `bootstrap-indexes` umbrella so all tenant chains self-heal.
- The hand-made stray (and the two exact-duplicate strays on the same table) get dropped during the planned duckling-posthog VACUUM FULL window; this recipe is the precondition so the drop can't orphan the access path.

Trivial conflict with #127 on the umbrella line — whichever merges second rebases.

## How did you test this code?

Agent-prepared; checks actually run: `just -f tools/justfile --list` parses and shows the recipe with its doc line; pattern is identical to sibling recipes; index shape verified against live usage stats (`pg_stat_user_indexes`) on duckling-posthog.