### PR TITLE
Cap consume timeout at 60s to protect liveness on quiet topics

### DIFF
--- a/millpond/main.py
+++ b/millpond/main.py
@@ -24,6 +24,23 @@ log = logging.getLogger(__name__)
 
 _LAG_SAMPLE_INTERVAL_S = 60.0  # how often to query watermark offsets for lag metrics
 _HEARTBEAT_INTERVAL_S = 60.0  # periodic log when idle (well under 300s liveness timeout)
+# Longest a single consume() may block. record_poll() runs only after consume
+# returns, and server.health marks the process dead at max_poll_age_s=300 —
+# so a consume timeout derived from a large FLUSH_INTERVAL_MS (e.g. 10min)
+# would starve the liveness probe on a quiet topic and SIGKILL the pod.
+# 60s also keeps the idle heartbeat cadence honest.
+_CONSUME_MAX_BLOCK_S = 60.0
+
+
+def _consume_timeout(remaining: float) -> float:
+    """Consume timeout for the main loop: the time left until the flush
+    interval fires, floored at 0.1s so we always poll, capped at
+    _CONSUME_MAX_BLOCK_S so liveness (record_poll) and the idle heartbeat
+    keep running on a quiet topic. Flush triggers are re-checked every
+    loop iteration, so the cap never delays a flush."""
+    return min(max(remaining, 0.1), _CONSUME_MAX_BLOCK_S)
+
+
 _WRITE_MAX_RETRIES = 3
 _WRITE_BASE_DELAY_S = 1.0
 _COMMIT_MAX_RETRIES = 3
@@ -479,7 +496,7 @@ def main():
 
         while not shutdown:
             remaining = cfg.flush_interval_s - (time.monotonic() - last_flush)
-            timeout = max(remaining, 0.1)
+            timeout = _consume_timeout(remaining)
 
             batch_size = backpressure.compute_batch_size(pending_bytes, cfg.flush_size)
             msgs = kafka.consume(num_messages=batch_size, timeout=timeout)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -982,3 +982,35 @@ class TestFlushCommit:
         # Committed offset is next-to-fetch (max consumed + 1).
         committed = kafka.commit.call_args.kwargs["offsets"]
         assert [(tp.partition, tp.offset) for tp in committed] == [(0, 101)]
+
+
+class TestConsumeTimeout:
+    """_consume_timeout must never exceed the liveness poll-age budget.
+
+    server.health marks the process dead when no poll lands for 300s
+    (max_poll_age_s), and record_poll only runs after consume() returns.
+    Before the cap, FLUSH_INTERVAL_MS=600000 on a quiet topic meant a
+    600s consume block -> liveness SIGKILL loop across the fleet.
+    """
+
+    def test_large_interval_capped_at_max_block(self):
+        from millpond.main import _CONSUME_MAX_BLOCK_S, _consume_timeout
+
+        assert _consume_timeout(600.0) == _CONSUME_MAX_BLOCK_S
+
+    def test_cap_stays_under_liveness_budget(self):
+        from millpond.main import _CONSUME_MAX_BLOCK_S
+        from millpond.server import _HealthState
+
+        assert _CONSUME_MAX_BLOCK_S < _HealthState().max_poll_age_s
+
+    def test_short_remaining_passes_through(self):
+        from millpond.main import _consume_timeout
+
+        assert _consume_timeout(30.0) == 30.0
+
+    def test_elapsed_interval_floors_at_poll_minimum(self):
+        from millpond.main import _consume_timeout
+
+        assert _consume_timeout(-5.0) == 0.1
+        assert _consume_timeout(0.0) == 0.1


### PR DESCRIPTION
## Problem

The main loop passes the remaining flush interval as the Kafka consume timeout (`main.py`). `record_poll()` only runs after `consume()` returns, and the health server declares the process dead when no poll lands for 300s (`_HealthState.max_poll_age_s`).

Today's configs stay under the line (max interval in prod is 300s for the events consumers, 180s for events-nrt). But any `FLUSH_INTERVAL_MS` above 300000 turns a quiet topic into a fleet-wide crash loop:

1. `consume()` blocks the full interval (e.g. 600s at a 10min interval).
2. Liveness fails at 300s of poll silence; kubelet kills at ~390s.
3. The SIGTERM handler can't run while the main thread is inside the blocking librdkafka call (CPython defers signal delivery), so the pod ignores SIGTERM, burns the 120s grace period, and dies by SIGKILL — no drain, no consumer close.
4. Repeat every ~6.5 minutes, on all replicas, for the duration of the quiet period — which is exactly when an upstream ingestion incident is already in progress.

Found by adversarial review of a planned charts change raising events-nrt `FLUSH_INTERVAL_MS` to 600000 (small-file reduction on megaduck — each flush writes one parquet file per tenant partition, so fewer flushes = fewer tiny files). This fix is a hard prerequisite for that change and must be on `:prod` before it merges.

## Change

- `_consume_timeout(remaining)`: floor 0.1s (always poll), cap `_CONSUME_MAX_BLOCK_S = 60.0`. Flush triggers are re-evaluated every loop iteration, so the cap never delays a flush; at steady state (batches arriving) the timeout rarely binds at all. 60s also keeps the idle heartbeat honest.
- `TestConsumeTimeout`: cap applies at large intervals, short remainders pass through, elapsed intervals floor at 0.1s, and — structurally — `_CONSUME_MAX_BLOCK_S < _HealthState().max_poll_age_s`, so the two constants can't drift apart without a test failure.

## Verification

`just lint` / `just fmt-check` clean; 689 unit, 65 integration, 4 e2e all pass locally.
