### PR TITLE
Add optional DUCKDB_MEMORY_LIMIT applied at connect

### DIFF
--- a/millpond/config.py
+++ b/millpond/config.py
@@ -45,6 +45,14 @@ class Config:
     # 100 default (the value DuckLake's own error message suggests).
     ducklake_max_retry_count: int
 
+    # Optional DuckDB memory_limit (e.g. "6GB"). Unset, DuckDB budgets
+    # ~80% of the cgroup limit and competes with the Arrow pending buffer
+    # for RSS during the partitioned INSERT — at large FLUSH_SIZE the sum
+    # can OOM the pod. Set, DuckDB spills to its temp dir beside the
+    # on-disk database file (the /tmp emptyDir in k8s) instead. Loaded
+    # from DUCKDB_MEMORY_LIMIT; None preserves the default behavior.
+    duckdb_memory_limit: str | None
+
     # Flush triggers
     flush_size: int  # bytes of accumulated Arrow data
     flush_interval_ms: int  # ms since last flush
@@ -507,6 +515,7 @@ def _load_ducklake_fields() -> dict[str, str | None]:
         "rds_password": _require("DUCKLAKE_RDS_PASSWORD"),
         "partition_by": partition_by,
         "ducklake_max_retry_count": ducklake_max_retry_count,
+        "duckdb_memory_limit": os.environ.get("DUCKDB_MEMORY_LIMIT") or None,
     }
 
 

--- a/millpond/ducklake.py
+++ b/millpond/ducklake.py
@@ -342,6 +342,15 @@ def connect(cfg: Config) -> duckdb.DuckDBPyConnection:
     # DUCKLAKE_MAX_RETRY_COUNT env (default 100).
     conn.execute(f"SET ducklake_max_retry_count = {int(cfg.ducklake_max_retry_count)}")
 
+    # Optional memory cap (DUCKDB_MEMORY_LIMIT). Without it DuckDB budgets
+    # ~80% of the cgroup limit and races the Arrow pending buffer for RSS
+    # during the partitioned INSERT; with it DuckDB spills to the temp dir
+    # next to the on-disk database file. Requires a file-backed
+    # ducklake_connection (the k8s chart uses /tmp/duck.db on a writable
+    # emptyDir) — with :memory: there is no adjacent temp dir to spill to.
+    if cfg.duckdb_memory_limit is not None:
+        conn.execute(f"SET memory_limit = '{_sanitize_setting_value(cfg.duckdb_memory_limit)}'")
+
     # Build a libpq connection string for DuckLake.
     # The 'postgres:' prefix tells DuckLake to use the Postgres extension
     # for metadata storage rather than a local DuckDB file.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -746,3 +746,32 @@ class TestIncludeValuesConfig:
         monkeypatch.setenv("MILLPOND_INCLUDE_VALUES_POLL_INTERVAL_S", "0")
         with pytest.raises(RuntimeError, match="must be positive"):
             load()
+
+
+class TestDuckdbMemoryLimit:
+    @pytest.fixture(autouse=True)
+    def _env(self, monkeypatch):
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+        monkeypatch.setenv("KAFKA_TOPIC", "test-topic")
+        monkeypatch.setenv("REPLICA_COUNT", "4")
+        monkeypatch.setenv("POD_NAME", "millpond-events-2")
+        monkeypatch.setenv("DUCKLAKE_TABLE", "events")
+        monkeypatch.setenv("DUCKLAKE_DATA_PATH", "s3://bucket/data")
+        monkeypatch.setenv("DUCKLAKE_RDS_HOST", "host")
+        monkeypatch.setenv("DUCKLAKE_RDS_PASSWORD", "pass")
+        monkeypatch.setenv("DUCKLAKE_CONNECTION", ":memory:")
+
+    def test_default_none(self):
+        cfg = load()
+        assert cfg.duckdb_memory_limit is None
+
+    def test_explicit_value(self, monkeypatch):
+        monkeypatch.setenv("DUCKDB_MEMORY_LIMIT", "6GB")
+        cfg = load()
+        assert cfg.duckdb_memory_limit == "6GB"
+
+    def test_empty_string_treated_as_unset(self, monkeypatch):
+        # A chart rendering `value: ""` must not produce SET memory_limit = ''.
+        monkeypatch.setenv("DUCKDB_MEMORY_LIMIT", "")
+        cfg = load()
+        assert cfg.duckdb_memory_limit is None

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -148,6 +148,7 @@ def _make_cfg(**overrides) -> Config:
         rds_password="pass",
         partition_by=None,
         ducklake_max_retry_count=100,
+        duckdb_memory_limit=None,
         flush_size=100,
         flush_interval_ms=1000,
         fetch_min_bytes=1,

--- a/tests/unit/test_millpond_logging_config.py
+++ b/tests/unit/test_millpond_logging_config.py
@@ -52,6 +52,7 @@ def _minimal_config() -> Config:
         rds_password="pass",
         partition_by=None,
         ducklake_max_retry_count=100,
+        duckdb_memory_limit=None,
         flush_size=104857600,
         flush_interval_ms=60000,
         fetch_min_bytes=1048576,


### PR DESCRIPTION
Uncapped, DuckDB budgets ~80% of the cgroup limit and competes with the Arrow pending buffer for RSS during the partitioned INSERT — the charts#14038 OOM shape (1GB Arrow buffers OOMKilled the events consumers at 5940Mi). When `DUCKDB_MEMORY_LIMIT` is set (e.g. `"6GB"`), `connect()` applies `SET memory_limit` through the existing `_sanitize_setting_value` guard, so DuckDB spills to the temp dir beside the on-disk database file (the `/tmp` emptyDir in k8s) instead of growing RSS. Spilling requires a file-backed `DUCKLAKE_CONNECTION` — the chart uses `/tmp/duck.db`; the code comment documents the `:memory:` caveat.

Unset or empty leaves behavior unchanged (a chart rendering `value: ""` is treated as unset — tested). Older images ignore the env var harmlessly.

Companion to the pending charts change raising events-nrt `FLUSH_SIZE` to 1.5GiB with a 12Gi limit; the chart will set `duckdbMemoryLimit: "6GB"` per-consumer there. Follows #129 (both were flagged by the adversarial review of that charts change).

## Verification

`just lint` / `just fmt-check` clean; 692 unit, 65 integration, 4 e2e pass locally (cherry-picked from the reviewed branch; unit suite re-run post-pick).