### PR TITLE
feat(cd): dispatch digest-pinned state updates to PostHog/charts after each release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,9 @@ permissions:
 
 jobs:
   release:
+    # Only run in the canonical repo — forks must not push images, tags,
+    # or deployment dispatches.
+    if: github.repository == 'PostHog/millpond'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -103,9 +106,52 @@ jobs:
           MILLPOND_VERSION=${{ steps.next_tag.outputs.version }}
         tags: |
           ghcr.io/posthog/millpond:${{ steps.next_tag.outputs.tag }}
+          ghcr.io/posthog/millpond:${{ github.sha }}
           ghcr.io/posthog/millpond:latest
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+    # --- Deploy: pin the pushed image by digest in PostHog/charts ---
+    # The production deployment must not follow mutable tags (:prod,
+    # :latest). Instead we record the manifest digest of the image built
+    # here in the charts state file (state/millpond.yaml) via a
+    # repository_dispatch. ArgoCD then rolls the pinned
+    # <commit>@sha256:<digest> reference with prod-approval gating.
+    # The :latest / :prod tag pushes above stay for back-compat until the
+    # charts-side cutover lands.
+
+    - name: Get image digest
+      id: digest
+      run: |
+        digest=$(docker buildx imagetools inspect --raw ghcr.io/posthog/millpond:${{ github.sha }} | sha256sum | awk '{print "sha256:"$1}')
+        echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+    - name: Get deployer token
+      id: deployer
+      uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
+      with:
+        app_id: ${{ secrets.GH_APP_CHARTS_DEPLOYER_APP_ID }}
+        private_key: ${{ secrets.GH_APP_CHARTS_DEPLOYER_PRIVATE_KEY }}
+
+    - name: Trigger deployment via Charts repo
+      uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+      with:
+        token: ${{ steps.deployer.outputs.token }}
+        repository: PostHog/charts
+        event-type: commit_state_update
+        client-payload: |
+          {
+            "values": {
+              "image": {
+                "sha": "${{ github.sha }}@${{ steps.digest.outputs.digest }}"
+              }
+            },
+            "release": "millpond",
+            "commit": ${{ toJson(github.event.head_commit) }},
+            "repository": ${{ toJson(github.repository) }},
+            "labels": [],
+            "timestamp": "${{ github.event.head_commit.timestamp }}"
+          }
 
     - name: Create git tag
       env:

--- a/AGENT.md
+++ b/AGENT.md
@@ -440,8 +440,9 @@ Every merge to `main` triggers `.github/workflows/release.yaml`:
 
 1. Auto-bumps patch version from latest git tag (`v0.0.1` → `v0.0.2`)
 2. Builds a source tarball (`millpond-v0.0.X.tar.gz`) containing `pyproject.toml`, `uv.lock`, and all source — attached to the GitHub release
-3. Builds and pushes Docker image to `ghcr.io/posthog/millpond:<tag>` and `:latest`
-4. Creates GitHub release with auto-generated changelog
+3. Builds and pushes Docker image to `ghcr.io/posthog/millpond:<tag>`, `:<commit-sha>`, and `:latest`
+4. Dispatches `commit_state_update` to PostHog/charts with the manifest digest, so `state/millpond.yaml` records `<commit>@sha256:<digest>` and ArgoCD rolls the pinned image (prod-approval gated). Deployment must not follow the mutable `:prod`/`:latest` tags.
+5. Creates GitHub release with auto-generated changelog
 
 The tarball is the primary artifact for external Docker builds (e.g. `posthog-cloud-infra`). It includes the lockfile so `uv sync --frozen` produces reproducible installs with pinned binary wheels. Do not distribute standalone wheels — they lack the lockfile and resolve unpinned deps from PyPI.
 


### PR DESCRIPTION
## Summary

Millpond deploys to the managed-warehouse clusters from the mutable `:prod`/`:latest` tags with `pullPolicy: Always` and an auto-restart CronJob. Anyone who can retag the GHCR package ships code to production within ~10 minutes with no PR, no approval, and no recorded provenance. A security review flagged this as a High finding.

This PR onboards millpond to the standard state-file digest-pin pipeline (like duckgres): after each release build, the workflow records `<commit>@sha256:<digest>` in `state/millpond.yaml` via `commit_state_update` repository-dispatch. ArgoCD rolls the pinned digest with prod-approval gating (`require_prod_approval: true` in the seeded state file).

## Changes

- `release.yaml`: `github.repository == 'PostHog/millpond'` guard; push a `:<commit-sha>` tag (digest inspection + traceability); compute the manifest digest; dispatch `commit_state_update` with `release: "millpond"` to PostHog/charts.
- New actions pinned by SHA (same pins as duckgres's CD).
- AGENT.md Releases section documents the dispatch.
- No existing tags removed — `:latest`/`:prod` keep flowing until the charts-side cutover PR lands.

## Prerequisites

- `GH_APP_CHARTS_DEPLOYER_APP_ID` / `GH_APP_CHARTS_DEPLOYER_PRIVATE_KEY` secrets must exist in this repo (or org) — same app as duckgres uses. `gh secret list` shows neither; needs an org admin if not org-level.

## Testing

- YAML validated; dispatch payload mirrors the proven duckgres `container-image-cache-proxy-cd.yml` contract. First real validation is the next main build after merge: expect a `state/millpond.yaml` commit bumping `image.sha`.

## Rollback

- Revert; charts continues to follow the seed digest in `state/millpond.yaml`.